### PR TITLE
fix(react-email): Export default props

### DIFF
--- a/packages/react-email/source/commands/export.ts
+++ b/packages/react-email/source/commands/export.ts
@@ -36,7 +36,7 @@ export const exportTemplates = async (
 
   for (const template of allBuiltTemplates) {
     const component = await import(template);
-    const rendered = render(component.default(), options);
+    const rendered = render(component.default({}), options);
     const htmlPath = template.replace(
       '.js',
       options.plainText ? '.txt' : '.html',


### PR DESCRIPTION
Fix this

```
❮ yarn export                                                                                                    
⠋ Preparing files...
/react-email-starter/out/notion-magic-link.js:38320
  loginCode = "sparo-ndigo-amurt-secan"
  ^

TypeError: Cannot read properties of undefined (reading 'loginCode')
    at Object.NotionMagicLinkEmail (/react-email-starter/out/notion-magic-link.js:38320:3)
    at exportTemplates (/react-email-starter/node_modules/react-email/dist/source/commands/export.js:61:64)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v18.15.0
```

The mail is https://github.com/resendlabs/react-email/blob/d9628ecdf69723f4810c51a4da7cd06efd16e3d8/packages/create-email/template/emails/notion-magic-link.tsx#L23
