### PR TITLE
fix(react-email): Allow custom folder structure inside emails folder

### DIFF
--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email",
-  "version": "1.7.10",
+  "version": "1.7.11",
   "description": "A live preview of your emails right in your browser.",
   "bin": {
     "email": "./dist/source/index.js"

--- a/packages/react-email/source/commands/dev.ts
+++ b/packages/react-email/source/commands/dev.ts
@@ -148,7 +148,6 @@ const generateEmailsPreview = async (emailDir: string) => {
 
     await createEmailPreviews(emailDir);
     await createStaticFiles(emailDir);
-    await createComponents(emailDir);
 
     spinner.stopAndPersist({
       symbol: logSymbols.success,
@@ -161,12 +160,8 @@ const generateEmailsPreview = async (emailDir: string) => {
 
 const createEmailPreviews = async (emailDir: string) => {
   const hasEmailsDirectory = checkDirectoryExist(emailDir);
-
-  const isEmailsDirectoryEmpty = hasEmailsDirectory
-    ? await checkEmptyDirectory(emailDir)
-    : true;
-
-  if (isEmailsDirectoryEmpty) {
+  if (hasEmailsDirectory) {
+    await checkEmptyDirectory(emailDir);
   }
 
   const hasPackageEmailsDirectory = checkDirectoryExist(PACKAGE_EMAILS_PATH);
@@ -175,42 +170,35 @@ const createEmailPreviews = async (emailDir: string) => {
     await fs.promises.rm(PACKAGE_EMAILS_PATH, { recursive: true });
   }
 
-  await copy(path.join(emailDir, '*{.tsx,.jsx}'), PACKAGE_EMAILS_PATH);
+  await copy(path.join(emailDir, '**'), PACKAGE_EMAILS_PATH);
 };
 
 const createStaticFiles = async (emailDir: string) => {
   const hasPackageStaticDirectory = checkDirectoryExist(
     `${REACT_EMAIL_ROOT}/public/static`,
   );
-  const staticDir = path.join(emailDir, 'static');
-  const hasStaticDirectory = checkDirectoryExist(staticDir);
-
   if (hasPackageStaticDirectory) {
     await fs.promises.rm(`${REACT_EMAIL_ROOT}/public/static`, {
       recursive: true,
     });
   }
 
-  if (hasStaticDirectory) {
-    await copy(staticDir, `${REACT_EMAIL_ROOT}/public/static`);
-  }
-};
-
-const createComponents = async (emailDir: string) => {
-  const hasPackageComponentsDirectory = checkDirectoryExist(
-    `${PACKAGE_EMAILS_PATH}/components`,
+  // Make sure that the "static" folder does not exists in .react-email/emails
+  // since it should only exists in .react-email/public, but the "createEmailPreviews"-function will blindly copy the complete emails folder
+  const hasPackageStaticDirectoryInEmails = checkDirectoryExist(
+    `${REACT_EMAIL_ROOT}/emails/static`,
   );
-  const componentDir = path.join(emailDir, 'components');
-  const hasComponentsDirectory = checkDirectoryExist(componentDir);
-
-  if (hasPackageComponentsDirectory) {
-    await fs.promises.rm(`${PACKAGE_EMAILS_PATH}/components`, {
+  if (hasPackageStaticDirectoryInEmails) {
+    await fs.promises.rm(`${REACT_EMAIL_ROOT}/emails/static`, {
       recursive: true,
     });
   }
 
-  if (hasComponentsDirectory) {
-    await copy(componentDir, `${PACKAGE_EMAILS_PATH}/components`);
+  const staticDir = path.join(emailDir, 'static');
+  const hasStaticDirectory = checkDirectoryExist(staticDir);
+
+  if (hasStaticDirectory) {
+    await copy(staticDir, `${REACT_EMAIL_ROOT}/public/static`);
   }
 };
 


### PR DESCRIPTION
Currently, the dev server only allows us (implicitly) to create the following folders inside the `email`-folder: `components` & `static`. Sub folders are not allowed inside the `components`-folder which can lead to a messy folder structure.

This PR allows us to create the folder structure we want/need for the project, while still moving the files in the `static`-folder to the `public`-folder for NextJS. A nice side-effect is that all files are now moved to the NextJS server, like custom interfaces in `.ts`-files or json data (fixes #379). Project example:

Before             |  After
:-------------------------:|:-------------------------:
<img width="289" alt="Screenshot 2023-02-01 at 10 15 36" src="https://user-images.githubusercontent.com/3987804/216001150-8590afc8-bab0-4c46-bd0a-419cf1e4c4d8.png">  |  <img width="301" alt="Screenshot 2023-02-01 at 10 13 46" src="https://user-images.githubusercontent.com/3987804/216000796-33ad1f96-ac09-4ec9-bc3b-67b7d78eba7b.png">

Note: The watcher is already equip to deal with custom folder structures, so no change was needed there.