### PR TITLE
fix(heading, markdown): Export types

### DIFF
--- a/packages/heading/src/heading.tsx
+++ b/packages/heading/src/heading.tsx
@@ -4,8 +4,8 @@ import { As, Margin, withMargin } from "./utils";
 
 interface HeadingOwnProps {}
 
-type HeadingAs = As<"h1", "h2", "h3", "h4", "h5", "h6">;
-type HeadingProps = HeadingAs & HeadingOwnProps & Margin;
+export type HeadingAs = As<"h1", "h2", "h3", "h4", "h5", "h6">;
+export type HeadingProps = HeadingAs & HeadingOwnProps & Margin;
 
 export const Heading = React.forwardRef<
   HTMLHeadingElement,

--- a/packages/markdown/src/markdown.tsx
+++ b/packages/markdown/src/markdown.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 
 type MarkdownElement = React.ElementRef<"div">;
 
-interface MarkdownProps {
+export interface MarkdownProps {
   children: string;
   markdownCustomStyles?: StylesType;
   markdownContainerStyles?: React.CSSProperties;


### PR DESCRIPTION
Hey, added missing export of props two packages: @react-email/heading and @react-email/markdown. 

I created one PR without conventional commit scope for this one, but if thats a problem then hmu about it and I will change it