### PR TITLE
fix(tailwind): Regex classes with `.`, `/`, and `%`

### DIFF
--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -267,4 +267,38 @@ describe('Tailwind component', () => {
       );
     });
   });
+  describe('Class name replacement', () => {
+    it('should replace forward slash with underscore in both class name and selector', () => {
+      const actualOutput = render(
+        <Tailwind>
+          <html>
+            <head />
+            <body>
+              <div className="w-full" />
+              <div className="w-1/2 sm:w-1/2" />
+            </body>
+          </html>
+        </Tailwind>,
+      );
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<html><head><style>.w_1_2{width:50%}.w_full{width:100%}@media(min-width:640px){.sm_w_1_2{width: 50% !important}}</style></head><body><div class=\\"w_full\\"></div><div class=\\"w_1_2 sm_w_1_2\\"></div></body></html>"`,
+      );
+    });
+    it('should replace period with underscore in both class name and selector', () => {
+      const actualOutput = render(
+        <Tailwind>
+          <html>
+            <head />
+            <body>
+              <div className="w-1.5" />
+              <div className="w-1.5 sm:w-1.5" />
+            </body>
+          </html>
+        </Tailwind>,
+      );
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<html><head><style>.w_1{width:0.25rem}.w_1_5{width:0.375rem}@media(min-width:640px){.sm_w_1{width: 0.25rem}.sm_w_1_5{width:0.375rem !important}}</style></head><body><div class=\\"w_1_5\\"></div><div class=\\"w_1_5 sm_w_1_5\\"></div></body></html>"`,
+      );
+    });
+  });
 });

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -300,5 +300,21 @@ describe('Tailwind component', () => {
         `"<html><head><style>.w_1{width:0.25rem}.w_1_5{width:0.375rem}@media(min-width:640px){.sm_w_1{width: 0.25rem}.sm_w_1_5{width:0.375rem !important}}</style></head><body><div class=\\"w_1_5\\"></div><div class=\\"w_1_5 sm_w_1_5\\"></div></body></html>"`,
       );
     });
+    it('should replace percent signs with underscore in both class name and selector', () => {
+      const actualOutput = render(
+        <Tailwind>
+          <html>
+            <head />
+            <body>
+              <div className="w-[50%]" />
+              <div className="w-[50%] sm:w-[50%]" />
+            </body>
+          </html>
+        </Tailwind>,
+      );
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<html><head><style>.w_50_{width:50%}@media(min-width:640px){.sm_w_50_{width: 50% !important}}</style></head><body><div class=\\"w_50_\\"></div><div class=\\"w_50_ sm_w_50_\\"></div></body></html>"`,
+      );
+    });
   });
 });

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -71,7 +71,7 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
           if (domNode.attribs?.class) {
             if (hasResponsiveStyles) {
               domNode.attribs.class = domNode.attribs.class.replace(
-                /[:#\!\-[\]\/\.]+/g,
+                /[:#\!\-[\]\/\.%]+/g,
                 '_',
               );
             } else {
@@ -114,8 +114,8 @@ function getMediaQueryCSS(css: string) {
         },
       );
     })
-    .replace(/[.\!\#\w\d\\:\-\[\]\/\.]+\s*?{/g, (m) => {
-      return m.replace(/(?<=.)[:#\!\-[\\\]\/\.]+/g, '_');
+    .replace(/[.\!\#\w\d\\:\-\[\]\/\.%]+\s*?{/g, (m) => {
+      return m.replace(/(?<=.)[:#\!\-[\\\]\/\.%]+/g, '_');
     })
     .replace(/font-family(?<value>[^;\r\n]+)/g, (m, value) => {
       return `font-family${value.replace(/['"]+/g, '')}`;

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -71,7 +71,7 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
           if (domNode.attribs?.class) {
             if (hasResponsiveStyles) {
               domNode.attribs.class = domNode.attribs.class.replace(
-                /[:#\!\-[\]]+/g,
+                /[:#\!\-[\]\/\.]+/g,
                 '_',
               );
             } else {
@@ -114,8 +114,8 @@ function getMediaQueryCSS(css: string) {
         },
       );
     })
-    .replace(/[.\!\#\w\d\\:\-\[\]]+\s*?{/g, (m) => {
-      return m.replace(/[:#\!\-[\\\]]+/g, '_');
+    .replace(/[.\!\#\w\d\\:\-\[\]\/\.]+\s*?{/g, (m) => {
+      return m.replace(/(?<=.)[:#\!\-[\\\]\/\.]+/g, '_');
     })
     .replace(/font-family(?<value>[^;\r\n]+)/g, (m, value) => {
       return `font-family${value.replace(/['"]+/g, '')}`;


### PR DESCRIPTION
Fix for #518

Tailwind classes with `/` (forward slash), `.` (period), and `%` (percent) were not getting transformed with the underscore correctly. 

I added regex for:
- replacing the dom attribute characters
- correctly matching on selectors
- replacing selector characters (i used a look ahead here in order to not grab the class's initial `.`)

So far its been a good journey using this lib! Let me know if this needs anything else. 
I also added tests for my use cases