### PR TITLE
feat(render): Add renderAsync function to enable edge runtime support

### DIFF
--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./render";
+export * from "./renderAsync";

--- a/packages/render/src/renderAsync.spec.tsx
+++ b/packages/render/src/renderAsync.spec.tsx
@@ -1,0 +1,119 @@
+import * as React from "react";
+import { renderAsync } from "./index";
+import { Template } from "./utils/template";
+import { Preview } from "./utils/preview";
+import ReactDOMServer from "react-dom/server";
+
+describe("renderAsync using renderToStaticMarkup", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it("converts a React component into HTML", async () => {
+    const actualOutput = await renderAsync(<Template firstName="Jim" />);
+
+    expect(actualOutput).toMatchInlineSnapshot(
+      `"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><h1>Welcome, Jim!</h1><img src=\\"img/test.png\\" alt=\\"test\\"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p>"`
+    );
+  });
+
+  it("converts a React component into PlainText", async () => {
+    const actualOutput = await renderAsync(<Template firstName="Jim" />, {
+      plainText: true,
+    });
+
+    expect(actualOutput).toMatchInlineSnapshot(`
+      "WELCOME, JIM!
+
+      Thanks for trying our product. We're thrilled to have you on board!"
+    `);
+  });
+
+  it("converts to plain text and removes reserved ID", async () => {
+    const actualOutput = await renderAsync(<Preview />, {
+      plainText: true,
+    });
+
+    expect(actualOutput).toMatchInlineSnapshot(
+      `"THIS SHOULD BE RENDERED IN PLAIN TEXT"`
+    );
+  });
+});
+
+describe("renderAsync using renderToReadableStream", () => {
+  const renderToStaticMarkup = ReactDOMServer.renderToStaticMarkup;
+  const renderToReadableStream = ReactDOMServer.renderToReadableStream;
+
+  const mockRenderToReadableStream = (
+    component: React.ReactNode
+  ): Promise<ReactDOMServer.ReactDOMServerReadableStream> => {
+    const encoder = new TextEncoder();
+    const markup = ReactDOMServer.renderToString(
+      component as React.ReactElement
+    );
+
+    let done = false;
+
+    return Promise.resolve({
+      allReady: Promise.resolve(),
+      [Symbol.asyncIterator]: () => ({
+        next: () => {
+          if (done) {
+            return Promise.resolve({ done: true, value: undefined });
+          }
+
+          done = true;
+
+          return Promise.resolve({
+            done: false,
+            value: encoder.encode(markup),
+          });
+        },
+      }),
+    });
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+
+    (ReactDOMServer.renderToStaticMarkup as unknown as undefined) = undefined;
+    ReactDOMServer.renderToReadableStream = mockRenderToReadableStream;
+  });
+
+  afterEach(() => {
+    ReactDOMServer.renderToStaticMarkup = renderToStaticMarkup;
+    ReactDOMServer.renderToReadableStream = renderToReadableStream;
+  });
+
+  it("converts a React component into HTML", async () => {
+    const actualOutput = await renderAsync(<Template firstName="Jim" />);
+
+    expect(actualOutput).toMatchInlineSnapshot(
+      `"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><h1>Welcome, Jim!</h1><img src=\\"img/test.png\\" alt=\\"test\\"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p>"`
+    );
+  });
+
+  it("converts a React component into PlainText", async () => {
+    const actualOutput = await renderAsync(<Template firstName="Jim" />, {
+      plainText: true,
+    });
+
+    expect(actualOutput).toMatchInlineSnapshot(`
+      "WELCOME, JIM!
+
+      Thanks for trying our product. We're thrilled to have you on board!"
+    `);
+  });
+
+  it("converts to plain text and removes reserved ID", async () => {
+    const actualOutput = await renderAsync(<Preview />, {
+      plainText: true,
+    });
+
+    expect(actualOutput).toMatchInlineSnapshot(
+      `"THIS SHOULD BE RENDERED IN PLAIN TEXT"`
+    );
+  });
+});

--- a/packages/render/src/renderAsync.ts
+++ b/packages/render/src/renderAsync.ts
@@ -10,7 +10,7 @@ export default async function renderToString(children: ReactNode) {
   const html = await readableStreamToString(
     // ReactDOMServerReadableStream behaves like ReadableStream
     // in modern edge runtimes but the types are not compatible
-    stream as unknown as ReadableStream
+    stream as unknown as ReadableStream<Uint8Array>
   );
 
   return (
@@ -22,14 +22,18 @@ export default async function renderToString(children: ReactNode) {
   );
 }
 
-async function readableStreamToString(readableStream: ReadableStream) {
-  const chunks: Uint8Array[] = [];
+async function readableStreamToString(
+  readableStream: ReadableStream<Uint8Array>
+) {
+  let result = "";
+
+  const decoder = new TextDecoder();
 
   for await (const chunk of readableStream) {
-    chunks.push(chunk);
+    result += decoder.decode(chunk);
   }
 
-  return Buffer.concat(chunks).toString("utf-8");
+  return result;
 }
 
 export const renderAsync = async (

--- a/packages/render/src/renderAsync.ts
+++ b/packages/render/src/renderAsync.ts
@@ -1,0 +1,66 @@
+import { convert } from "html-to-text";
+import pretty from "pretty";
+import { type ReactNode } from "react";
+import { renderToReadableStream, renderToStaticMarkup } from "react-dom/server";
+import { type ReadableStream } from "node:stream/web";
+
+export default async function renderToString(children: ReactNode) {
+  const stream = await renderToReadableStream(children);
+
+  const html = await readableStreamToString(
+    // ReactDOMServerReadableStream behaves like ReadableStream
+    // in modern edge runtimes but the types are not compatible
+    stream as unknown as ReadableStream
+  );
+
+  return (
+    html
+      // Remove leading doctype becuase we add it manually
+      .replace(/^<!DOCTYPE html>/, "")
+      // Remove empty comments to match the output of renderToStaticMarkup
+      .replace(/<!-- -->/g, "")
+  );
+}
+
+async function readableStreamToString(readableStream: ReadableStream) {
+  const chunks: Uint8Array[] = [];
+
+  for await (const chunk of readableStream) {
+    chunks.push(chunk);
+  }
+
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export const renderAsync = async (
+  component: React.ReactElement,
+  options?: {
+    pretty?: boolean;
+    plainText?: boolean;
+  }
+) => {
+  const markup =
+    typeof renderToStaticMarkup === "undefined"
+      ? await renderToString(component)
+      : renderToStaticMarkup(component);
+
+  if (options?.plainText) {
+    return convert(markup, {
+      selectors: [
+        { selector: "img", format: "skip" },
+        { selector: "#__react-email-preview", format: "skip" },
+      ],
+    });
+  }
+
+  const doctype =
+    '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">';
+
+  const document = `${doctype}${markup}`;
+
+  if (options?.pretty) {
+    return pretty(document);
+  }
+
+  return document;
+};


### PR DESCRIPTION
closes https://github.com/resendlabs/react-email/issues/493

> My implementation checks if `renderToStaticMarkup` is defined. If not `renderToReadableStream` is used and the stream is converted to a string.
> 
> It would be nice to have something like this directly integrated in react-email, but it requires the introduction of an async function like `renderAsync` to work, so we are not introducing a breaking change for the `render` function. I could create a pull request with my changes and add it to the docs if you are ok with creating a `renderAsync` function.