### PR TITLE
fix(client): allow .tsx extension file can be imported from auto-generated emails folder

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -23,7 +23,8 @@
         "name": "next"
       }
     ],
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "allowImportingTsExtensions": true
   },
   "include": [
     "preview/next-env.d.ts",

--- a/packages/react-email/source/utils/generate-email-preview.ts
+++ b/packages/react-email/source/utils/generate-email-preview.ts
@@ -76,9 +76,7 @@ const createEmailPreviews = async (emailDir: string) => {
       path.dirname(absoluteSrcFilePath),
     );
 
-    const importFile = osIndependentPath(
-      path.join(importPath, path.parse(fileName).name),
-    );
+    const importFile = osIndependentPath(path.join(importPath, fileName));
 
     // if this import is changed, you also need to update `client/src/app/preview/[slug]/page.tsx`
     const sourceCode =

--- a/packages/react-email/source/utils/generate-email-preview.ts
+++ b/packages/react-email/source/utils/generate-email-preview.ts
@@ -76,7 +76,9 @@ const createEmailPreviews = async (emailDir: string) => {
       path.dirname(absoluteSrcFilePath),
     );
 
-    const importFile = osIndependentPath(path.join(importPath, fileName));
+    const importFile = osIndependentPath(
+      path.join(importPath, path.parse(fileName).name),
+    );
 
     // if this import is changed, you also need to update `client/src/app/preview/[slug]/page.tsx`
     const sourceCode =


### PR DESCRIPTION
This PR should fix #883.
The error message said that the extension (.tsx) is the problem. I just allowed the extension to be imported from emails folder

Sorry for dirty work history