### PR TITLE
feat(react-email): Add skip install flag

### DIFF
--- a/packages/react-email/source/commands/dev.ts
+++ b/packages/react-email/source/commands/dev.ts
@@ -6,22 +6,23 @@ import { setupServer } from '../utils/run-server';
 interface Args {
   dir: string;
   port: string;
+  skipInstall: boolean;
 }
 
-export const dev = async ({ dir, port }: Args) => {
+export const dev = async ({ dir, port, skipInstall }: Args) => {
   try {
     if (!fs.existsSync(dir)) {
       throw new Error(`Missing ${dir} folder`);
     }
 
     if (fs.existsSync(REACT_EMAIL_ROOT)) {
-      await setupServer('dev', dir, port);
+      await setupServer('dev', dir, port, skipInstall);
       return;
     }
 
     await downloadClient();
 
-    await setupServer('dev', dir, port);
+    await setupServer('dev', dir, port, skipInstall);
   } catch (error) {
     console.log(error);
     shell.exit(1);

--- a/packages/react-email/source/index.ts
+++ b/packages/react-email/source/index.ts
@@ -16,6 +16,7 @@ program
   .description('Starts the application in development mode')
   .option('-d, --dir <path>', 'Directory with your email templates', './emails')
   .option('-p --port <port>', 'Port to run dev server on', '3000')
+  .option('-s, --skip-install', 'Do not install depenedencies', false)
   .action(dev);
 
 program

--- a/packages/react-email/source/utils/run-server.ts
+++ b/packages/react-email/source/utils/run-server.ts
@@ -27,6 +27,7 @@ export const setupServer = async (
   type: 'dev' | 'build' | 'start',
   dir: string,
   port: string,
+  skipInstall: boolean = false
 ) => {
   const cwd = await findRoot(CURRENT_PATH).catch(() => ({
     rootDir: CURRENT_PATH,
@@ -40,7 +41,9 @@ export const setupServer = async (
   if (type !== 'start') {
     await generateEmailsPreview(emailDir);
     await syncPkg();
-    await installDependencies(packageManager);
+    if (!skipInstall) {
+      await installDependencies(packageManager);
+    }
   }
 
   if (type === 'dev') {


### PR DESCRIPTION
This change is to stop us from getting a `yarn.lock` file added to our project starting the email dev server.

Since we use a monorepo we don't need the react-email server to manage installing deps and this is a way to opt-out with `--skip-install`.

Repo for context:
https://github.com/bautistaaa/typehero/tree/main/apps/email