### PR TITLE
fix(react-email): Package.json version

### DIFF
--- a/packages/react-email/source/index.ts
+++ b/packages/react-email/source/index.ts
@@ -3,11 +3,12 @@ import { program } from '@commander-js/extra-typings';
 import { PACKAGE_NAME } from './utils/constants';
 import { dev } from './commands/dev';
 import { exportTemplates } from './commands/export';
+import packageJson from '../package.json'
 
 program
   .name(PACKAGE_NAME)
   .description('A live preview of your emails right in your browser')
-  .version('0.0.0');
+  .version(packageJson.version);
 
 program
   .command('dev')

--- a/packages/react-email/tsconfig.json
+++ b/packages/react-email/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "ES2020", // Node.js 14
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "allowSyntheticDefaultImports": true, // To provide backwards compatibility, Node.js allows you to import most CommonJS packages with a default import. This flag tells TypeScript that it's okay to use import on CommonJS modules.
-    "resolveJsonModule": false, // ESM doesn't yet support JSON modules.
+    "resolveJsonModule": true,
     "jsx": "react",
     "declaration": true,
     "pretty": true,


### PR DESCRIPTION
I removed the hard-coded version and passed package.json's version

Note: `"resolveJsonModule": true` works because `esModuleInterop` is true