### PR TITLE
fix(tailwind): Tailwind should override default inline styles

### DIFF
--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -1,6 +1,7 @@
 import { Tailwind } from './tailwind';
 import { renderToStaticMarkup as render } from 'react-dom/server';
 import { TailwindConfig } from 'tw-to-css';
+import { Button } from '@react-email/button';
 
 describe('Tailwind component', () => {
   beforeEach(() => {
@@ -30,6 +31,33 @@ describe('Tailwind component', () => {
 
       expect(actualOutput).toMatchInlineSnapshot(
         `"<div style=\\"background-image:url(https://react.email/static/covers/tailwind.png)\\"></div>"`,
+      );
+    });
+
+    it('should override inline styles with Tailwind styles', () => {
+      const actualOutput = render(
+        <Tailwind>
+          <div
+            style={{ fontSize: '12px', backgroundColor: 'red' }}
+            className="bg-black text-[16px]"
+          />
+        </Tailwind>,
+      );
+
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<div style=\\"font-size:16px;background-color:rgb(0,0,0)\\"></div>"`,
+      );
+    });
+
+    it('should override component styles with Tailwind styles', () => {
+      const actualOutput = render(
+        <Tailwind>
+          <Button className="py-3 px-6" />
+        </Tailwind>,
+      );
+
+      expect(actualOutput).toContain(
+        'padding:0px 0px;padding-left:1.5rem;padding-right:1.5rem;padding-top:0.75rem;padding-bottom:0.75rem',
       );
     });
   });

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -75,9 +75,11 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
                 '_',
               );
             } else {
-              domNode.attribs.style = `${twi(domNode.attribs.class)} ${
-                domNode.attribs.style || ''
-              }`;
+              const currentStyles = domNode.attribs.style
+                ? `${domNode.attribs.style};`
+                : '';
+              const tailwindStyles = twi(domNode.attribs.class);
+              domNode.attribs.style = `${currentStyles} ${tailwindStyles}`;
               delete domNode.attribs.class;
             }
           }


### PR DESCRIPTION
This PR should fix this issue (https://github.com/resendlabs/react-email/pull/502#issuecomment-1445639455) reported by @ysm-dev


> Looks there is some bug on this PR. Suddenly, My Button Component got weird style `padding: 0px 0px` after bump this package to `0.0.5` so my tailwind styles are ignored.
> 
> <img alt="image" width="599" src="https://user-images.githubusercontent.com/18487241/221466155-e3af116e-687e-45db-8d63-aa4be400d7ee.png">
> 
> <img alt="image" width="265" src="https://user-images.githubusercontent.com/18487241/221466176-2a3b783b-f572-4490-810e-38990668ce05.png">