### PR TITLE
fix(font): Allow the typical fallback-fonts

### DIFF
--- a/packages/font/src/font.tsx
+++ b/packages/font/src/font.tsx
@@ -5,7 +5,12 @@ type FallbackFont =
   | "Helvetica"
   | "Verdana"
   | "Georgia"
-  | "Times New Roman";
+  | "Times New Roman"
+  | "serif"
+  | "sans-serif"
+  | "monospace"
+  | "cursive"
+  | "fantasy";
 
 type FontFormat =
   | "woff"


### PR DESCRIPTION
As many people use browsers to display their emails, in my opinion it makes sense to allow the [typical](https://www.w3schools.com/css/css_font_fallbacks.asp) font fallbacks like "sans-serif" in the fallbackFontFamily array.