### PR TITLE
chore(section): Bump to `v0.0.5`

### DIFF
--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -5,6 +5,12 @@ description: 'New features, bug fixes, and improvements made to each package.'
 'og:image': 'https://react.email/static/covers/react-email.png'
 ---
 
+## January 24, 2023
+
+**Section `0.0.5`**
+
+- Fix extra `<td>` elements when using `<Column>`
+
 ## January 4, 2023
 
 **React Email `1.6.0`**

--- a/packages/section/package.json
+++ b/packages/section/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/section",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Display a section that can be formatted using columns",
   "sideEffects": false,
   "main": "./dist/index.js",


### PR DESCRIPTION
This PR bumps `<Section>` version after the recent fix from https://github.com/resendlabs/react-email/pull/312.