### PR TITLE
fix(client): Console warnings

### DIFF
--- a/client/src/components/code-container.tsx
+++ b/client/src/components/code-container.tsx
@@ -106,13 +106,13 @@ export const CodeContainer: React.FC<Readonly<CodeContainerProps>> = ({
           </LayoutGroup>
         </div>
         <Tooltip>
-          <Tooltip.Trigger className="absolute top-2 right-2 hidden md:block">
+          <Tooltip.Trigger asChild className="absolute top-2 right-2 hidden md:block">
             {renderClipboardIcon()}
           </Tooltip.Trigger>
           <Tooltip.Content>Copy to Clipboard</Tooltip.Content>
         </Tooltip>
         <Tooltip>
-          <Tooltip.Trigger className="text-gray-11 absolute top-2 right-8 hidden md:block">
+          <Tooltip.Trigger asChild className="text-gray-11 absolute top-2 right-8 hidden md:block">
             {renderDownloadIcon()}
           </Tooltip.Trigger>
           <Tooltip.Content>Download</Tooltip.Content>

--- a/client/src/components/code.tsx
+++ b/client/src/components/code.tsx
@@ -70,16 +70,18 @@ export const Code: React.FC<Readonly<CodeProps>> = ({
           />
           <div className="p-4 h-[650px] overflow-auto">
             {tokens.map((line, i) => {
+              const { key: lineKey, ...lineProps } = getLineProps({ line, key: i });
               return (
                 <div
                   key={i}
-                  {...getLineProps({ line, key: i })}
+                  {...lineProps}
                   className={classnames('whitespace-pre', {
                     "before:text-slate-11 before:mr-2 before:content-['$']":
                       language === 'bash' && tokens && tokens.length === 1,
                   })}
                 >
                   {line.map((token, key) => {
+                    const { key: tokenKey, ...tokenProps} = getTokenProps({ token, key });
                     const isException =
                       token.content === 'from' &&
                       line[key + 1]?.content === ':';
@@ -90,7 +92,7 @@ export const Code: React.FC<Readonly<CodeProps>> = ({
 
                     return (
                       <React.Fragment key={key}>
-                        <span {...getTokenProps({ token, key })} />
+                        <span {...tokenProps} />
                       </React.Fragment>
                     );
                   })}


### PR DESCRIPTION
When starting the dev server and accessing the `Source` view of an email, several warnings appear in the console.

![Capture d’écran 2023-06-20 à 02 01 08](https://github.com/resendlabs/react-email/assets/11467072/aea4d44b-eef5-4f0d-bf25-1619b55b38ed)

This PR involves 2 components and fixes the following warnings:
- **code-container** - `Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>.`
- **code** - `A props object containing a “key” prop is being spread into JSX [...] React keys must be passed directly to JSX without using spread`