### PR TITLE
fix(tailwind): Persist existing head elements when responsive styles are present

### DIFF
--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -93,6 +93,26 @@ describe("Tailwind component", () => {
         );
       }
     });
+  
+    it("should persist exsisting head when responsive styles are present", () => {
+      const actualOutput = render(
+        <Tailwind>
+          <html>
+            <head>
+              <style />
+              <link />
+            </head>
+            <body>
+              <div className="bg-red-200 sm:bg-red-500" />
+            </body>
+          </html>
+        </Tailwind>
+      );
+
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<html><head><style></style><link/><style>.bg_red_200{background-color:rgb(254,202,202)}@media(min-width:640px){.sm_bg_red_500{background-color: rgb(239,68,68) !important}}</style></head><body><div class="bg_red_200 sm_bg_red_500"></div></body></html>"`
+      );
+    });
   });
 
   describe("Custom theme config", () => {

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -94,7 +94,7 @@ describe("Tailwind component", () => {
       }
     });
   
-    it("should persist exsisting head when responsive styles are present", () => {
+    it("should persist exsisting <head/> elements", () => {
       const actualOutput = render(
         <Tailwind>
           <html>

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import htmlParser, { attributesToProps, Element } from "html-react-parser";
+import htmlParser, { attributesToProps, domToReact, Element } from "html-react-parser";
 import { tailwindToCSS, TailwindConfig } from "tw-to-css";
 
 export interface TailwindProps {
@@ -48,19 +48,12 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
             let newDomNode: JSX.Element | null = null;
 
             if (domNode.children) {
-              const style = domNode.children.find(
-                (child) => child instanceof Element && child.name === "style"
-              );
-
               const props = attributesToProps(domNode.attribs);
 
               newDomNode = (
                 <head {...props}>
-                  {style && style instanceof Element ? (
-                    <style>{`${style.children} ${headStyle}`}</style>
-                  ) : (
-                    <style>{headStyle}</style>
-                  )}
+                  {domToReact(domNode.children)}
+                  <style>{headStyle}</style>
                 </head>
               );
             }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

Current elements in the `<head/>` are not being being handled properly when responsive styles are present using the tailwind component.

For example, you cannot use the `<Font/>` component right now if you are using tailwind with responsive styles. 

This merge request just passes all existing elements in the `<head/>` through, and adds the `<style/>` tag for the new classes being added.

The end result is all elements you have in the `<head/>`, plus an additional `<style/>` tag with the tailwind styles. 
