### PR TITLE
fix(react-email): Dev server commands

### DIFF
--- a/packages/react-email/source/utils/start-server-command.ts
+++ b/packages/react-email/source/utils/start-server-command.ts
@@ -1,11 +1,11 @@
 import shell from 'shelljs';
 
 export const startDevServer = (packageManager: string, port: string) => {
-  shell.exec(`${packageManager} run dev -p ${port}`, { async: true });
+  shell.exec(`${packageManager} run dev -- -p ${port}`, { async: true });
 };
 
 export const startProdServer = (packageManager: string, port: string) => {
-  shell.exec(`${packageManager} run start -p ${port}`, { async: true });
+  shell.exec(`${packageManager} run start -- -p ${port}`, { async: true });
 };
 
 export const buildProdServer = (packageManager: string) => {


### PR DESCRIPTION
For some reason this bug came back, it was previously fixed here #417.

Also, I noticed a canary release was published under the `latest` tag on npm, should watch out for that.