### PR TITLE
feat(demo): Implement email props with default values

### DIFF
--- a/apps/demo/emails/airbnb-review.tsx
+++ b/apps/demo/emails/airbnb-review.tsx
@@ -10,13 +10,30 @@ import { Section } from '@react-email/section';
 import { Text } from '@react-email/text';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
+interface EmailProps {
+  authorName: string;
+  authorImage: string;
+  reviewText: string;
+}
+
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
+
+export default function Email({
+  authorName = 'Alex',
+  authorImage = `${baseUrl}/static/airbnb-review-user.jpg`,
+  reviewText = `“Zeno was a great guest! Easy communication, the apartment was left
+  in great condition, very polite, and respectful of all house rules.
+  He’s welcome back anytime and would easily recommend him to any
+  host!”`,
+}: EmailProps) {
+  const previewText = `Read ${authorName}'s review`;
 
   return (
     <Html>
       <Head />
-      <Preview>Read Alex's review</Preview>
+      <Preview>{previewText}</Preview>
       <Section style={main}>
         <Container style={container}>
           <Img
@@ -27,27 +44,22 @@ export default function Email() {
           />
           <Section>
             <Img
-              src={`${baseUrl}/static/airbnb-review-user.jpg`}
+              src={authorImage}
               width="96"
               height="96"
-              alt="Alex"
+              alt={authorName}
               style={userImage}
             />
           </Section>
-          <Text style={heading}>Here's what Alex wrote</Text>
-          <Text style={review}>
-            “Zeno was a great guest! Easy communication, the apartment was left
-            in great condition, very polite, and respectful of all house rules.
-            He’s welcome back anytime and would easily recommend him to any
-            host!”
-          </Text>
+          <Text style={heading}>Here's what {authorName} wrote</Text>
+          <Text style={review}>{reviewText}</Text>
           <Text style={paragraph}>
-            Now that the review period is over, we’ve posted Alex’s review to
-            your Airbnb profile.
+            Now that the review period is over, we’ve posted {authorName}’s
+            review to your Airbnb profile.
           </Text>
           <Text style={paragraph}>
             While it’s too late to write a review of your own, you can send your
-            feedback to Alex using your Airbnb message thread.
+            feedback to {authorName} using your Airbnb message thread.
           </Text>
           <Section style={{ padding: '16px 0 20px' }}>
             <Button pY={19} style={button} href="https://airbnb.com/">

--- a/apps/demo/emails/dropbox-reset-password.tsx
+++ b/apps/demo/emails/dropbox-reset-password.tsx
@@ -9,23 +9,38 @@ import { Section } from '@react-email/section';
 import { Text } from '@react-email/text';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
+interface EmailProps {
+  userFirstname: string;
+  resetPasswordLink: string;
+}
 
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
+
+export default function Email({
+  userFirstname = 'Zeno',
+  resetPasswordLink = 'https://dropbox.com',
+}: EmailProps) {
   return (
     <Html>
       <Head />
       <Preview>Dropbox reset your password</Preview>
       <Section style={main}>
         <Container style={container}>
-          <Img src={`${baseUrl}/static/dropbox-logo.png`} width="40" height="33" alt="Dropbox" />
+          <Img
+            src={`${baseUrl}/static/dropbox-logo.png`}
+            width="40"
+            height="33"
+            alt="Dropbox"
+          />
           <Section>
-            <Text style={text}>Hi Zeno,</Text>
+            <Text style={text}>Hi {userFirstname},</Text>
             <Text style={text}>
               Someone recently requested a password change for your Dropbox
               account. If this was you, you can set a new password here:
             </Text>
-            <Button style={button} href="https://dropbox.com">
+            <Button style={button} href={resetPasswordLink}>
               Reset password
             </Button>
             <Text style={text}>

--- a/apps/demo/emails/google-play-policy-update.tsx
+++ b/apps/demo/emails/google-play-policy-update.tsx
@@ -9,9 +9,11 @@ import { Section } from '@react-email/section';
 import { Text } from '@react-email/text';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
 
+export default function Email() {
   return (
     <Html>
       <Head />
@@ -128,7 +130,11 @@ export default function Email() {
                 </tr>
               </table>
             </Section>
-            <Img width="540" height="48" src={`${baseUrl}/static/google-play-footer.png`} />
+            <Img
+              width="540"
+              height="48"
+              src={`${baseUrl}/static/google-play-footer.png`}
+            />
           </Section>
 
           <Section style={{ ...paragraphContent, paddingBottom: 30 }}>

--- a/apps/demo/emails/koala-welcome.tsx
+++ b/apps/demo/emails/koala-welcome.tsx
@@ -9,9 +9,15 @@ import { Section } from '@react-email/section';
 import { Text } from '@react-email/text';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
+interface EmailProps {
+  userFirstname: string;
+}
 
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
+
+export default function Email({ userFirstname = 'Zeno' }: EmailProps) {
   return (
     <Html>
       <Head />
@@ -27,7 +33,7 @@ export default function Email() {
             alt="Koala"
             style={logo}
           />
-          <Text style={paragraph}>Hi Zeno,</Text>
+          <Text style={paragraph}>Hi {userFirstname},</Text>
           <Text style={paragraph}>
             Welcome to Koala, the sales intelligence platform that helps you
             uncover qualified leads and close deals faster.

--- a/apps/demo/emails/linear-login-code.tsx
+++ b/apps/demo/emails/linear-login-code.tsx
@@ -10,9 +10,15 @@ import { Section } from '@react-email/section';
 import { Text } from '@react-email/text';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
+interface EmailProps {
+  validationCode: string;
+}
 
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
+
+export default function Email({ validationCode = 'tt226-5398x' }: EmailProps) {
   return (
     <Html>
       <Head />
@@ -38,7 +44,7 @@ export default function Email() {
             directly:
           </Text>
           <Section>
-            <code style={code}>tt226-5398x</code>
+            <code style={code}>{validationCode}</code>
           </Section>
           <Hr style={hr} />
           <Link href="https://linear.app" style={reportLink}>

--- a/apps/demo/emails/notion-magic-link.tsx
+++ b/apps/demo/emails/notion-magic-link.tsx
@@ -8,9 +8,17 @@ import { Section } from '@react-email/section';
 import { Text } from '@react-email/text';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
+interface EmailProps {
+  loginCode: string;
+}
 
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
+
+export default function Email({
+  loginCode = 'sparo-ndigo-amurt-secan',
+}: EmailProps) {
   return (
     <Html>
       <Head />
@@ -32,7 +40,7 @@ export default function Email() {
           <Text style={{ ...text, marginBottom: '14px' }}>
             Or, copy and paste this temporary login code:
           </Text>
-          <code style={code}>sparo-ndigo-amurt-secan</code>
+          <code style={code}>{loginCode}</code>
           <Text
             style={{
               ...text,

--- a/apps/demo/emails/plaid-verify-identity.tsx
+++ b/apps/demo/emails/plaid-verify-identity.tsx
@@ -7,9 +7,15 @@ import { Link } from '@react-email/link';
 import { Text } from '@react-email/text';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
+interface EmailProps {
+  validationCode: string;
+}
 
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
+
+export default function Email({ validationCode = '144833' }: EmailProps) {
   return (
     <Html>
       <Head />
@@ -26,7 +32,7 @@ export default function Email() {
           Enter the following code to finish linking Venmo.
         </Text>
         <Section style={codeContainer}>
-          <Text style={code}>144833</Text>
+          <Text style={code}>{validationCode}</Text>
         </Section>
         <Text style={paragraph}>Not expecting this email?</Text>
         <Text style={paragraph}>

--- a/apps/demo/emails/raycast-magic-link.tsx
+++ b/apps/demo/emails/raycast-magic-link.tsx
@@ -9,9 +9,17 @@ import { Section } from '@react-email/section';
 import { Text } from '@react-email/text';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
+interface EmailProps {
+  magicLink: string;
+}
 
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
+
+export default function Email({
+  magicLink = 'https://raycast.com',
+}: EmailProps) {
   return (
     <Html>
       <Head />
@@ -27,7 +35,7 @@ export default function Email() {
           <Text style={heading}>🪄 Your magic link</Text>
           <Section style={body}>
             <Text style={paragraph}>
-              <Link style={link} href="https://raycast.com">
+              <Link style={link} href={magicLink}>
                 👉 Click here to sign in 👈
               </Link>
             </Text>

--- a/apps/demo/emails/slack-confirm.tsx
+++ b/apps/demo/emails/slack-confirm.tsx
@@ -8,9 +8,15 @@ import { Text } from '@react-email/text';
 import { Link } from '@react-email/link';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
+interface EmailProps {
+  validationCode: string;
+}
 
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
+
+export default function Email({ validationCode = 'DJZ-TLX' }: EmailProps) {
   return (
     <Html>
       <Head />
@@ -25,19 +31,19 @@ export default function Email() {
               alt="Slack"
             />
           </Section>
-          <Text style={h1}>
-            Confirm your email address
+          <Text style={h1}>Confirm your email address</Text>
+          <Text style={heroText}>
+            Your confirmation code is below - enter it in your open browser
+            window and we'll help you get signed in.
           </Text>
-          <Text style={heroText}>Your confirmation code is below - enter it in your open browser window and we'll help you get signed in.</Text>
 
           <Section style={codeBox}>
-            <Text style={confirmationCodeText}>
-              DJZ-TLX
-            </Text>
+            <Text style={confirmationCodeText}>{validationCode}</Text>
           </Section>
 
           <Text style={text}>
-            If you didn't request this email, there's nothing to worry about - you can safely ignore it.
+            If you didn't request this email, there's nothing to worry about -
+            you can safely ignore it.
           </Text>
 
           <table
@@ -57,13 +63,14 @@ export default function Email() {
                 />
               </td>
               <td align="right" valign="top">
-                <Link href="https://twitter.com/slackhq"><Img
-                  src={`${baseUrl}/static/slack-twitter.png`}
-                  width="32"
-                  height="32"
-                  alt="Slack"
-                  style={socialMediaIcon}
-                />
+                <Link href="https://twitter.com/slackhq">
+                  <Img
+                    src={`${baseUrl}/static/slack-twitter.png`}
+                    width="32"
+                    height="32"
+                    alt="Slack"
+                    style={socialMediaIcon}
+                  />
                 </Link>
                 <Link href="https://facebook.com/slackhq">
                   <Img
@@ -87,21 +94,51 @@ export default function Email() {
             </tr>
           </table>
 
-
           <Section style={footerText}>
-            <Link style={footerLink} href="https://slackhq.com" target="_blank" rel="noopener noreferrer" >Our blog</Link>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
-            <Link style={footerLink} href="https://slack.com/legal" target="_blank" rel="noopener noreferrer">Policies</Link>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
-            <Link style={footerLink} href="https://slack.com/help" target="_blank" rel="noopener noreferrer">Help center</Link>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
-            <Link style={footerLink} href="https://slack.com/community" target="_blank" rel="noopener noreferrer" data-auth="NotApplicable" data-linkindex="6">Slack Community</Link>
-
+            <Link
+              style={footerLink}
+              href="https://slackhq.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Our blog
+            </Link>
+            &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
+            <Link
+              style={footerLink}
+              href="https://slack.com/legal"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Policies
+            </Link>
+            &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
+            <Link
+              style={footerLink}
+              href="https://slack.com/help"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Help center
+            </Link>
+            &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
+            <Link
+              style={footerLink}
+              href="https://slack.com/community"
+              target="_blank"
+              rel="noopener noreferrer"
+              data-auth="NotApplicable"
+              data-linkindex="6"
+            >
+              Slack Community
+            </Link>
             <Text style={footerText}>
               ©2022 Slack Technologies, LLC, a Salesforce company. <br />
-              500 Howard Street, San Francisco, CA 94105, USA  <br />
+              500 Howard Street, San Francisco, CA 94105, USA <br />
               <br />
               All rights reserved.
             </Text>
           </Section>
-
         </Container>
       </Section>
     </Html>
@@ -113,24 +150,23 @@ const footerText = {
   color: '#b7b7b7',
   lineHeight: '15px',
   textAlign: 'left' as const,
-  marginBottom: '50px'
-}
+  marginBottom: '50px',
+};
 
 const footerLink = {
   color: '#b7b7b7',
-  textDecoration: 'underline'
-}
+  textDecoration: 'underline',
+};
 
 const footerLogos = {
   marginBottom: '32px',
-  width: '100%'
-}
+  width: '100%',
+};
 
 const socialMediaIcon = {
   display: 'inline',
   marginLeft: '32px',
 };
-
 
 const main = {
   backgroundColor: '#ffffff',
@@ -141,11 +177,11 @@ const main = {
 
 const container = {
   maxWidth: '600px',
-  margin: '0 auto'
+  margin: '0 auto',
 };
 
 const logoContainer = {
-  marginTop: '32px'
+  marginTop: '32px',
 };
 
 const h1 = {
@@ -160,8 +196,8 @@ const h1 = {
 const heroText = {
   fontSize: '20px',
   lineHeight: '28px',
-  marginBottom: '30px'
-}
+  marginBottom: '30px',
+};
 
 const codeBox = {
   background: 'rgb(245, 244, 245)',
@@ -174,8 +210,8 @@ const codeBox = {
 const confirmationCodeText = {
   fontSize: '30px',
   textAlign: 'center' as const,
-  verticalAlign: 'middle'
-}
+  verticalAlign: 'middle',
+};
 
 const text = {
   color: '#000',

--- a/apps/demo/emails/stack-overflow-tips.tsx
+++ b/apps/demo/emails/stack-overflow-tips.tsx
@@ -10,11 +10,23 @@ import { Column } from '@react-email/column';
 import { Link } from '@react-email/link';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : '';
+interface EmailProps {
+  tips: string[];
+}
 
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
+
+const PropDefaults: EmailProps = {
+  tips: [
+    'To find a specific phrase, enter it in quotes: "local storage"',
+    'To search within specific tag(s), enter them in square brackets: [javascript]',
+    'Combine them to get even more precise results - [javascript] "local storage" searches for the phrase “local storage” in questions that have the [javascript] tag',
+  ],
+};
+
+export default function Email({ tips = PropDefaults.tips }: EmailProps) {
   return (
     <Html>
       <Head />
@@ -62,24 +74,11 @@ export default function Email() {
               Here are a few simple search tips to get you started:
             </Text>
             <ul>
-              <li>
-                <Text style={paragraph}>
-                  To find a specific phrase, enter it in quotes: "local storage"
-                </Text>
-              </li>
-              <li>
-                <Text style={paragraph}>
-                  To search within specific tag(s), enter them in square
-                  brackets: [javascript]
-                </Text>
-              </li>
-              <li>
-                <Text style={paragraph}>
-                  Combine them to get even more precise results - [javascript]
-                  "local storage" searches for the phrase “local storage” in
-                  questions that have the [javascript] tag
-                </Text>
-              </li>
+              {tips.map((t) => (
+                <li>
+                  <Text style={paragraph}>{t}</Text>
+                </li>
+              ))}
             </ul>
 
             <Text style={paragraph}>

--- a/apps/demo/emails/stripe-welcome.tsx
+++ b/apps/demo/emails/stripe-welcome.tsx
@@ -10,9 +10,11 @@ import { Section } from '@react-email/section';
 import { Text } from '@react-email/text';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
 
+export default function Email() {
   return (
     <Html>
       <Head />

--- a/apps/demo/emails/twitch-reset-password.tsx
+++ b/apps/demo/emails/twitch-reset-password.tsx
@@ -8,8 +8,23 @@ import { Text } from '@react-email/text';
 import { Link } from '@react-email/link';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
+interface EmailProps {
+  username: string;
+  updatedDate: Date;
+}
+
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
+
+export default function Email({
+  username = 'zenorocha',
+  updatedDate = new Date('June 23, 2022 4:06:00 pm UTC'),
+}: EmailProps) {
+  const formattedDate = new Intl.DateTimeFormat('en', {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+  }).format(updatedDate);
 
   return (
     <Html>
@@ -26,10 +41,10 @@ export default function Email() {
             <Section style={sectionBorder} />
           </div>
           <Section style={content}>
-            <Text style={paragraph}>Hi zenorocha,</Text>
+            <Text style={paragraph}>Hi {username},</Text>
             <Text style={paragraph}>
-              You updated the password for your Twitch account on June 23, 2022
-              4:06:00 pm UTC. If this was you, then no further action is
+              You updated the password for your Twitch account on{' '}
+              {formattedDate}. If this was you, then no further action is
               required.
             </Text>
             <Text style={paragraph}>

--- a/apps/demo/emails/vercel-invite-user.tsx
+++ b/apps/demo/emails/vercel-invite-user.tsx
@@ -10,13 +10,39 @@ import { Section } from '@react-email/section';
 import { Text } from '@react-email/text';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
+interface EmailProps {
+  username: string;
+  userImage: string;
+  invitedByUsername: string;
+  invitedByEmail: string;
+  teamName: string;
+  teamImage: string;
+  inviteLink: string;
+  inviteFromIp: string;
+  inviteFromLocation: string;
+}
+
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
+
+export default function Email({
+  username = 'zenorocha',
+  userImage = `${baseUrl}/static/vercel-user.png`,
+  invitedByUsername = 'bukinoshita',
+  invitedByEmail = 'bukinoshita@example.com',
+  teamName = 'My Project',
+  teamImage = `${baseUrl}/static/vercel-team.png`,
+  inviteLink = 'https://vercel.com/teams/invite/foo',
+  inviteFromIp = '204.13.186.218',
+  inviteFromLocation = 'São Paulo, Brazil',
+}: EmailProps) {
+  const previewText = `Join ${invitedByUsername} on Vercel`;
 
   return (
     <Html>
       <Head />
-      <Preview>Join bukinoshita on Vercel</Preview>
+      <Preview>{previewText}</Preview>
       <Section style={main}>
         <Container style={container}>
           <Section style={{ marginTop: '32px' }}>
@@ -29,15 +55,15 @@ export default function Email() {
             />
           </Section>
           <Text style={h1}>
-            Join <strong>My Project</strong> on <strong>Vercel</strong>
+            Join <strong>{teamName}</strong> on <strong>Vercel</strong>
           </Text>
-          <Text style={text}>Hello zenorocha,</Text>
+          <Text style={text}>Hello {username},</Text>
           <Text style={text}>
             <strong>bukinoshita</strong> (
-            <Link href="mailto:bukinoshita@example.com" style={link}>
-              bukinoshita@example.com
+            <Link href={`mailto:${invitedByEmail}`} style={link}>
+              {invitedByEmail}
             </Link>
-            ) has invited you to the <strong>My Project</strong> team on{' '}
+            ) has invited you to the <strong>{teamName}</strong> team on{' '}
             <strong>Vercel</strong>.
           </Text>
           <table
@@ -49,12 +75,7 @@ export default function Email() {
           >
             <tr>
               <td style={center} align="left" valign="middle">
-                <Img
-                  style={avatar}
-                  src={`${baseUrl}/static/vercel-user.png`}
-                  width="64"
-                  height="64"
-                />
+                <Img style={avatar} src={userImage} width="64" height="64" />
               </td>
               <td style={center} align="left" valign="middle">
                 <Img
@@ -65,22 +86,12 @@ export default function Email() {
                 />
               </td>
               <td style={center} align="left" valign="middle">
-                <Img
-                  style={avatar}
-                  src={`${baseUrl}/static/vercel-team.png`}
-                  width="64"
-                  height="64"
-                />
+                <Img style={avatar} src={teamImage} width="64" height="64" />
               </td>
             </tr>
           </table>
           <Section style={{ textAlign: 'center' }}>
-            <Button
-              pX={20}
-              pY={12}
-              style={btn}
-              href="https://vercel.com/teams/invite/foo"
-            >
+            <Button pX={20} pY={12} style={btn} href={inviteLink}>
               Join the team
             </Button>
           </Section>
@@ -88,20 +99,20 @@ export default function Email() {
             <br />
             or copy and paste this URL into your browser:{' '}
             <Link
-              href="https://vercel.com/teams/invite/foo"
+              href={inviteLink}
               target="_blank"
               style={link}
               rel="noreferrer"
             >
-              https://vercel.com/teams/invite/foo
+              {inviteLink}
             </Link>
           </Text>
           <Hr style={hr} />
           <Text style={footer}>
             This invitation was intended for{' '}
-            <span style={black}>zenorocha</span>.This invite was sent from{' '}
-            <span style={black}>204.13.186.218</span> located in{' '}
-            <span style={black}>São Paulo, Brazil</span>. If you were not
+            <span style={black}>{username} </span>.This invite was sent from{' '}
+            <span style={black}>{inviteFromIp}</span> located in{' '}
+            <span style={black}>{inviteFromLocation}</span>. If you were not
             expecting this invitation, you can ignore this email. If you are
             concerned about your account's safety, please reply to this email to
             get in touch with us.

--- a/apps/demo/emails/yelp-recent-login.tsx
+++ b/apps/demo/emails/yelp-recent-login.tsx
@@ -8,8 +8,29 @@ import { Section } from '@react-email/section';
 import { Text } from '@react-email/text';
 import * as React from 'react';
 
-export default function Email() {
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
+interface EmailProps {
+  userFirstName: string;
+  loginDate: Date;
+  loginDevice: string;
+  loginLocation: string;
+  loginIp: string;
+}
+
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : '';
+
+export default function Email({
+  userFirstName = 'Zeno',
+  loginDate = new Date('September 7, 2022, 10:58 am'),
+  loginDevice = 'Chrome on Mac OS X',
+  loginLocation = 'Upland, California, United States',
+  loginIp = '47.149.53.167',
+}: EmailProps) {
+  const formattedDate = new Intl.DateTimeFormat('en', {
+    dateStyle: 'long',
+    timeStyle: 'short',
+  }).format(loginDate);
 
   return (
     <Html>
@@ -34,7 +55,7 @@ export default function Email() {
                     textAlign: 'center',
                   }}
                 >
-                  Hi Zeno,
+                  Hi {userFirstName},
                 </Text>
                 <Text
                   style={{
@@ -50,15 +71,16 @@ export default function Email() {
 
               <Section>
                 <Text style={paragraph}>
-                  <b>Time: </b>Today, September 7, 2022, 10:58 am {'('}
-                  US/Pacific
-                  {')'}
+                  <b>Time: </b>
+                  {formattedDate}
                 </Text>
                 <Text style={{ ...paragraph, marginTop: -5 }}>
-                  <b>Device: </b>Chrome on Mac OS X
+                  <b>Device: </b>
+                  {loginDevice}
                 </Text>
                 <Text style={{ ...paragraph, marginTop: -5 }}>
-                  <b>Location: </b>Upland, California, United States
+                  <b>Location: </b>
+                  {loginLocation}
                 </Text>
                 <Text
                   style={{
@@ -69,7 +91,7 @@ export default function Email() {
                   }}
                 >
                   *Approximate geographic location based on IP address:
-                  47.149.53.167
+                  {loginIp}
                 </Text>
               </Section>
 


### PR DESCRIPTION
Quick PR to add some value to the examples by providing email props and default values for those props.

I pulled the `baseUrl` variable up a layer in scope to allow the default values to access it.
Other than that, all emails that have some variable data have had a new interface created and referenced in the component. Then the object is desctructured and default values added.

Looks like prettier also made a few changes, but they seem to respect the existing top level prettier config.