### PR TITLE
fix(docs): Path to image

### DIFF
--- a/apps/docs/getting-started/automatic-setup.mdx
+++ b/apps/docs/getting-started/automatic-setup.mdx
@@ -58,7 +58,7 @@ yarn dev
 Visit [localhost:3000](http://localhost:3000) and edit any of the files on the `emails` folder to see the changes.
 
 <Frame>
-  <img alt="Local Development" src="/docs/images/local-dev.png" />
+  <img alt="Local Development" src="/images/local-dev.png" />
 </Frame>
 
 ## 4. Next steps

--- a/apps/docs/getting-started/manual-setup.mdx
+++ b/apps/docs/getting-started/manual-setup.mdx
@@ -91,7 +91,7 @@ yarn dev
 Visit [localhost:3000](http://localhost:3000) and edit the `index.tsx` file to see the changes.
 
 <Frame>
-  <img alt="Local Development" src="/docs/images/local-dev.png" />
+  <img alt="Local Development" src="/images/local-dev.png" />
 </Frame>
 
 ## 7. Next steps


### PR DESCRIPTION
# Summary

Two images in the `Getting Started` section had urls set to invalid paths. This PR fixes that

![CleanShot 2023-01-18 at 19 14 20@2x](https://user-images.githubusercontent.com/44352119/213347072-05fcccca-f421-4822-bca9-391c043c925d.png)
