### PR TITLE
doc: fix wrong export on integrations

### DIFF
--- a/apps/docs/integrations/aws-ses.mdx
+++ b/apps/docs/integrations/aws-ses.mdx
@@ -30,7 +30,7 @@ import * as React from 'react';
 import { Html } from '@react-email/html';
 import { Button } from '@react-email/button';
 
-export default function Email(props) {
+export function Email(props) {
   const { url } = props;
 
   return (

--- a/apps/docs/integrations/nodemailer.mdx
+++ b/apps/docs/integrations/nodemailer.mdx
@@ -30,7 +30,7 @@ import * as React from 'react';
 import { Html } from '@react-email/html';
 import { Button } from '@react-email/button';
 
-export default function Email(props) {
+export function Email(props) {
   const { url } = props;
 
   return (

--- a/apps/docs/integrations/postmark.mdx
+++ b/apps/docs/integrations/postmark.mdx
@@ -30,7 +30,7 @@ import * as React from 'react';
 import { Html } from '@react-email/html';
 import { Button } from '@react-email/button';
 
-export default function Email(props) {
+export function Email(props) {
   const { url } = props;
 
   return (

--- a/apps/docs/integrations/sendgrid.mdx
+++ b/apps/docs/integrations/sendgrid.mdx
@@ -30,7 +30,7 @@ import * as React from 'react';
 import { Html } from '@react-email/html';
 import { Button } from '@react-email/button';
 
-export default function Email(props) {
+export function Email(props) {
   const { url } = props;
 
   return (


### PR DESCRIPTION
The exported `Email` component on nodemailer,aws ses, postmark and sendgrid has wrong export type.
Should not be a default export  