### PR TITLE
fix(react-email): command not found error

### DIFF
--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -3,9 +3,9 @@
   "version": "1.7.7",
   "description": "A live preview of your emails right in your browser.",
   "bin": {
-    "email": "./dist/index.js"
+    "email": "./dist/source/index.js"
   },
-  "types": "./dist/index.d.ts",
+  "types": "./dist/source/index.d.ts",
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",


### PR DESCRIPTION
related to https://github.com/resendlabs/react-email/issues/248#issuecomment-1407272929

`react-email@1.7.7` raises "command not found" error.

I created a branch to reproduce it. Please check out [this](https://github.com/m-shaka/react-email/tree/repro-command-not-found) and run
```
yarn --force
yarn workspace repro-command-not-found dev
```

cause:
`dist/index.js` is not published.
https://www.npmjs.com/package/react-email/v/1.7.7?activeTab=explore
![image](https://user-images.githubusercontent.com/12842076/215252828-4569af70-fa03-45a8-91ea-e403c7668b77.png)

This is understandable because `build` command generate `dist/source/index.js` instead of `dist/index.js`.
You can see it through executing `yarn turbo build --scope=react-email` and then `ls packages/react-email/dist` manually.

I don't know `dist/index.js` had been published until 1.7.6 but it must be cache