### PR TITLE
fix(font): Styles should not include HTML entities

### DIFF
--- a/packages/font/src/font.spec.tsx
+++ b/packages/font/src/font.spec.tsx
@@ -14,15 +14,15 @@ describe("render", () => {
     expect(actualOutput).toMatchInlineSnapshot(`
       "<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><style>
           @font-face {
-            font-family: &#x27;Roboto&#x27;;
+            font-family: 'Roboto';
             font-style: normal;
             font-weight: 400;
-            mso-font-alt: &#x27;Verdana&#x27;;
+            mso-font-alt: 'Verdana';
             
           }
 
           * {
-            font-family: &#x27;Roboto&#x27;, Verdana;
+            font-family: 'Roboto', Verdana;
           }
         </style>"
     `);

--- a/packages/font/src/font.tsx
+++ b/packages/font/src/font.tsx
@@ -67,7 +67,7 @@ export const Font: React.FC<Readonly<FontProps>> = ({
   };
     }
   `;
-  return <style>{style}</style>;
+  return <style dangerouslySetInnerHTML={{__html: style}} />;
 };
 
 Font.displayName = "Font";


### PR DESCRIPTION
Maybe I'm crazy or missing something significant, but the `Font` component generates markup that is full of HTML entities and doesn't seem to work with those entities. I suspect something similar is probably going on for https://github.com/resendlabs/react-email/issues/442.

What am I missing? ~~I can't find any indication that style blocks are supposed to use HTML entities, but it's a big internet out there.~~ HTML 4 spec is pretty explicit that [`style` elements should not contain character references](https://www.w3.org/TR/1998/REC-html40-19980424/types.html#:~:text=style%20sheet%20data%20that%20is%20element%20content%20may%20not%20contain%20character%20references).

I'm happy to pursue a solution that uses something other than `dangerouslySetInnerHTML`, but I'm not sure what that would look like. 

Here's a semi-related comment that seems to argue that `dangerouslySetInnerHtml` is the right choice in this scenario: https://github.com/facebook/react/issues/13838#issuecomment-470296607

Any thoughts or guidance is welcome.