### PR TITLE
chore(docs): Update install command

### DIFF
--- a/docs/getting-started/automatic-setup.mdx
+++ b/docs/getting-started/automatic-setup.mdx
@@ -43,7 +43,7 @@ yarn
 ```
 
 ```sh pnpm
-pnpm
+pnpm install
 ```
 
 </CodeGroup>


### PR DESCRIPTION
The current doc says `pnpm` which would not install dependencies
pnpm install command should be `pnpm install` or `pnpm i`

