### PR TITLE
chore(tailwind): Add support for responsive classes and custom nested components

### DIFF
--- a/packages/tailwind/.babelrc
+++ b/packages/tailwind/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-react"]
+}

--- a/packages/tailwind/jest.config.js
+++ b/packages/tailwind/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  preset: 'ts-jest',
+  clearMocks: true,
+  resetMocks: true,
+  restoreMocks: true,
+  verbose: true,
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['/node_modules/', '/build/'],
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.ts?$': 'ts-jest',
+    '^.+\\.(js|jsx)$': 'babel-jest',
+  },
+};

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -15,6 +15,8 @@
     "dev": "tsup src/index.ts --format esm,cjs --dts --external react --watch",
     "lint": "eslint",
     "clean": "rm -rf dist",
+    "test": "jest",
+    "test:watch": "jest --watch",
     "format:check": "prettier --ignore-path ./../../.prettierignore  --check \"**/*.{ts,tsx,md}\"",
     "format": "prettier --ignore-path ./../../.prettierignore  --write \"**/*.{ts,tsx,md}\""
   },
@@ -32,9 +34,13 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "tw-to-css": "0.0.9"
+    "html-react-parser": "3.0.9",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tw-to-css": "0.0.10"
   },
   "devDependencies": {
+    "@testing-library/react": "14.0.0",
     "@types/react": "18.0.20",
     "@types/react-dom": "18.0.6",
     "eslint": "8.23.1",

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -20,6 +20,18 @@ describe('Tailwind component', () => {
         `"<div style=\\"background-color:rgb(0,0,0);color:rgb(255,255,255)\\"></div>"`,
       );
     });
+
+    it('should be able to use background image', () => {
+      const actualOutput = render(
+        <Tailwind>
+          <div className="bg-[url(https://react.email/static/covers/tailwind.png)]" />
+        </Tailwind>,
+      );
+
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<div style=\\"background-image:url(https://react.email/static/covers/tailwind.png)\\"></div>"`,
+      );
+    });
   });
 
   describe('Responsive styles', () => {

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -40,15 +40,15 @@ describe('Tailwind component', () => {
         <Tailwind>
           <html>
             <head />
+            <body>
+              <div className="bg-red-200 sm:bg-red-300 md:bg-red-400 lg:bg-red-500" />
+            </body>
           </html>
-          <body>
-            <div className="bg-red-200 sm:bg-red-300 md:bg-red-400 lg:bg-red-500" />
-          </body>
         </Tailwind>,
       );
 
       expect(actualOutput).toMatchInlineSnapshot(
-        `"<html><head><style>.bg_red_200{background-color:rgb(254,202,202)}@media(min-width:640px){.sm_bg_red_300{background-color: rgb(252,165,165) !important}}@media(min-width:768px){.md_bg_red_400{background-color: rgb(248,113,113) !important}}@media(min-width:1024px){.lg_bg_red_500{background-color: rgb(239,68,68) !important}}</style></head></html><body><div class=\\"bg_red_200 sm_bg_red_300 md_bg_red_400 lg_bg_red_500\\"></div></body>"`,
+        `"<html><head><style>.bg_red_200{background-color:rgb(254,202,202)}@media(min-width:640px){.sm_bg_red_300{background-color: rgb(252,165,165) !important}}@media(min-width:768px){.md_bg_red_400{background-color: rgb(248,113,113) !important}}@media(min-width:1024px){.lg_bg_red_500{background-color: rgb(239,68,68) !important}}</style></head><body><div class=\\"bg_red_200 sm_bg_red_300 md_bg_red_400 lg_bg_red_500\\"></div></body></html>"`,
       );
     });
 

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -224,15 +224,15 @@ describe('Tailwind component', () => {
         <Tailwind config={config}>
           <html>
             <head />
+            <body>
+              <div className="border-custom sm:border-custom" />
+            </body>
           </html>
-          <body>
-            <div className="border-custom sm:border-custom" />
-          </body>
         </Tailwind>,
       );
 
       expect(actualOutput).toMatchInlineSnapshot(
-        `"<html><head><style>.border_custom{border:2px solid}@media(min-width:640px){.sm_border_custom{border: 2px solid !important}}</style></head></html><body><div class=\\"border_custom sm_border_custom\\"></div></body>"`,
+        `"<html><head><style>.border_custom{border:2px solid}@media(min-width:640px){.sm_border_custom{border: 2px solid !important}}</style></head><body><div class=\\"border_custom sm_border_custom\\"></div></body></html>"`,
       );
     });
   });

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -71,30 +71,33 @@ describe('Tailwind component', () => {
     it('should be able to use custom colors', () => {
       const config: TailwindConfig = {
         theme: {
-          colors: {
-            blue: '#1fb6ff',
+          extend: {
+            colors: {
+              custom: '#1fb6ff',
+            },
           },
         },
       };
 
       const actualOutput = render(
         <Tailwind config={config}>
-          <div className="text-blue" />
-          <div className="bg-blue" />
+          <div className="text-custom bg-custom" />
         </Tailwind>,
       );
 
       expect(actualOutput).toMatchInlineSnapshot(
-        `"<div style=\\"color:rgb(31,182,255)\\"></div><div style=\\"background-color:rgb(31,182,255)\\"></div>"`,
+        `"<div style=\\"background-color:rgb(31,182,255);color:rgb(31,182,255)\\"></div>"`,
       );
     });
 
     it('should be able to use custom colors', () => {
       const config: TailwindConfig = {
         theme: {
-          fontFamily: {
-            sans: ['Graphik', 'sans-serif'],
-            serif: ['Merriweather', 'serif'],
+          extend: {
+            fontFamily: {
+              sans: ['Graphik', 'sans-serif'],
+              serif: ['Merriweather', 'serif'],
+            },
           },
         },
       };

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -1,0 +1,227 @@
+import { Tailwind } from './tailwind';
+import { renderToStaticMarkup as render } from 'react-dom/server';
+import { TailwindConfig } from 'tw-to-css';
+
+describe('Tailwind component', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  describe('Inline styles', () => {
+    it('should render children with inline Tailwind styles', () => {
+      const actualOutput = render(
+        <Tailwind>
+          <div className="bg-black text-white" />
+        </Tailwind>,
+      );
+
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<div style=\\"background-color:rgb(0,0,0);color:rgb(255,255,255)\\"></div>"`,
+      );
+    });
+  });
+
+  describe('Responsive styles', () => {
+    it('should add css to <head/>', () => {
+      const actualOutput = render(
+        <Tailwind>
+          <html>
+            <head />
+          </html>
+          <body>
+            <div className="bg-red-200 sm:bg-red-300 md:bg-red-400 lg:bg-red-500" />
+          </body>
+        </Tailwind>,
+      );
+
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<html><head><style>.bg_red_200{background-color:rgb(254,202,202)}@media(min-width:640px){.sm_bg_red_300{background-color: rgb(252,165,165) !important}}@media(min-width:768px){.md_bg_red_400{background-color: rgb(248,113,113) !important}}@media(min-width:1024px){.lg_bg_red_500{background-color: rgb(239,68,68) !important}}</style></head></html><body><div class=\\"bg_red_200 sm_bg_red_300 md_bg_red_400 lg_bg_red_500\\"></div></body>"`,
+      );
+    });
+
+    it('should throw an error when used without <html/> and <head/> tags', () => {
+      try {
+        render(
+          <Tailwind>
+            <div className="bg-red-200 sm:bg-red-500" />
+          </Tailwind>,
+        );
+      } catch (error: any) {
+        expect(error.message).toBe(
+          'Tailwind: To use responsive styles you must have a <html> and <head> element in your template.',
+        );
+      }
+    });
+  });
+
+  describe('Custom theme config', () => {
+    it('should be able to use custom colors', () => {
+      const config: TailwindConfig = {
+        theme: {
+          colors: {
+            blue: '#1fb6ff',
+          },
+        },
+      };
+
+      const actualOutput = render(
+        <Tailwind config={config}>
+          <div className="text-blue" />
+          <div className="bg-blue" />
+        </Tailwind>,
+      );
+
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<div style=\\"color:rgb(31,182,255)\\"></div><div style=\\"background-color:rgb(31,182,255)\\"></div>"`,
+      );
+    });
+
+    it('should be able to use custom colors', () => {
+      const config: TailwindConfig = {
+        theme: {
+          fontFamily: {
+            sans: ['Graphik', 'sans-serif'],
+            serif: ['Merriweather', 'serif'],
+          },
+        },
+      };
+
+      const actualOutput = render(
+        <Tailwind config={config}>
+          <div className="font-sans" />
+          <div className="font-serif" />
+        </Tailwind>,
+      );
+
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<div style=\\"font-family:Graphik, sans-serif\\"></div><div style=\\"font-family:Merriweather, serif\\"></div>"`,
+      );
+    });
+
+    it('should be able to use custom spacing', () => {
+      const config: TailwindConfig = {
+        theme: {
+          extend: {
+            spacing: {
+              '8xl': '96rem',
+            },
+          },
+        },
+      };
+
+      const actualOutput = render(
+        <Tailwind config={config}>
+          <div className="m-8xl"></div>
+        </Tailwind>,
+      );
+
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<div style=\\"margin:96rem\\"></div>"`,
+      );
+    });
+
+    it('should be able to use custom border radius', () => {
+      const config: TailwindConfig = {
+        theme: {
+          extend: {
+            borderRadius: {
+              '4xl': '2rem',
+            },
+          },
+        },
+      };
+
+      const actualOutput = render(
+        <Tailwind config={config}>
+          <div className="rounded-4xl" />
+        </Tailwind>,
+      );
+
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<div style=\\"border-radius:2rem\\"></div>"`,
+      );
+    });
+
+    it('should be able to use custom text alignment', () => {
+      const config: TailwindConfig = {
+        theme: {
+          extend: {
+            textAlign: {
+              justify: 'justify',
+            },
+          },
+        },
+      };
+
+      const actualOutput = render(
+        <Tailwind config={config}>
+          <div className="text-justify" />
+        </Tailwind>,
+      );
+
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<div style=\\"text-align:justify\\"></div>"`,
+      );
+    });
+  });
+
+  describe('Custom plugins config', () => {
+    it('should be able to use custom plugins', () => {
+      const config: TailwindConfig = {
+        plugins: [
+          function ({ addUtilities }: any) {
+            const newUtilities = {
+              '.border-custom': {
+                border: '2px solid',
+              },
+            };
+
+            addUtilities(newUtilities);
+          },
+        ],
+      };
+
+      const actualOutput = render(
+        <Tailwind config={config}>
+          <div className="border-custom" />
+        </Tailwind>,
+      );
+
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<div style=\\"border:2px solid\\"></div>"`,
+      );
+    });
+
+    it('should be able to use custom plugins with responsive styles', () => {
+      const config: TailwindConfig = {
+        plugins: [
+          function ({ addUtilities }: any) {
+            const newUtilities = {
+              '.border-custom': {
+                border: '2px solid',
+              },
+            };
+
+            addUtilities(newUtilities);
+          },
+        ],
+      };
+
+      const actualOutput = render(
+        <Tailwind config={config}>
+          <html>
+            <head />
+          </html>
+          <body>
+            <div className="border-custom sm:border-custom" />
+          </body>
+        </Tailwind>,
+      );
+
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<html><head><style>.border_custom{border:2px solid}@media(min-width:640px){.sm_border_custom{border: 2px solid !important}}</style></head></html><body><div class=\\"border_custom sm_border_custom\\"></div></body>"`,
+      );
+    });
+  });
+});

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -1,4 +1,6 @@
-import * as React from 'react';
+import React, { Children, isValidElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import htmlParser, { attributesToProps, Element } from 'html-react-parser';
 import { tailwindToCSS, TailwindConfig } from 'tw-to-css';
 
 export interface TailwindProps {
@@ -6,32 +8,116 @@ export interface TailwindProps {
   config?: TailwindConfig;
 }
 
-export const Tailwind: React.FC<Readonly<TailwindProps>> = ({
-  children,
-  config,
-}) => {
-  const { twj } = tailwindToCSS({ config });
+export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
+  const { twi } = tailwindToCSS({
+    config,
+  });
 
-  const replaceTailwindStyles = (child: React.ReactNode): React.ReactNode => {
-    if (!React.isValidElement(child)) {
-      return child;
-    }
+  const newChildren = Children.toArray(children);
 
-    const { className, children: childChildren, style, ...rest } = child.props;
+  const fullHTML = renderToStaticMarkup(<>{newChildren}</>);
 
-    return React.cloneElement(child, {
-      ...rest,
-      children: React.Children.map(childChildren, replaceTailwindStyles),
-      style: { ...style, ...(className ? twj(className) : {}) },
-    });
-  };
-
-  const tailwindStylesToCSS = React.Children.map(
-    children,
-    replaceTailwindStyles,
+  const headStyle = getMediaQueryCSS(
+    twi(fullHTML, {
+      merge: false,
+      ignoreMediaQueries: false,
+    }),
   );
 
-  return <>{tailwindStylesToCSS}</>;
+  const hasResponsiveStyles = /@media[^{]+\{(?<content>[\s\S]+?)\}\s*\}/gm.test(
+    headStyle,
+  );
+  const hasHTML = /<html[^>]*>/gm.test(fullHTML);
+  const hasHead = /<head[^>]*>/gm.test(fullHTML);
+
+  if (hasResponsiveStyles && !hasHTML && !hasHead) {
+    throw new Error(
+      'Tailwind: To use responsive styles you must have a <html> and <head> element in your template.',
+    );
+  }
+
+  const reactHTML = Children.map(newChildren, (child) => {
+    if (!isValidElement(child)) return child;
+
+    const html = renderToStaticMarkup(child);
+
+    const parsedHTML = htmlParser(html, {
+      replace: (domNode) => {
+        if (domNode instanceof Element) {
+          if (hasResponsiveStyles && hasHead && domNode.name === 'head') {
+            let newDomNode: JSX.Element | null = null;
+
+            if (domNode.children) {
+              const style = domNode.children.find(
+                (child) => child instanceof Element && child.name === 'style',
+              );
+
+              const props = attributesToProps(domNode.attribs);
+
+              newDomNode = (
+                <head {...props}>
+                  {style && style instanceof Element ? (
+                    <style>{`${style.children} ${headStyle}`}</style>
+                  ) : (
+                    <style>{headStyle}</style>
+                  )}
+                </head>
+              );
+            }
+
+            return newDomNode;
+          }
+
+          if (domNode.attribs?.class) {
+            if (hasResponsiveStyles) {
+              domNode.attribs.class = domNode.attribs.class.replace(
+                /[:#\!\-[\]]+/g,
+                '_',
+              );
+            } else {
+              domNode.attribs.style = `${twi(domNode.attribs.class)} ${
+                domNode.attribs.style || ''
+              }`;
+              delete domNode.attribs.class;
+            }
+          }
+        }
+      },
+    });
+
+    return parsedHTML;
+  });
+
+  return <>{reactHTML}</>;
 };
 
 Tailwind.displayName = 'Tailwind';
+
+function getMediaQueryCSS(css: string) {
+  const mediaQueryRegex = /@media[^{]+\{(?<content>[\s\S]+?)\}\s*\}/gm;
+
+  let newCss = css
+    .replace(mediaQueryRegex, (m) => {
+      return m.replace(
+        /([^{]+\{)([\s\S]+?)(\}\s*\})/gm,
+        (_, start, content, end) => {
+          const newcontent = (content as string).replace(
+            /(?:[\s\r\n]*)?(?<prop>[\w-]+)\s*:\s*(?<value>[^;\r\n]+)/gm,
+            (_, prop, value) => {
+              return `${prop}: ${value} !important`;
+            },
+          );
+
+          return `${start}${newcontent}${end}`;
+        },
+      );
+    })
+    .replace(/[.\!\#\w\d\\:\-\[\]]+\s*?{/g, (m) => {
+      return m.replace(/[:#\!\-[\\\]]+/g, '_');
+    })
+    .replace(/font-family(?<value>[^;\r\n]+)/g, (m, value) => {
+      return `font-family${value.replace(/['"]+/g, '')}`;
+    });
+
+  return newCss;
+}

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -1,4 +1,4 @@
-import React, { Children, isValidElement } from 'react';
+import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import htmlParser, { attributesToProps, Element } from 'html-react-parser';
 import { tailwindToCSS, TailwindConfig } from 'tw-to-css';
@@ -13,7 +13,7 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
     config,
   });
 
-  const newChildren = Children.toArray(children);
+  const newChildren = React.Children.toArray(children);
 
   const fullHTML = renderToStaticMarkup(<>{newChildren}</>);
 
@@ -36,8 +36,8 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
     );
   }
 
-  const reactHTML = Children.map(newChildren, (child) => {
-    if (!isValidElement(child)) return child;
+  const reactHTML = React.Children.map(newChildren, (child) => {
+    if (!React.isValidElement(child)) return child;
 
     const html = renderToStaticMarkup(child);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,7 +42,7 @@
     ajv-draft-04 "^1.0.0"
     call-me-maybe "^1.0.1"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz"
   integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
@@ -354,6 +354,13 @@
   version "7.20.6"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz"
   integrity sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
+"@babel/runtime@^7.12.5":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
+  integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
   dependencies:
     regenerator-runtime "^0.13.11"
 
@@ -1227,6 +1234,28 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "1.0.0"
 
+"@react-email/components@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@react-email/components/-/components-0.0.1.tgz#c28fca89f523847a714b9b88639fe8ea8faac194"
+  integrity sha512-+zgRKbR6j8w5himDgRgZY6JIoUPYY38LW9meal+FQcEP7wMF/xvNlkkXgU8hKG6WO60J89RkgZBjhP0OpTwDbA==
+  dependencies:
+    "@react-email/body" "0.0.1"
+    "@react-email/button" "0.0.6"
+    "@react-email/column" "0.0.6"
+    "@react-email/container" "0.0.7"
+    "@react-email/head" "0.0.4"
+    "@react-email/heading" "0.0.7"
+    "@react-email/hr" "0.0.4"
+    "@react-email/html" "0.0.4"
+    "@react-email/img" "0.0.4"
+    "@react-email/link" "0.0.4"
+    "@react-email/preview" "0.0.5"
+    "@react-email/render" "0.0.6"
+    "@react-email/row" "0.0.4"
+    "@react-email/section" "0.0.8"
+    "@react-email/text" "0.0.4"
+    react "18.2.0"
+
 "@react-email/html@0.0.4":
   version "0.0.4"
   resolved "https://registry.npmjs.org/@react-email/html/-/html-0.0.4.tgz"
@@ -1264,6 +1293,29 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@testing-library/dom@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.0.0.tgz#cc50e8df2a7dccff95555102beebbae60e95e95e"
+  integrity sha512-+/TLgKNFsYUshOY/zXsQOk+PlFQK+eyJ9T13IDVNJEi+M+Un7xlJK+FZKkbGSnf0+7E1G6PlDhkSYQ/GFiruBQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.0.0.tgz#59030392a6792450b9ab8e67aea5f3cc18d6347c"
+  integrity sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^9.0.0"
+    "@types/react-dom" "^18.0.0"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
   resolved "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz"
@@ -1290,6 +1342,11 @@
   integrity sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==
   dependencies:
     "@types/estree" "*"
+
+"@types/aria-query@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.1.tgz#3286741fb8f1e1580ac28784add4c7a1d49bdfbc"
+  integrity sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==
 
 "@types/babel__core@^7.1.14":
   version "7.1.20"
@@ -1475,6 +1532,13 @@
   version "18.0.6"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz"
   integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-dom@^18.0.0":
+  version "18.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.11.tgz#321351c1459bc9ca3d216aefc8a167beec334e33"
+  integrity sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==
   dependencies:
     "@types/react" "*"
 
@@ -1759,6 +1823,13 @@ aria-query@^4.2.2:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
 
+aria-query@^5.0.0:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
+  integrity sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==
+  dependencies:
+    deep-equal "^2.0.5"
+
 array-includes@^3.1.4, array-includes@^3.1.5, array-includes@^3.1.6:
   version "3.1.6"
   resolved "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz"
@@ -1820,6 +1891,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 axe-core@^4.4.3:
   version "4.5.2"
@@ -2562,6 +2638,29 @@ dedent@^0.7.0:
   resolved "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz"
   integrity sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==
 
+deep-equal@^2.0.5:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.0.tgz#5caeace9c781028b9ff459f33b779346637c43e6"
+  integrity sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==
+  dependencies:
+    call-bind "^1.0.2"
+    es-get-iterator "^1.1.2"
+    get-intrinsic "^1.1.3"
+    is-arguments "^1.1.1"
+    is-array-buffer "^3.0.1"
+    is-date-object "^1.0.5"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    isarray "^2.0.5"
+    object-is "^1.1.5"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.4.3"
+    side-channel "^1.0.4"
+    which-boxed-primitive "^1.0.2"
+    which-collection "^1.0.1"
+    which-typed-array "^1.1.9"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz"
@@ -2699,6 +2798,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
+
 dom-serializer@0:
   version "0.2.2"
   resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz"
@@ -2734,19 +2838,19 @@ domelementtype@^2.0.1, domelementtype@^2.3.0:
   resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
+domhandler@5.0.3, domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
 domhandler@^2.3.0:
   version "2.4.2"
   resolved "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz"
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
     domelementtype "1"
-
-domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz"
-  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
-  dependencies:
-    domelementtype "^2.3.0"
 
 domutils@1.5.1:
   version "1.5.1"
@@ -2880,6 +2984,21 @@ es-abstract@^1.19.0, es-abstract@^1.20.4:
     string.prototype.trimend "^1.0.5"
     string.prototype.trimstart "^1.0.5"
     unbox-primitive "^1.0.2"
+
+es-get-iterator@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
+  integrity sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    has-symbols "^1.0.3"
+    is-arguments "^1.1.1"
+    is-map "^2.0.2"
+    is-set "^2.0.2"
+    is-string "^1.0.7"
+    isarray "^2.0.5"
+    stop-iteration-iterator "^1.0.0"
 
 es-shim-unscopables@^1.0.0:
   version "1.0.0"
@@ -3643,6 +3762,13 @@ follow-redirects@^1.15.0:
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz"
@@ -3748,6 +3874,15 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@
   version "1.1.3"
   resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz"
   integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.3"
+
+get-intrinsic@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.0.tgz#7ad1dc0535f3a2904bba075772763e5051f6d05f"
+  integrity sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
@@ -3875,6 +4010,13 @@ globby@^11.0.0, globby@^11.0.3, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
+
 graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz"
@@ -3951,10 +4093,28 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
+html-dom-parser@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/html-dom-parser/-/html-dom-parser-3.1.3.tgz#ba87ca379f2817ca733523cac55c90de6bac43dd"
+  integrity sha512-fI0yyNlIeSboxU+jnrA4v8qj4+M8SI9/q6AKYdwCY2qki22UtKCDTxvagHniECu7sa5/o2zFRdLleA67035lsA==
+  dependencies:
+    domhandler "5.0.3"
+    htmlparser2 "8.0.1"
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+html-react-parser@3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-3.0.9.tgz#f9428f3b1689e4b0d538f944ef18f53ea66345d1"
+  integrity sha512-gOPZmaCMXNYu7Y9+58k2tLhTMXQ+QN8ctNFijzLuBxJaLZ6TsN+tUpN+MhbI+6nGaBCRGT2rpw6y/AqkTFZckg==
+  dependencies:
+    domhandler "5.0.3"
+    html-dom-parser "3.1.3"
+    react-property "2.0.0"
+    style-to-js "1.1.3"
 
 html-to-text@9.0.3:
   version "9.0.3"
@@ -3967,6 +4127,16 @@ html-to-text@9.0.3:
     htmlparser2 "^8.0.1"
     selderee "^0.10.0"
 
+htmlparser2@8.0.1, htmlparser2@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.1.tgz#abaa985474fcefe269bc761a779b544d7196d010"
+  integrity sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    entities "^4.3.0"
+
 htmlparser2@^3.9.1:
   version "3.10.1"
   resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz"
@@ -3978,16 +4148,6 @@ htmlparser2@^3.9.1:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
-
-htmlparser2@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz"
-  integrity sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==
-  dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.2"
-    domutils "^3.0.1"
-    entities "^4.3.0"
 
 https-proxy-agent@5.0.1:
   version "5.0.1"
@@ -4068,6 +4228,11 @@ ini@^1.3.4, ini@~1.3.0:
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
+inline-style-parser@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
+  integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
+
 inquirer@^9.1.0:
   version "9.1.4"
   resolved "https://registry.npmjs.org/inquirer/-/inquirer-9.1.4.tgz"
@@ -4098,6 +4263,15 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+internal-slot@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.5.tgz#f2a2ee21f668f8627a4667f309dc0f4fb6674986"
+  integrity sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==
+  dependencies:
+    get-intrinsic "^1.2.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
 interpret@^1.0.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz"
@@ -4120,6 +4294,23 @@ is-alphanumerical@^2.0.0:
   dependencies:
     is-alphabetical "^2.0.0"
     is-decimal "^2.0.0"
+
+is-arguments@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
+is-array-buffer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.1.tgz#deb1db4fcae48308d54ef2442706c0393997052a"
+  integrity sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    is-typed-array "^1.1.10"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -4163,7 +4354,7 @@ is-buffer@^2.0.0:
   resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
-is-callable@^1.1.4, is-callable@^1.2.7:
+is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
@@ -4182,7 +4373,7 @@ is-core-module@^2.8.1, is-core-module@^2.9.0:
   dependencies:
     has "^1.0.3"
 
-is-date-object@^1.0.1:
+is-date-object@^1.0.1, is-date-object@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz"
   integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
@@ -4248,6 +4439,11 @@ is-internet-available@^3.1.0:
   dependencies:
     lodash "^4.17.19"
 
+is-map@^2.0.1, is-map@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
+  integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
+
 is-negative-zero@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz"
@@ -4293,6 +4489,11 @@ is-regex@^1.1.4:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-set@^2.0.1, is-set@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
+  integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
+
 is-shared-array-buffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz"
@@ -4326,6 +4527,17 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.2"
 
+is-typed-array@^1.1.10:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
+  integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+
 is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz"
@@ -4336,12 +4548,25 @@ is-unicode-supported@^1.1.0, is-unicode-supported@^1.2.0:
   resolved "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz"
   integrity sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==
 
+is-weakmap@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.1.tgz#5008b59bdc43b698201d18f62b37b2ca243e8cf2"
+  integrity sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==
+
 is-weakref@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz"
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
   dependencies:
     call-bind "^1.0.2"
+
+is-weakset@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakset/-/is-weakset-2.0.2.tgz#4569d67a747a1ce5a994dfd4ef6dcea76e7c0a1d"
+  integrity sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 is-whitespace@^0.3.0:
   version "0.3.0"
@@ -4359,6 +4584,11 @@ is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -5089,6 +5319,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -5971,6 +6206,14 @@ object-inspect@^1.12.2, object-inspect@^1.9.0:
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz"
   integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
+object-is@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
+  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz"
@@ -6271,9 +6514,9 @@ postcss-import@^14.1.0:
     resolve "^1.1.7"
 
 postcss-js@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz"
-  integrity sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-js/-/postcss-js-4.0.1.tgz#61598186f3703bab052f1c4f7d805f3991bee9d2"
+  integrity sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==
   dependencies:
     camelcase-css "^2.0.1"
 
@@ -6292,7 +6535,7 @@ postcss-nested@6.0.0:
   dependencies:
     postcss-selector-parser "^6.0.10"
 
-postcss-selector-parser@^6.0.10:
+postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.11:
   version "6.0.11"
   resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz"
   integrity sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==
@@ -6305,7 +6548,7 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.21, postcss@^8.4.18:
+postcss@8.4.21, postcss@^8.0.9:
   version "8.4.21"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz"
   integrity sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==
@@ -6361,6 +6604,15 @@ pretty-bytes@^5.6.0:
   version "5.6.0"
   resolved "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
+
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
 
 pretty-format@^28.0.0, pretty-format@^28.1.3:
   version "28.1.3"
@@ -6496,15 +6748,44 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-email@1.7.13:
+  version "1.7.13"
+  resolved "https://registry.yarnpkg.com/react-email/-/react-email-1.7.13.tgz#2812fb49173e326bcb64bb0900e21fe1ebde8ade"
+  integrity sha512-jvne1O6hkHEqeh10gtHWFCNFSSF0mzioM2FJjXoUxkDOuO/KY24pX+b3S8eVGOGih44zWFUdrFEA4L4gM5ZDPA==
+  dependencies:
+    "@commander-js/extra-typings" "9.4.1"
+    "@react-email/render" "0.0.6"
+    chokidar "3.5.3"
+    commander "9.4.1"
+    detect-package-manager "2.0.1"
+    esbuild "0.16.4"
+    glob "8.0.3"
+    log-symbols "4.1.0"
+    normalize-path "3.0.0"
+    ora "5.4.1"
+    read-pkg "5.2.0"
+    shelljs "0.8.5"
+    tree-node-cli "1.6.0"
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
 react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-property@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.0.tgz#2156ba9d85fa4741faf1918b38efc1eae3c6a136"
+  integrity sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==
 
 react@18.2.0:
   version "18.2.0"
@@ -7049,6 +7330,13 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stop-iteration-iterator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz#6a60be0b4ee757d1ed5254858ec66b10c49285e4"
+  integrity sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==
+  dependencies:
+    internal-slot "^1.0.4"
+
 stream-transform@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.3.tgz"
@@ -7187,6 +7475,20 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
+style-to-js@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/style-to-js/-/style-to-js-1.1.3.tgz#2012d75dc89bf400edc29c545ed61c8626b00184"
+  integrity sha512-zKI5gN/zb7LS/Vm0eUwjmjrXWw8IMtyA8aPBJZdYiQTXj4+wQ3IucOLIOnF7zCHxvW8UhIGh/uZh/t9zEHXNTQ==
+  dependencies:
+    style-to-object "0.4.1"
+
+style-to-object@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.4.1.tgz#53cf856f7cf7f172d72939d9679556469ba5de37"
+  integrity sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==
+  dependencies:
+    inline-style-parser "0.1.1"
+
 sucrase@^3.20.3:
   version "3.29.0"
   resolved "https://registry.npmjs.org/sucrase/-/sucrase-3.29.0.tgz"
@@ -7233,10 +7535,10 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-tailwindcss@3.2.4:
-  version "3.2.4"
-  resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.4.tgz"
-  integrity sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==
+tailwindcss@3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.2.7.tgz#5936dd08c250b05180f0944500c01dce19188c07"
+  integrity sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==
   dependencies:
     arg "^5.0.2"
     chokidar "^3.5.3"
@@ -7252,12 +7554,12 @@ tailwindcss@3.2.4:
     normalize-path "^3.0.0"
     object-hash "^3.0.0"
     picocolors "^1.0.0"
-    postcss "^8.4.18"
+    postcss "^8.0.9"
     postcss-import "^14.1.0"
     postcss-js "^4.0.0"
     postcss-load-config "^3.1.4"
     postcss-nested "6.0.0"
-    postcss-selector-parser "^6.0.10"
+    postcss-selector-parser "^6.0.11"
     postcss-value-parser "^4.2.0"
     quick-lru "^5.1.1"
     resolve "^1.22.1"
@@ -7561,14 +7863,14 @@ turbo@1.6.3:
     turbo-windows-64 "1.6.3"
     turbo-windows-arm64 "1.6.3"
 
-tw-to-css@0.0.9:
-  version "0.0.9"
-  resolved "https://registry.npmjs.org/tw-to-css/-/tw-to-css-0.0.9.tgz"
-  integrity sha512-2mKCdfJst3gtMDssDw9kMhEXXRZ+bGbhtg7jPRYMpiM1RTs4xZcsE9ryuyaBhGFJdooTlSkCi2n5f6GnGzXrYA==
+tw-to-css@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/tw-to-css/-/tw-to-css-0.0.10.tgz#e14afd698d998a1a61ecc307ed2ca5ca1c313f58"
+  integrity sha512-Uxq/wers7ZAbl5xnISDcFSpfol6DtNxTw6ZUgM1GExgaMUH84RHDB8MMtF4UcFnXc+MByShhC0gAjWhZ6aVWjg==
   dependencies:
     postcss "8.4.21"
     postcss-css-variables "0.18.0"
-    tailwindcss "3.2.4"
+    tailwindcss "3.2.7"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -7863,6 +8165,16 @@ which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
+which-collection@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.1.tgz#70eab71ebbbd2aefaf32f917082fc62cdcb70906"
+  integrity sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==
+  dependencies:
+    is-map "^2.0.1"
+    is-set "^2.0.1"
+    is-weakmap "^2.0.1"
+    is-weakset "^2.0.1"
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
@@ -7875,6 +8187,18 @@ which-pm@2.0.0:
   dependencies:
     load-yaml-file "^0.2.0"
     path-exists "^4.0.0"
+
+which-typed-array@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.9.tgz#307cf898025848cf995e795e8423c7f337efbde6"
+  integrity sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+    is-typed-array "^1.1.10"
 
 which@^1.2.9:
   version "1.3.1"


### PR DESCRIPTION
This PR brings some upgrades to the Tailwind component:

### 🌈 Support for responsive styles:
Using responsive styles is not something that can be done inline, so when adding responsive styles, the component will automatically place its code in the `style` tag inside the `head` tag of your email, which is why `html` and `head` tags are required in your code. For example:
```tsx
<Tailwind>
  <Html> // <-- Required
    <Head /> // <-- Required
    <Section>
      <div className="bg-red-200 sm:bg-red-300 md:bg-red-400 lg:bg-red-500" />
    </Section>
  </Html>
</Tailwind>
```
Some changes were also necessary to make this happen, such as escaping the class names because some email clients do not support them.

> **Before:** `md:bg-red-400 `
> **After:** `md_bg_red_400`

### 🎁 Support for custom nested components:
In the past, we used `React.Children` to nest components. But it didn't play nice with children that had more than one node element or no `children` defined. Not cool. Now, this component reads all the content, renders it, and applies the right styles.

### 🧪 Bonus: Unit tests
Additionally, unit tests were implemented to ensure that most of the features are working correctly.
![CleanShot 2023-02-23 at 11 35 24](https://user-images.githubusercontent.com/3522573/221078062-cf73d969-0497-409a-946d-11710c44aefc.png)

### 🚨 Important
Although we're using Tailwind, not all CSS properties work across all email clients. So while it gives you the freedom to create, it's up to you to decide what you want to prioritize. If you need clarification on what's good or not for your email, check out https://www.caniemail.com/.

---

Should fix: #462, #448, #451 

