### PR TITLE
Fix: fix(react-email): cant quit dev server with SIGINT

### DIFF
--- a/packages/react-email/source/commands/export.ts
+++ b/packages/react-email/source/commands/export.ts
@@ -9,6 +9,7 @@ import normalize from 'normalize-path';
 import path from 'path';
 import shell from 'shelljs';
 import fs from 'fs';
+import { closeOraOnSIGNIT } from '../utils/close-ora-on-sigint';
 /*
   This first builds all the templates using esbuild and then puts the output in the `.js`
   files. Then these `.js` files are imported dynamically and rendered to `.html` files
@@ -20,6 +21,8 @@ export const exportTemplates = async (
   options: Options,
 ) => {
   const spinner = ora('Preparing files...\n').start();
+  closeOraOnSIGNIT(spinner)
+
   const allTemplates = glob.sync(normalize(path.join(srcDir, '*.{tsx,jsx}')));
 
   esbuild.buildSync({

--- a/packages/react-email/source/utils/close-ora-on-sigint.ts
+++ b/packages/react-email/source/utils/close-ora-on-sigint.ts
@@ -1,0 +1,7 @@
+import { Ora } from 'ora'
+
+export const closeOraOnSIGNIT = (spinner: Ora) => {
+  process.on('SIGINT', function () {
+    spinner.stop()
+  });
+}

--- a/packages/react-email/source/utils/generate-email-preview.ts
+++ b/packages/react-email/source/utils/generate-email-preview.ts
@@ -6,9 +6,12 @@ import shell from 'shelljs';
 import path from 'path';
 import fse from 'fs-extra';
 
+import { closeOraOnSIGNIT } from './close-ora-on-sigint';
+
 export const generateEmailsPreview = async (emailDir: string) => {
   try {
     const spinner = ora('Generating emails preview').start();
+    closeOraOnSIGNIT(spinner)
 
     await createEmailPreviews(emailDir);
     await createStaticFiles(emailDir);

--- a/packages/react-email/source/utils/install-dependencies.ts
+++ b/packages/react-email/source/utils/install-dependencies.ts
@@ -3,11 +3,13 @@ import path from 'path';
 import { REACT_EMAIL_ROOT } from './constants';
 import ora from 'ora';
 import logSymbols from 'log-symbols';
+import { closeOraOnSIGNIT } from './close-ora-on-sigint';
 
 export type PackageManager = 'yarn' | 'npm' | 'pnpm';
 
 export const installDependencies = async (packageManager: PackageManager) => {
   const spinner = ora('Installing dependencies...\n').start();
+  closeOraOnSIGNIT(spinner)
 
   shell.cd(path.join(REACT_EMAIL_ROOT));
   shell.exec(`${packageManager} install`);


### PR DESCRIPTION
This should fix issue #636

The problem described in issue #636 refers to the spinner created at `generateEmailsPreview`.
The other spinners affected in this PR should not be often seen resulting in this issue once they have an end and close the process. However, looks like the same issue on `installDependencies` and `exportTemplates` so I also fixed them.