### PR TITLE
fix(react-email): Remove obsolete appDir option from next.config.js

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -3,7 +3,6 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   experimental: {
-    appDir: true,
     externalDir: true // compile files that are located next to the .react-email directory
   },
 };


### PR DESCRIPTION
This pull request removes the no longer necessary appDir option from the next.config.js  (experimental) file in the react-email repository. The App Router is now stable as of Next.js 13.4, eliminating the need for this option.
changes:
- Removed experimental appDir option from next.config.js.


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->
