### PR TITLE
fix(react-email): support bun

### DIFF
--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -31,7 +31,7 @@
     "@react-email/render": "0.0.6",
     "chokidar": "3.5.3",
     "commander": "9.4.1",
-    "detect-package-manager": "2.0.1",
+    "detect-package-manager": "3.0.1",
     "esbuild": "0.16.4",
     "fs-extra": "11.1.1",
     "glob": "10.3.4",

--- a/packages/react-email/source/utils/install-dependencies.ts
+++ b/packages/react-email/source/utils/install-dependencies.ts
@@ -1,13 +1,12 @@
 import path from 'node:path';
-import shell from 'shelljs';
-import ora from 'ora';
+import type { PM } from 'detect-package-manager';
 import logSymbols from 'log-symbols';
-import { REACT_EMAIL_ROOT } from './constants';
+import ora from 'ora';
+import shell from 'shelljs';
 import { closeOraOnSIGNIT } from './close-ora-on-sigint';
+import { REACT_EMAIL_ROOT } from './constants';
 
-export type PackageManager = 'yarn' | 'npm' | 'pnpm';
-
-export const installDependencies = (packageManager: PackageManager) => {
+export const installDependencies = (packageManager: PM) => {
   const spinner = ora('Installing dependencies...\n').start();
   closeOraOnSIGNIT(spinner);
 

--- a/packages/react-email/source/utils/run-server.ts
+++ b/packages/react-email/source/utils/run-server.ts
@@ -1,19 +1,21 @@
 import path from 'node:path';
-import { detect as detectPackageManager } from 'detect-package-manager';
 import { findRoot } from '@manypkg/find-root';
+import {
+  detect as detectPackageManager,
+  type PM,
+} from 'detect-package-manager';
 import shell from 'shelljs';
 import { createWatcherInstance, watcher } from './watcher';
-import type { PackageManager } from '.';
 import {
-  CURRENT_PATH,
-  convertToAbsolutePath,
-  startDevServer,
-  installDependencies,
-  syncPkg,
-  generateEmailsPreview,
   buildProdServer,
-  startProdServer,
+  convertToAbsolutePath,
+  CURRENT_PATH,
+  generateEmailsPreview,
+  installDependencies,
   REACT_EMAIL_ROOT,
+  startDevServer,
+  startProdServer,
+  syncPkg,
 } from '.';
 
 /**
@@ -33,7 +35,7 @@ export const setupServer = async (
     rootDir: CURRENT_PATH,
   }));
   const emailDir = convertToAbsolutePath(dir);
-  const packageManager: PackageManager = await detectPackageManager({
+  const packageManager: PM = await detectPackageManager({
     cwd: cwd.rootDir,
   }).catch(() => 'npm');
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,8 +514,8 @@ importers:
         specifier: 9.4.1
         version: 9.4.1
       detect-package-manager:
-        specifier: 2.0.1
-        version: 2.0.1
+        specifier: 3.0.1
+        version: 3.0.1
       esbuild:
         specifier: 0.16.4
         version: 0.16.4
@@ -3073,8 +3073,8 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
-  /detect-package-manager@2.0.1:
-    resolution: {integrity: sha512-j/lJHyoLlWi6G1LDdLgvUtz60Zo5GEj+sVYtTVXnYLDPuzgC3llMxonXym9zIwhhUII8vjdw0LXxavpLqTbl1A==}
+  /detect-package-manager@3.0.1:
+    resolution: {integrity: sha512-qoHDH6+lMcpJPAScE7+5CYj91W0mxZNXTwZPrCqi1KMk+x+AoQScQ2V1QyqTln1rHU5Haq5fikvOGHv+leKD8A==}
     engines: {node: '>=12'}
     dependencies:
       execa: 5.1.1


### PR DESCRIPTION
Once I'm using `bun` as package manager to my project, I've a bug because the installed version of `detect-package-manager` does not support bun. But, in the new major (3) have support.