### PR TITLE
fix(react-email): make NPM the default package manager

### DIFF
--- a/packages/react-email/source/commands/dev.ts
+++ b/packages/react-email/source/commands/dev.ts
@@ -36,12 +36,9 @@ export const dev = async ({ dir, port }: Args) => {
   const watcherInstance = createWatcherInstance(emailDir);
   try {
     const hasReactEmailDirectory = checkDirectoryExist(REACT_EMAIL_ROOT);
-    let packageManager: PackageManager;
-    try {
-      packageManager = await detectPackageManager({ cwd: CURRENT_PATH });
-    } catch (_) {
-      packageManager = 'yarn';
-    }
+    const packageManager: PackageManager = await detectPackageManager({
+      cwd: CURRENT_PATH,
+    }).catch(() => 'npm');
 
     if (hasReactEmailDirectory) {
       const isUpToDate = await checkPackageIsUpToDate();


### PR DESCRIPTION
fix #411 

This is caused by a bug of `detect-package-manager`. See https://github.com/egoist/detect-package-manager/pull/7