### PR TITLE
fix(react-email): Watcher for subfolders

### DIFF
--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "A live preview of your emails right in your browser.",
   "bin": {
     "email": "./dist/index.js"

--- a/packages/react-email/source/utils/watcher.ts
+++ b/packages/react-email/source/utils/watcher.ts
@@ -3,7 +3,6 @@ import {
   CLIENT_EMAILS_PATH,
   CURRENT_PATH,
   EVENT_FILE_DELETED,
-  PACKAGE_EMAILS_PATH,
   REACT_EMAIL_ROOT,
 } from './constants';
 import fs from 'fs';
@@ -21,20 +20,18 @@ export const watcher = () =>
     if (event === EVENT_FILE_DELETED) {
       const file = filename.split(path.sep);
 
-      if (file[1] === 'static') {
-        if (file[2]) {
-          await fs.promises.rm(
-            path.join(REACT_EMAIL_ROOT, 'public', 'static', file[2]),
-          );
-          return;
-        }
+      if (file[1] === 'static' && file[2]) {
+        await fs.promises.rm(
+          path.join(REACT_EMAIL_ROOT, 'public', 'static', file[2]),
+        );
+        return;
       }
 
       await fs.promises.rm(path.join(REACT_EMAIL_ROOT, filename));
     } else {
       const file = filename.split(path.sep);
 
-      if (file[1] === 'static') {
+      if (file[1] === 'static' && file[2]) {
         await copy(
           `${CLIENT_EMAILS_PATH}/static/${file[2]}`,
           `${REACT_EMAIL_ROOT}/public/static`,
@@ -42,6 +39,9 @@ export const watcher = () =>
         return;
       }
 
-      await copy(`${CLIENT_EMAILS_PATH}/${file[1]}`, PACKAGE_EMAILS_PATH);
+      await copy(
+        path.join(CURRENT_PATH, filename),
+        path.join(REACT_EMAIL_ROOT, file.slice(0, -1).join(path.sep)),
+      );
     }
   });


### PR DESCRIPTION
In the current version (1.7.2), if you were to change a file in (for example) `emails/components` the watcher would not copy that file to the correct location. This pr fixes this behaviour, see pictures below:

Before changing `header.tsx`:
<img width="316" alt="Screenshot 2023-01-26 at 09 27 13" src="https://user-images.githubusercontent.com/3987804/214789570-c5a190e8-43c1-4b43-b4f8-d328c006d924.png">

After changing `header.tsx` (old flow):
<img width="313" alt="Screenshot 2023-01-26 at 09 28 03" src="https://user-images.githubusercontent.com/3987804/214789668-029ec4db-3c52-44f3-89a2-f60276cb8fca.png">

After changing `header.tsx` (new flow):
<img width="316" alt="Screenshot 2023-01-26 at 09 27 13" src="https://user-images.githubusercontent.com/3987804/214789570-c5a190e8-43c1-4b43-b4f8-d328c006d924.png">