### PR TITLE
fix(tailwind): Keep custom class-names 

### DIFF
--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -88,8 +88,11 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
               // remove all non-responsive classes (ex: m-2 md:m-4 > md:m-4)
               .split(" ")
               .filter((className) => {
-                const cleanedClassName = className.replace(cleanRegex, "_")
-                return className.search(/^.{2}:/) !== -1 || !cssMap[`.${cleanedClassName}`]
+                const cleanedClassName = className.replace(cleanRegex, "_");
+                return (
+                  className.search(/^.{2}:/) !== -1 ||
+                  !cssMap[`.${cleanedClassName}`]
+                );
               })
               .join(" ")
               // replace all non-alphanumeric characters with underscores

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -87,7 +87,10 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
             domNode.attribs.class = domNode.attribs.class
               // remove all non-responsive classes (ex: m-2 md:m-4 > md:m-4)
               .split(" ")
-              .filter((className) => className.search(/^.{2}:/) !== -1)
+              .filter((className) => {
+                const cleanedClassName = className.replace(cleanRegex, "_")
+                return className.search(/^.{2}:/) !== -1 || !cssMap[`.${cleanedClassName}`]
+              })
               .join(" ")
               // replace all non-alphanumeric characters with underscores
               .replace(cleanRegex, "_");


### PR DESCRIPTION

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

## Description

This PR fixes #922 #888

## Problem

Current filter implementation filters out all class-names when it's trying to filter out non-responsive classes

## Solution

Add an extra check to filter out only class-names that tailwind has styles for - class-names that map to tailwind styles, otherwise keep the class-names