### PR TITLE
feat(preview): Add single code container in order to simplify preview

### DIFF
--- a/packages/react-email/preview/src/components/code-container.tsx
+++ b/packages/react-email/preview/src/components/code-container.tsx
@@ -1,0 +1,114 @@
+import { Language } from 'prism-react-renderer';
+import { IconButton } from './icon-button';
+import { IconClipboard } from './icon-clipboard';
+import { IconDownload } from './icon-download';
+import { IconCheck } from './icon-check';
+import { copyTextToClipboard } from '../utils';
+import languageMap from '../utils/language-map';
+import { Tooltip } from './tooltip';
+import { Code } from './code';
+import * as React from 'react';
+
+interface CodeContainerProps {
+  markups: MarkupProps[];
+}
+
+interface MarkupProps {
+  language: Language;
+  content: string;
+}
+
+export const CodeContainer: React.FC<Readonly<CodeContainerProps>> = ({
+  markups,
+}) => {
+  const [isCopied, setIsCopied] = React.useState(false);
+  const [activeTab, setActiveTab] = React.useState(markups[0].language);
+  let file = null;
+  let url = null;
+
+  const renderDownloadIcon = () => {
+    let value = markups.filter((markup) => markup.language === activeTab);
+    file = new File([value[0].content], `email.${value[0].language}`);
+    url = URL.createObjectURL(file);
+
+    return (
+      <a href={url} download={file.name}>
+        <IconDownload />
+      </a>
+    );
+  };
+
+  const renderClipboardIcon = () => {
+    const handleClipboard = async () => {
+      const activeContent = markups.filter(({ language }) => {
+        return activeTab === language;
+      });
+      setIsCopied(true);
+      await copyTextToClipboard(activeContent[0].content);
+      setTimeout(() => setIsCopied(false), 3000);
+    };
+
+    return (
+      <IconButton onClick={handleClipboard}>
+        {isCopied ? <IconCheck /> : <IconClipboard />}
+      </IconButton>
+    );
+  };
+
+  React.useEffect(() => {
+    setIsCopied(false);
+  }, [activeTab]);
+
+  return (
+    <pre
+      className={
+        'border-slate-6 relative w-full items-center overflow-auto whitespace-pre rounded-md border text-sm backdrop-blur-md'
+      }
+      style={{
+        lineHeight: '130%',
+        background:
+          'linear-gradient(145.37deg, rgba(255, 255, 255, 0.09) -8.75%, rgba(255, 255, 255, 0.027) 83.95%)',
+        boxShadow: 'rgb(0 0 0 / 10%) 0px 5px 30px -5px',
+      }}
+    >
+      <div className="h-9 border-b border-slate-6">
+        <div className="py-[10px] px-4 text-xs flex gap-8">
+          {markups.map(({ language }) => {
+            return (
+              <div key={language}>
+                <button
+                  className={`${activeTab !== language && 'opacity-25'}`}
+                  onClick={() => setActiveTab(language)}
+                >
+                  {languageMap[language]}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+        <Tooltip>
+          <Tooltip.Trigger className="absolute top-2 right-2 hidden md:block">
+            {renderClipboardIcon()}
+          </Tooltip.Trigger>
+          <Tooltip.Content>Copy to Clipboard</Tooltip.Content>
+        </Tooltip>
+        <Tooltip>
+          <Tooltip.Trigger className="text-gray-11 absolute top-2 right-8 hidden md:block">
+            {renderDownloadIcon()}
+          </Tooltip.Trigger>
+          <Tooltip.Content>Download</Tooltip.Content>
+        </Tooltip>
+      </div>
+      {markups.map(({ language, content }) => {
+        return (
+          <div
+            className={`${activeTab !== language && 'hidden'}`}
+            key={language}
+          >
+            <Code language={language}>{content}</Code>
+          </div>
+        );
+      })}
+    </pre>
+  );
+};

--- a/packages/react-email/preview/src/components/code.tsx
+++ b/packages/react-email/preview/src/components/code.tsx
@@ -1,11 +1,5 @@
 import classnames from 'classnames';
 import Highlight, { defaultProps, Language } from 'prism-react-renderer';
-import { IconButton } from './icon-button';
-import { IconClipboard } from './icon-clipboard';
-import { IconDownload } from './icon-download';
-import { IconCheck } from './icon-check';
-import { copyTextToClipboard } from '../utils';
-import { Tooltip } from './tooltip';
 import * as React from 'react';
 
 interface CodeProps {
@@ -50,9 +44,7 @@ const theme = {
 
 export const Code: React.FC<Readonly<CodeProps>> = ({
   children,
-  className,
   language = 'html',
-  ...props
 }) => {
   const [isCopied, setIsCopied] = React.useState(false);
   const value = children.trim();
@@ -68,53 +60,14 @@ export const Code: React.FC<Readonly<CodeProps>> = ({
       language={language as Language}
     >
       {({ tokens, getLineProps, getTokenProps }) => (
-        <pre
-          className={classnames(
-            'border-slate-6 relative w-full items-center overflow-auto whitespace-pre rounded-md border text-sm backdrop-blur-md',
-            className,
-          )}
-          style={{
-            lineHeight: '130%',
-            background:
-              'linear-gradient(145.37deg, rgba(255, 255, 255, 0.09) -8.75%, rgba(255, 255, 255, 0.027) 83.95%)',
-            boxShadow: 'rgb(0 0 0 / 10%) 0px 5px 30px -5px',
-          }}
-        >
-          <div className="h-9 border-b border-slate-6">
-            <div className="py-[10px] px-4 text-xs">
-              {language === 'jsx' ? 'React' : 'HTML'}
-            </div>
-            <Tooltip>
-              <Tooltip.Trigger className="absolute top-2 right-2 hidden md:block">
-                <IconButton
-                  onClick={async () => {
-                    setIsCopied(true);
-                    await copyTextToClipboard(value);
-                    setTimeout(() => setIsCopied(false), 3000);
-                  }}
-                >
-                  {isCopied ? <IconCheck /> : <IconClipboard />}
-                </IconButton>
-              </Tooltip.Trigger>
-              <Tooltip.Content>Copy to Clipboard</Tooltip.Content>
-            </Tooltip>
-
-            <Tooltip>
-              <Tooltip.Trigger className="text-gray-11 absolute top-2 right-8 hidden md:block">
-                <a href={url} download={file.name}>
-                  <IconDownload />
-                </a>
-              </Tooltip.Trigger>
-              <Tooltip.Content>Download</Tooltip.Content>
-            </Tooltip>
-          </div>
-
+        <>
           <div
             className="absolute right-0 top-0 h-px w-[200px]"
             style={{
               background:
                 'linear-gradient(90deg, rgba(56, 189, 248, 0) 0%, rgba(56, 189, 248, 0) 0%, rgba(232, 232, 232, 0.2) 33.02%, rgba(143, 143, 143, 0.6719) 64.41%, rgba(236, 72, 153, 0) 98.93%)',
             }}
+            
           />
           <div className="p-4">
             {tokens.map((line, i) => {
@@ -153,7 +106,7 @@ export const Code: React.FC<Readonly<CodeProps>> = ({
                 'linear-gradient(90deg, rgba(56, 189, 248, 0) 0%, rgba(56, 189, 248, 0) 0%, rgba(232, 232, 232, 0.2) 33.02%, rgba(143, 143, 143, 0.6719) 64.41%, rgba(236, 72, 153, 0) 98.93%)',
             }}
           />
-        </pre>
+        </>
       )}
     </Highlight>
   );

--- a/packages/react-email/preview/src/pages/preview/[slug].tsx
+++ b/packages/react-email/preview/src/pages/preview/[slug].tsx
@@ -4,11 +4,17 @@ import path from 'path';
 import { render } from '@react-email/render';
 import { GetStaticPaths } from 'next';
 import { Layout } from '../../components/layout';
+import { CodeContainer } from '../../components/code-container';
 import { Code } from '../../components';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
-interface PreviewProps {}
+interface PreviewProps {
+  navItems: string;
+  markup: string;
+  reactMarkup: string;
+  slug: string;
+}
 
 export const CONTENT_DIR = 'emails';
 
@@ -100,8 +106,12 @@ const Preview: React.FC<Readonly<PreviewProps>> = ({
         />
       ) : (
         <div className="flex gap-6 mx-auto p-6">
-          <Code language="jsx">{reactMarkup}</Code>
-          <Code>{markup}</Code>
+          <CodeContainer
+            markups={[
+              { language: 'jsx', content: reactMarkup },
+              { language: 'markup', content: markup },
+            ]}
+          />
         </div>
       )}
     </Layout>

--- a/packages/react-email/preview/src/utils/language-map.ts
+++ b/packages/react-email/preview/src/utils/language-map.ts
@@ -1,0 +1,6 @@
+const languageMap = {
+    jsx: 'React',
+    markup: 'HTML' 
+}
+
+export default languageMap;


### PR DESCRIPTION
This PR changes the "view mode" of the generated code by replacing two vertical columns with a single container. The "Download" and "Copy to Clipboard" features continue to work according to the `activeTab`.

The `<CodeContainer markups={[...any markups]} />` component now manages how many markups are provided, generating a respective _tab_ and _content_ for each one.

https://user-images.githubusercontent.com/8185819/210676547-f463d03d-4f22-44bc-92fa-e94a546b2dfe.mp4
