### PR TITLE
fix(react-email): Support nested email paths

### DIFF
--- a/packages/react-email/source/utils/watcher.ts
+++ b/packages/react-email/source/utils/watcher.ts
@@ -1,6 +1,5 @@
 import chokidar, { FSWatcher } from 'chokidar';
 import {
-  CURRENT_PATH,
   EVENT_FILE_DELETED,
   PACKAGE_EMAILS_PATH,
   REACT_EMAIL_ROOT,
@@ -12,7 +11,7 @@ import copy from 'cpy';
 export const createWatcherInstance = (watchDir: string) =>
   chokidar.watch(watchDir, {
     ignoreInitial: true,
-    cwd: CURRENT_PATH,
+    cwd: watchDir.split(path.sep).slice(0, -1).join(path.sep),
     ignored: /(^|[\/\\])\../,
   });
 


### PR DESCRIPTION
There is an error when copying email templates from its folder to `.react-email` folder when `-d` argument is provided to `email dev` command with a nested path like `src/emails`. (`email dev -d src/emails`).

The error was the following:
```node
node:internal/process/promises:279
            triggerUncaughtException(err, true /* fromPromise */);
            ^
NestedError: Cannot copy `/home/xxx/projectRoot/src/emails/emails/biweekly-event-reminder.tsx`: the file doesn't exist
    at /home/dani/glissandoo/functions/node_modules/cpy/index.js:96:10
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async FSWatcher.<anonymous> (/home/dani/glissandoo/functions/node_modules/react-email/dist/source/utils/watcher.js:38:9) {
  nested: undefined,
  name: 'CpyError'
```

This happened because `cwd` in `createWatcherInstance` was set to `CURRENT_PATH`, which in this case was `/home/xxx/projectRoot`, therefore, in the `copy` call of line 42, joining `watchDir` which is equal to `/home/xxx/projectRoot/src/emails` with `file.slice(1)` which is equal to `['emails', 'file.tsx']`, since file path equals  `['src', 'emails', 'file.tsx']`, which as we can see, starts from the base cwd specified in `createWatcherInstance` (`CURRENT_PATH`). This duplicated `emails` folder, and this is what this PR fixes.