### PR TITLE
fix(create-email): spelling mistake for `dir` arg description

### DIFF
--- a/packages/create-email/src/index.js
+++ b/packages/create-email/src/index.js
@@ -45,6 +45,6 @@ const program = new Command()
   .name("create-email")
   .version("0.0.16")
   .description("The easiest way to get started with React Email")
-  .arguments("[dir]", "path to initiliaze the project")
+  .arguments("[dir]", "path to initialize the project")
   .action(init)
   .parse(process.argv);


### PR DESCRIPTION
This PR fixes a spelling mistake in the description of the `dir` argument in `create-email`.