### PR TITLE
fix(docs): Typos

### DIFF
--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -78,7 +78,7 @@ description: 'New features, bug fixes, and improvements made to each package.'
 
 **Column `0.0.2`**
 
-- Fix default stylingto accomodate `<Section>` component
+- Fix default styling to accomodate `<Section>` component
 
 **Section `0.0.2`**
 

--- a/apps/docs/getting-started/manual-setup.mdx
+++ b/apps/docs/getting-started/manual-setup.mdx
@@ -9,7 +9,7 @@ import NextSteps from '../snippets/next-steps.mdx';
 
 ## 1. Create directory
 
-Create a new folder called `react-email-starter` and initiliaze a new npm project:
+Create a new folder called `react-email-starter` and initialize a new npm project:
 
 ```sh
 mkdir react-email-starter


### PR DESCRIPTION
This PR fixes two typos, one in `Changelog` and `Manual Setup`.