### PR TITLE
feat(create-email): Add `package.json` workspaces

### DIFF
--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -2,6 +2,9 @@
   "name": "emails",
   "version": "0.0.0",
   "private": true,
+  "workspaces": [
+    ".react-email"
+  ],
   "scripts": {
     "dev": "email dev",
     "export": "email export"


### PR DESCRIPTION
Fix this issue

```
$ yarn --version
3.4.1

$ yarn create email
$ cd react-email-starter
$ yarn dev
✔ Emails preview generated
⠋ Installing dependencies...
Usage Error: The nearest package directory (/react-email-starter/.react-email) doesn't seem to be part of the project declared in /react-email-starter.

- If /react-email-starter isn't intended to be a project, remove any yarn.lock and/or package.json file there.
- If /react-email-starter is intended to be a project, it might be that you forgot to list .react-email in its workspace configuration.
- Finally, if /react-email-starter is fine and you intend .react-email to be treated as a completely separate project (not even a workspace), create an empty yarn.lock file in it.
```
