### PR TITLE
feat(html): Add direction prop

### DIFF
--- a/apps/docs/components/html.mdx
+++ b/apps/docs/components/html.mdx
@@ -31,7 +31,7 @@ import { Html } from '@react-email/html';
 
 const Email = () => {
   return (
-    <Html lang="en">
+    <Html lang="en" dir="ltr">
       <Button href="https://example.com" style={{ color: '#61dafb' }}>
         Click me
       </Button>
@@ -44,6 +44,9 @@ const Email = () => {
 
 <ResponseField name="lang" type="string" default="en">
   Identify the language of text content on the email
+</ResponseField>
+<ResponseField name="dir" type="string" default="ltr" >
+  Identify the direction of text content on the email
 </ResponseField>
 
 <Snippet file="support.mdx" />

--- a/packages/html/src/html.tsx
+++ b/packages/html/src/html.tsx
@@ -6,8 +6,8 @@ type RootProps = React.ComponentPropsWithoutRef<'html'>;
 export interface HtmlProps extends RootProps {}
 
 export const Html = React.forwardRef<HtmlElement, Readonly<HtmlProps>>(
-  ({ children, lang = 'en', ...props }, forwardedRef) => (
-    <html {...props} id="__react-email" ref={forwardedRef} lang={lang}>
+  ({ children, lang = 'en', dir = "ltr", ...props }, forwardedRef) => (
+    <html {...props} id="__react-email" ref={forwardedRef} lang={lang} dir={dir}>
       {children}
     </html>
   ),


### PR DESCRIPTION
Hello 👋, this pr adds `dir` prop which will benefit lots of `rtl` users e.g Arabic speaking users 
I checked the [compatibility](https://www.caniemail.com/features/css-direction/) to make sure it works on almost all email clients 

docs updated + ran lint to make sure everything is okay

before:

![Screenshot 1444-07-22 at 6 09 54 PM](https://user-images.githubusercontent.com/43112535/218495682-01c785c8-d21c-4c59-958c-b5d8e54dcfdf.png)


After:

![Screenshot 1444-07-22 at 6 09 44 PM](https://user-images.githubusercontent.com/43112535/218495750-8c20ecb8-d411-4cf6-8a99-9c12f217d507.png)


