### PR TITLE
fix(head): Meta tag content declaration

### DIFF
--- a/packages/head/src/head.tsx
+++ b/packages/head/src/head.tsx
@@ -8,7 +8,7 @@ export interface HeadProps extends RootProps {}
 export const Head = React.forwardRef<HeadElement, Readonly<HeadProps>>(
   ({ children, ...props }, forwardedRef) => (
     <head ref={forwardedRef} {...props}>
-      <meta httpEquiv="Content-Type" content="text/html charset=UTF-8" />
+      <meta httpEquiv="Content-Type" content="text/html; charset=UTF-8" />
       {children}
     </head>
   ),


### PR DESCRIPTION
This PR adds a ; in the declaration of the content properties of the meta tag. This correction was necessary because when testing some emails on the [Email On Acid](https://www.emailonacid.com/) platform, I noticed along with my coworker (@thudf) that some email providers were not recognizing words that had an accent. Here's an example:

The purpose was to write "olá".
![image](https://user-images.githubusercontent.com/20157546/215900397-fefa7367-5a67-4cd6-bb9a-c47b76fec7a6.png)
