### PR TITLE
feat(react-email): Move `static` files outside of `emails` folder

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -54,6 +54,12 @@ description: "New features, bug fixes, and improvements made to each package."
 - Add `data-id` attribute
 - Reorder `props` to not be able to override `style`, `target`, and `ref`
 
+**React Email `1.9.0`**
+
+- Change how to handle `static` files (`static` files should live in the root, and not in the `emails` folder)
+- Throw error when missing `emails` folder
+- Removed unused script commands
+
 **Row `0.0.5`**
 
 - Add `data-id` attribute

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A live preview of your emails right in your browser.",
   "bin": {
     "email": "./dist/source/index.js"

--- a/packages/react-email/source/utils/generate-email-preview.ts
+++ b/packages/react-email/source/utils/generate-email-preview.ts
@@ -49,7 +49,7 @@ const createStaticFiles = async (emailDir: string) => {
 
   const result = shell.cp(
     '-r',
-    path.join(emailDir, 'static'),
+    path.join('static'),
     path.join(PACKAGE_PUBLIC_PATH),
   );
   if (result.code > 0) {


### PR DESCRIPTION
This PR changes how we handle `static` files. The `static` files should live outside of `emails` folder.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->
