### PR TITLE
feature(react-email CLI): make it sync path aliases from the parent tsconfig file into the .react-email client

### DIFF
--- a/packages/react-email/source/utils/run-server.ts
+++ b/packages/react-email/source/utils/run-server.ts
@@ -15,6 +15,7 @@ import {
 } from '.';
 import path from 'path';
 import shell from 'shelljs';
+import { syncAliases } from './sync-aliases';
 
 /**
  * Utility function to run init/sync for the server in dev, build or start mode.
@@ -41,6 +42,7 @@ export const setupServer = async (
   if (type !== 'start') {
     await generateEmailsPreview(emailDir);
     await syncPkg();
+    await syncAliases();
     if (!skipInstall) {
       await installDependencies(packageManager);
     }

--- a/packages/react-email/source/utils/sync-aliases.ts
+++ b/packages/react-email/source/utils/sync-aliases.ts
@@ -22,8 +22,8 @@ export const syncAliases = async () => {
         [key]: paths.map(
           // this is required because the aliases are relative to the rootDir
           (p) =>
-            path.join(`../`, userTsConfig.compilerOptions.rootDir ?? '', p),
-          //                                 the default rootDir is just where the tsconfig is located
+            path.join(`../`, userTsConfig.compilerOptions.baseUrl ?? '', p),
+          //                                 the default baseUrl is just where the tsconfig is located
         ),
       };
     }, {});

--- a/packages/react-email/source/utils/sync-aliases.ts
+++ b/packages/react-email/source/utils/sync-aliases.ts
@@ -1,0 +1,36 @@
+import { REACT_EMAIL_ROOT } from './constants';
+import * as fs from 'fs/promises';
+import path from 'path';
+
+export const syncAliases = async () => {
+  const clientTsConfig = JSON.parse(
+    (
+      await fs.readFile(path.join(REACT_EMAIL_ROOT, 'tsconfig.json'))
+    ).toString(),
+  );
+  const userTsConfig = JSON.parse(
+    (await fs.readFile('tsconfig.json')).toString(),
+  );
+
+  let tsConfig = clientTsConfig;
+  if (userTsConfig.compilerOptions.paths) {
+    tsConfig.compilerOptions.paths = Object.entries<string[]>(
+      userTsConfig.compilerOptions.paths,
+    ).reduce((prev, [key, paths]) => {
+      return {
+        ...prev,
+        [key]: paths.map(
+          // this is required because the aliases are relative to the rootDir
+          (p) =>
+            path.join(`../`, userTsConfig.compilerOptions.rootDir ?? '', p),
+          //                                 the default rootDir is just where the tsconfig is located
+        ),
+      };
+    }, {});
+  }
+
+  await fs.writeFile(
+    path.join(REACT_EMAIL_ROOT, 'tsconfig.json'),
+    JSON.stringify(tsConfig),
+  );
+};


### PR DESCRIPTION
This is a PR on the react-email CLI. I have tested and confirm it works and solves issue #895.

This PR implements an extra step next to the `syncPkg()` step called `syncAliases()` 
that just copies and adjusts the paths for the property `compilerOptions.paths` in the user's
tsconfig. Some of the code is borrowed from the temporary solution that @Gregory-Gerard used in #895.

I have ran `yarn format` to ensure formatting is proper as well.

Thanks for consdering accepting the PR. 
If anything is wrong with it, please don't spare any criticism.
