### PR TITLE
fix(button): Provide default value for button padding

### DIFF
--- a/packages/button/src/button.spec.tsx
+++ b/packages/button/src/button.spec.tsx
@@ -15,4 +15,11 @@ describe("render", () => {
       `"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><a href=\\"https://example.com\\" data-id=\\"react-email-button\\" target=\\"_blank\\" style=\\"line-height:100%;text-decoration:none;display:inline-block;max-width:100%;padding:12px 20px\\"><span><!--[if mso]><i style=\\"letter-spacing: 20px;mso-font-width:-100%;mso-text-raise:18\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:9px\\"></span><span><!--[if mso]><i style=\\"letter-spacing: 20px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>"`
     );
   });
+
+  it("renders the <Button> component with no padding value", () => {
+    const actualOutput = render(<Button href="https://example.com" />);
+    expect(actualOutput).toMatchInlineSnapshot(
+      `"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><a href=\\"https://example.com\\" data-id=\\"react-email-button\\" target=\\"_blank\\" style=\\"line-height:100%;text-decoration:none;display:inline-block;max-width:100%;padding:0px 0px\\"><span><!--[if mso]><i style=\\"letter-spacing: 0px;mso-font-width:-100%;mso-text-raise:0\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:0\\"></span><span><!--[if mso]><i style=\\"letter-spacing: 0px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>"`
+    );
+  });
 });

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -10,7 +10,7 @@ export interface ButtonProps extends RootProps {
 }
 
 export const Button = React.forwardRef<ButtonElement, Readonly<ButtonProps>>(
-  ({ children, style, pX, pY, target = "_blank", ...props }, forwardedRef) => {
+  ({ children, style, pX = 0, pY = 0, target = "_blank", ...props }, forwardedRef) => {
     const y = (pY || 0) * 2;
     const textRaise = pxToPt(y.toString());
 
@@ -41,7 +41,7 @@ export const Button = React.forwardRef<ButtonElement, Readonly<ButtonProps>>(
 Button.displayName = "Button";
 
 const buttonStyle = (
-  style?: React.CSSProperties & { pY?: number; pX?: number }
+  style?: React.CSSProperties & { pY: number; pX: number }
 ) => {
   const { pY, pX, ...rest } = style || {};
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

Per Typescript definition, padding is optional to the button component, especially if people using Tailwind CSS, props won't be provided. in this case we will be outputting `undefined` inline CSS.

Adding default value for pX, pY in the PR, we could also consider ignoring rendering those value if the props is undefined.