### PR TITLE
chore(markdown): upgrade md-to-react-email

### DIFF
--- a/packages/markdown/jest.config.js
+++ b/packages/markdown/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   clearMocks: true,
   resetMocks: true,
   restoreMocks: true,
+  // prettierPath: null,
   verbose: true,
   testEnvironment: "node",
   testPathIgnorePatterns: ["/node_modules/", "/build/"],

--- a/packages/markdown/jest.config.js
+++ b/packages/markdown/jest.config.js
@@ -3,7 +3,6 @@ module.exports = {
   clearMocks: true,
   resetMocks: true,
   restoreMocks: true,
-  // prettierPath: null,
   verbose: true,
   testEnvironment: "node",
   testPathIgnorePatterns: ["/node_modules/", "/build/"],

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/markdown",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Convert markdown input to valid react-email synthax",
   "sideEffects": false,
   "main": "./dist/index.js",
@@ -61,6 +61,6 @@
     "typescript": "5.1.6"
   },
   "dependencies": {
-    "md-to-react-email": "4.0.0"
+    "md-to-react-email": "4.1.0"
   }
 }

--- a/packages/markdown/src/markdown.spec.tsx
+++ b/packages/markdown/src/markdown.spec.tsx
@@ -56,9 +56,9 @@ console.log(\`Hello, \$\{name\}!\`);
       </Markdown>,
     );
     expect(actualOutput).toMatchInlineSnapshot(`
-"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div data-id="react-email-markdown"><h1 style="font-weight:500;padding-top:20px;font-size:2.5rem" data-id="react-email-heading">Markdown Test Document</h1><p data-id="react-email-text">This is a <strong style="font-weight:bold">test document</strong> to check the capabilities of a Markdown parser.</p>
-<h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Headings</h2><h3 style="font-weight:500;padding-top:20px;font-size:1.75rem" data-id="react-email-heading">Third-Level Heading</h3><h4 style="font-weight:500;padding-top:20px;font-size:1.5rem" data-id="react-email-heading">Fourth-Level Heading</h4><h5 style="font-weight:500;padding-top:20px;font-size:1.25rem" data-id="react-email-heading">Fifth-Level Heading</h5><h6 style="font-weight:500;padding-top:20px;font-size:1rem" data-id="react-email-heading">Sixth-Level Heading</h6><h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Text Formatting</h2><p data-id="react-email-text">This is some <strong style="font-weight:bold">bold text</strong> and this is some <em style="font-style:italic">italic text</em>. You can also use <del>strikethrough</del> and <code style="color:#212529;font-size:87.5%;display:inline;background: #f8f8f8;font-family:SFMono-Regular,Menlo,Monaco,Consolas,monospace;word-wrap:break-word">inline code</code>.</p>
-<h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Lists</h2><ol>
+"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"react-email-markdown\\"><h1 style=\\"font-weight:500;padding-top:20px;font-size:2.5rem\\" data-id=\\"react-email-heading\\">Markdown Test Document</h1><p data-id=\\"react-email-text\\">This is a <strong style=\\"font-weight:bold\\">test document</strong> to check the capabilities of a Markdown parser.</p>
+<h2 style=\\"font-weight:500;padding-top:20px;font-size:2rem\\" data-id=\\"react-email-heading\\">Headings</h2><h3 style=\\"font-weight:500;padding-top:20px;font-size:1.75rem\\" data-id=\\"react-email-heading\\">Third-Level Heading</h3><h4 style=\\"font-weight:500;padding-top:20px;font-size:1.5rem\\" data-id=\\"react-email-heading\\">Fourth-Level Heading</h4><h5 style=\\"font-weight:500;padding-top:20px;font-size:1.25rem\\" data-id=\\"react-email-heading\\">Fifth-Level Heading</h5><h6 style=\\"font-weight:500;padding-top:20px;font-size:1rem\\" data-id=\\"react-email-heading\\">Sixth-Level Heading</h6><h2 style=\\"font-weight:500;padding-top:20px;font-size:2rem\\" data-id=\\"react-email-heading\\">Text Formatting</h2><p data-id=\\"react-email-text\\">This is some <strong style=\\"font-weight:bold\\">bold text</strong> and this is some <em style=\\"font-style:italic\\">italic text</em>. You can also use <del>strikethrough</del> and <code style=\\"color:#212529;font-size:87.5%;display:inline;background: #f8f8f8;font-family:SFMono-Regular,Menlo,Monaco,Consolas,monospace;word-wrap:break-word\\">inline code</code>.</p>
+<h2 style=\\"font-weight:500;padding-top:20px;font-size:2rem\\" data-id=\\"react-email-heading\\">Lists</h2><ol>
 <li>Ordered List Item 1</li>
 <li>Ordered List Item 2</li>
 <li>Ordered List Item 3</li>
@@ -68,15 +68,15 @@ console.log(\`Hello, \$\{name\}!\`);
 <li>Unordered List Item 2</li>
 <li>Unordered List Item 3</li>
 </ul>
-<h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Links</h2><p data-id="react-email-text"><a href="https://www.markdownguide.org" target="_blank" data-id="react-email-link" style="color:#007bff;text-decoration:underline;background-color:transparent">Markdown Guide</a></p>
-<h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Images</h2><p data-id="react-email-text"><img src="https://markdown-here.com/img/icon256.png" alt="Markdown Logo"></p>
-<h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Blockquotes</h2><blockquote style="background:#f9f9f9;border-left:10px solid #ccc;margin:1.5em 10px;padding:1em 10px">
-<p data-id="react-email-text">This is a blockquote.</p>
+<h2 style=\\"font-weight:500;padding-top:20px;font-size:2rem\\" data-id=\\"react-email-heading\\">Links</h2><p data-id=\\"react-email-text\\"><a href=\\"https://www.markdownguide.org\\" target=\\"_blank\\" data-id=\\"react-email-link\\" style=\\"color:#007bff;text-decoration:underline;background-color:transparent\\">Markdown Guide</a></p>
+<h2 style=\\"font-weight:500;padding-top:20px;font-size:2rem\\" data-id=\\"react-email-heading\\">Images</h2><p data-id=\\"react-email-text\\"><img src=\\"https://markdown-here.com/img/icon256.png\\" alt=\\"Markdown Logo\\"></p>
+<h2 style=\\"font-weight:500;padding-top:20px;font-size:2rem\\" data-id=\\"react-email-heading\\">Blockquotes</h2><blockquote style=\\"background:#f9f9f9;border-left:10px solid #ccc;margin:1.5em 10px;padding:1em 10px\\">
+<p data-id=\\"react-email-text\\">This is a blockquote.</p>
 <ul>
 <li>Author</li>
 </ul>
 </blockquote>
-<h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Code Blocks</h2><pre style="color:#212529;font-size:87.5%;display:inline;background: #f8f8f8;font-family:SFMono-Regular,Menlo,Monaco,Consolas,monospace;padding-top:10px;padding-right:10px;padding-left:10px;padding-bottom:1px;margin-bottom:20px;word-wrap:break-word"><code>function greet(name) {
+<h2 style=\\"font-weight:500;padding-top:20px;font-size:2rem\\" data-id=\\"react-email-heading\\">Code Blocks</h2><pre style=\\"color:#212529;font-size:87.5%;display:inline;background: #f8f8f8;font-family:SFMono-Regular,Menlo,Monaco,Consolas,monospace;padding-top:10px;padding-right:10px;padding-left:10px;padding-bottom:1px;margin-bottom:20px;word-wrap:break-word\\"><code>function greet(name) {
 console.log(\`Hello, \${name}!\`);
 }
 </code></pre>
@@ -97,7 +97,9 @@ console.log(\`Hello, \${name}!\`);
        `}
       </Markdown>,
     );
-    expect(actualOutput).toMatchInlineSnapshot(`"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div data-id="react-email-markdown"><h1 style="font-weight:500;padding-top:20px;font-size:2.5rem" data-id="react-email-heading">Heading 1!</h1><h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Heading 2!</h2><h3 style="font-weight:500;padding-top:20px;font-size:1.75rem" data-id="react-email-heading">Heading 3!</h3><h4 style="font-weight:500;padding-top:20px;font-size:1.5rem" data-id="react-email-heading">Heading 4!</h4><h5 style="font-weight:500;padding-top:20px;font-size:1.25rem" data-id="react-email-heading">Heading 5!</h5><h6 style="font-weight:500;padding-top:20px;font-size:1rem" data-id="react-email-heading">Heading 6!</h6></div>"`);
+    expect(actualOutput).toMatchInlineSnapshot(
+      `"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"react-email-markdown\\"><h1 style=\\"font-weight:500;padding-top:20px;font-size:2.5rem\\" data-id=\\"react-email-heading\\">Heading 1!</h1><h2 style=\\"font-weight:500;padding-top:20px;font-size:2rem\\" data-id=\\"react-email-heading\\">Heading 2!</h2><h3 style=\\"font-weight:500;padding-top:20px;font-size:1.75rem\\" data-id=\\"react-email-heading\\">Heading 3!</h3><h4 style=\\"font-weight:500;padding-top:20px;font-size:1.5rem\\" data-id=\\"react-email-heading\\">Heading 4!</h4><h5 style=\\"font-weight:500;padding-top:20px;font-size:1.25rem\\" data-id=\\"react-email-heading\\">Heading 5!</h5><h6 style=\\"font-weight:500;padding-top:20px;font-size:1rem\\" data-id=\\"react-email-heading\\">Heading 6!</h6></div>"`,
+    );
   });
 
   it("renders text in the correct format for browsers", () => {
@@ -107,7 +109,7 @@ console.log(\`Hello, \${name}!\`);
       >{`**This is sample bold text in markdown** and *this is italic text*`}</Markdown>,
     );
     expect(actualOutput).toMatchInlineSnapshot(`
-"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div data-id="react-email-markdown"><p data-id="react-email-text"><strong style="font-weight:bold">This is sample bold text in markdown</strong> and <em style="font-style:italic">this is italic text</em></p>
+"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"react-email-markdown\\"><p data-id=\\"react-email-text\\"><strong style=\\"font-weight:bold\\">This is sample bold text in markdown</strong> and <em style=\\"font-style:italic\\">this is italic text</em></p>
 </div>"
 `);
   });
@@ -119,7 +121,7 @@ console.log(\`Hello, \${name}!\`);
       >{`Link to [React-email](https://react.email)`}</Markdown>,
     );
     expect(actualOutput).toMatchInlineSnapshot(`
-"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div data-id="react-email-markdown"><p data-id="react-email-text">Link to <a href="https://react.email" target="_blank" data-id="react-email-link" style="color:#007bff;text-decoration:underline;background-color:transparent">React-email</a></p>
+"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"react-email-markdown\\"><p data-id=\\"react-email-text\\">Link to <a href=\\"https://react.email\\" target=\\"_blank\\" data-id=\\"react-email-link\\" style=\\"color:#007bff;text-decoration:underline;background-color:transparent\\">React-email</a></p>
 </div>"
 `);
   });
@@ -137,7 +139,7 @@ console.log(\`Hello, \${name}!\`);
       </Markdown>,
     );
     expect(actualOutput).toMatchInlineSnapshot(`
-"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div data-id="react-email-markdown"><h1 style="font-weight:500;padding-top:20px;font-size:2.5rem" data-id="react-email-heading">Below is a list</h1><ul>
+"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"react-email-markdown\\"><h1 style=\\"font-weight:500;padding-top:20px;font-size:2.5rem\\" data-id=\\"react-email-heading\\">Below is a list</h1><ul>
 <li>Item One</li>
 <li>Item Two</li>
 <li>Item Three</li>

--- a/packages/markdown/src/markdown.spec.tsx
+++ b/packages/markdown/src/markdown.spec.tsx
@@ -56,9 +56,9 @@ console.log(\`Hello, \$\{name\}!\`);
       </Markdown>,
     );
     expect(actualOutput).toMatchInlineSnapshot(`
-"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"react-email-markdown\\"><h1 data-id=\\"react-email-heading\\" style=\\"font-weight:500;padding-top:20px;font-size:2.5rem\\">Markdown Test Document</h1><p data-id=\\"react-email-text\\">This is a <strong style=\\"font-weight:bold\\">test document</strong> to check the capabilities of a Markdown parser.</p>
-<h2 data-id=\\"react-email-heading\\" style=\\"font-weight:500;padding-top:20px;font-size:2rem\\">Headings</h2><h3 data-id=\\"react-email-heading\\" style=\\"font-weight:500;padding-top:20px;font-size:1.75rem\\">Third-Level Heading</h3><h4 data-id=\\"react-email-heading\\" style=\\"font-weight:500;padding-top:20px;font-size:1.5rem\\">Fourth-Level Heading</h4><h5 data-id=\\"react-email-heading\\" style=\\"font-weight:500;padding-top:20px;font-size:1.25rem\\">Fifth-Level Heading</h5><h6 data-id=\\"react-email-heading\\" style=\\"font-weight:500;padding-top:20px;font-size:1rem\\">Sixth-Level Heading</h6><h2 data-id=\\"react-email-heading\\" style=\\"font-weight:500;padding-top:20px;font-size:2rem\\">Text Formatting</h2><p data-id=\\"react-email-text\\">This is some <strong style=\\"font-weight:bold\\">bold text</strong> and this is some <em style=\\"font-style:italic\\">italic text</em>. You can also use <del>strikethrough</del> and <code style=\\"color:#212529;font-size:87.5%;display:inline;background: #f8f8f8;font-family:SFMono-Regular,Menlo,Monaco,Consolas,monospace;word-wrap:break-word\\">inline code</code>.</p>
-<h2 data-id=\\"react-email-heading\\" style=\\"font-weight:500;padding-top:20px;font-size:2rem\\">Lists</h2><ol>
+"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div data-id="react-email-markdown"><h1 style="font-weight:500;padding-top:20px;font-size:2.5rem" data-id="react-email-heading">Markdown Test Document</h1><p data-id="react-email-text">This is a <strong style="font-weight:bold">test document</strong> to check the capabilities of a Markdown parser.</p>
+<h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Headings</h2><h3 style="font-weight:500;padding-top:20px;font-size:1.75rem" data-id="react-email-heading">Third-Level Heading</h3><h4 style="font-weight:500;padding-top:20px;font-size:1.5rem" data-id="react-email-heading">Fourth-Level Heading</h4><h5 style="font-weight:500;padding-top:20px;font-size:1.25rem" data-id="react-email-heading">Fifth-Level Heading</h5><h6 style="font-weight:500;padding-top:20px;font-size:1rem" data-id="react-email-heading">Sixth-Level Heading</h6><h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Text Formatting</h2><p data-id="react-email-text">This is some <strong style="font-weight:bold">bold text</strong> and this is some <em style="font-style:italic">italic text</em>. You can also use <del>strikethrough</del> and <code style="color:#212529;font-size:87.5%;display:inline;background: #f8f8f8;font-family:SFMono-Regular,Menlo,Monaco,Consolas,monospace;word-wrap:break-word">inline code</code>.</p>
+<h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Lists</h2><ol>
 <li>Ordered List Item 1</li>
 <li>Ordered List Item 2</li>
 <li>Ordered List Item 3</li>
@@ -68,15 +68,15 @@ console.log(\`Hello, \$\{name\}!\`);
 <li>Unordered List Item 2</li>
 <li>Unordered List Item 3</li>
 </ul>
-<h2 data-id=\\"react-email-heading\\" style=\\"font-weight:500;padding-top:20px;font-size:2rem\\">Links</h2><p data-id=\\"react-email-text\\"><a style=\\"color:#007bff;text-decoration:underline;background-color:transparent\\" data-id=\\"react-email-link\\" href=\\"https://www.markdownguide.org\\" target=\\"_blank\\">Markdown Guide</a></p>
-<h2 data-id=\\"react-email-heading\\" style=\\"font-weight:500;padding-top:20px;font-size:2rem\\">Images</h2><p data-id=\\"react-email-text\\"><img alt=\\"Markdown Logo\\" src=\\"https://markdown-here.com/img/icon256.png\\"></p>
-<h2 data-id=\\"react-email-heading\\" style=\\"font-weight:500;padding-top:20px;font-size:2rem\\">Blockquotes</h2><blockquote style=\\"background:#f9f9f9;border-left:10px solid #ccc;margin:1.5em 10px;padding:1em 10px\\">
-<p data-id=\\"react-email-text\\">This is a blockquote.</p>
+<h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Links</h2><p data-id="react-email-text"><a href="https://www.markdownguide.org" target="_blank" data-id="react-email-link" style="color:#007bff;text-decoration:underline;background-color:transparent">Markdown Guide</a></p>
+<h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Images</h2><p data-id="react-email-text"><img src="https://markdown-here.com/img/icon256.png" alt="Markdown Logo"></p>
+<h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Blockquotes</h2><blockquote style="background:#f9f9f9;border-left:10px solid #ccc;margin:1.5em 10px;padding:1em 10px">
+<p data-id="react-email-text">This is a blockquote.</p>
 <ul>
 <li>Author</li>
 </ul>
 </blockquote>
-<h2 data-id=\\"react-email-heading\\" style=\\"font-weight:500;padding-top:20px;font-size:2rem\\">Code Blocks</h2><pre style=\\"color:#212529;font-size:87.5%;display:inline;background: #f8f8f8;font-family:SFMono-Regular,Menlo,Monaco,Consolas,monospace;padding-top:10px;padding-right:10px;padding-left:10px;padding-bottom:1px;margin-bottom:20px;word-wrap:break-word\\"><code>function greet(name) {
+<h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Code Blocks</h2><pre style="color:#212529;font-size:87.5%;display:inline;background: #f8f8f8;font-family:SFMono-Regular,Menlo,Monaco,Consolas,monospace;padding-top:10px;padding-right:10px;padding-left:10px;padding-bottom:1px;margin-bottom:20px;word-wrap:break-word"><code>function greet(name) {
 console.log(\`Hello, \${name}!\`);
 }
 </code></pre>
@@ -97,9 +97,7 @@ console.log(\`Hello, \${name}!\`);
        `}
       </Markdown>,
     );
-    expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"react-email-markdown\\"><h1 style=\\"font-weight:500;padding-top:20px;font-size:2.5rem\\" data-id=\\"react-email-heading\\">Heading 1!</h1><h2 style=\\"font-weight:500;padding-top:20px;font-size:2rem\\" data-id=\\"react-email-heading\\">Heading 2!</h2><h3 style=\\"font-weight:500;padding-top:20px;font-size:1.75rem\\" data-id=\\"react-email-heading\\">Heading 3!</h3><h4 style=\\"font-weight:500;padding-top:20px;font-size:1.5rem\\" data-id=\\"react-email-heading\\">Heading 4!</h4><h5 style=\\"font-weight:500;padding-top:20px;font-size:1.25rem\\" data-id=\\"react-email-heading\\">Heading 5!</h5><h6 style=\\"font-weight:500;padding-top:20px;font-size:1rem\\" data-id=\\"react-email-heading\\">Heading 6!</h6></div>"`,
-    );
+    expect(actualOutput).toMatchInlineSnapshot(`"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div data-id="react-email-markdown"><h1 style="font-weight:500;padding-top:20px;font-size:2.5rem" data-id="react-email-heading">Heading 1!</h1><h2 style="font-weight:500;padding-top:20px;font-size:2rem" data-id="react-email-heading">Heading 2!</h2><h3 style="font-weight:500;padding-top:20px;font-size:1.75rem" data-id="react-email-heading">Heading 3!</h3><h4 style="font-weight:500;padding-top:20px;font-size:1.5rem" data-id="react-email-heading">Heading 4!</h4><h5 style="font-weight:500;padding-top:20px;font-size:1.25rem" data-id="react-email-heading">Heading 5!</h5><h6 style="font-weight:500;padding-top:20px;font-size:1rem" data-id="react-email-heading">Heading 6!</h6></div>"`);
   });
 
   it("renders text in the correct format for browsers", () => {
@@ -109,7 +107,7 @@ console.log(\`Hello, \${name}!\`);
       >{`**This is sample bold text in markdown** and *this is italic text*`}</Markdown>,
     );
     expect(actualOutput).toMatchInlineSnapshot(`
-"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"react-email-markdown\\"><p data-id=\\"react-email-text\\"><strong style=\\"font-weight:bold\\">This is sample bold text in markdown</strong> and <em style=\\"font-style:italic\\">this is italic text</em></p>
+"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div data-id="react-email-markdown"><p data-id="react-email-text"><strong style="font-weight:bold">This is sample bold text in markdown</strong> and <em style="font-style:italic">this is italic text</em></p>
 </div>"
 `);
   });
@@ -121,7 +119,7 @@ console.log(\`Hello, \${name}!\`);
       >{`Link to [React-email](https://react.email)`}</Markdown>,
     );
     expect(actualOutput).toMatchInlineSnapshot(`
-"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"react-email-markdown\\"><p data-id=\\"react-email-text\\">Link to <a href=\\"https://react.email\\" data-id=\\"react-email-link\\" style=\\"color:#007bff;text-decoration:underline;background-color:transparent\\" target=\\"_blank\\">React-email</a></p>
+"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div data-id="react-email-markdown"><p data-id="react-email-text">Link to <a href="https://react.email" target="_blank" data-id="react-email-link" style="color:#007bff;text-decoration:underline;background-color:transparent">React-email</a></p>
 </div>"
 `);
   });
@@ -139,7 +137,7 @@ console.log(\`Hello, \${name}!\`);
       </Markdown>,
     );
     expect(actualOutput).toMatchInlineSnapshot(`
-"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"react-email-markdown\\"><h1 data-id=\\"react-email-heading\\" style=\\"font-weight:500;padding-top:20px;font-size:2.5rem\\">Below is a list</h1><ul>
+"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div data-id="react-email-markdown"><h1 style="font-weight:500;padding-top:20px;font-size:2.5rem" data-id="react-email-heading">Below is a list</h1><ul>
 <li>Item One</li>
 <li>Item Two</li>
 <li>Item Three</li>


### PR DESCRIPTION
### Description
`DOMPurify` has been removed from `md-to-react-email`.
This PR fixes #914.

### Reasons behind it:
- Developer Responsibility:
The primary purpose of this library is to allow developers to create email templates with markdown. Any potential vulnerabilities in the generated HTML content primarily result from the developers' input. Therefore, the need for DOMPurify to sanitize the Markdown output is minimal. Developers can opt to use it separately to ensure their content is safe.

- Compatibility on the Edge:
DOMPurify operates within the DOM (Document Object Model), and its behavior can be influenced by the surrounding context. This can lead to edge compatibility issues, especially in scenarios where the library is used in various contexts, such as server-side rendering or non-browser environments.
    
- Package Size:
Including DOMPurify as a dependency in the library unnecessarily increases the package size. Removing it will reduce the overall size of the library, making it more lightweight for users.

**Note**: This change does not affect the core functionality of the library in generating HTML content from Markdown, but it removes the automatic use of DOMPurify within the library itself.

If developers wish to sanitize the Markdown output manually using DOMPurify, they can do so by including it in their project separately. This change allows users to have more control over the sanitization process and makes the inclusion of DOMPurify an opt-in choice based on their specific security requirements.