### PR TITLE
fix(tailwind): Extra rough edges

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "packageManager": "pnpm@8.8.0",
   "pnpm": {
     "patchedDependencies": {
-      "postcss-css-variables@0.19.0": "patches/postcss-css-variables@0.19.0.patch"
+      "postcss-css-variables@0.19.0": "patches/postcss-css-variables@0.19.0.patch",
+      "tailwindcss@3.3.2": "patches/tailwindcss@3.3.2.patch"
     }
   }
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
     "@react-email/render": "0.0.9",
     "@react-email/row": "0.0.6",
     "@react-email/section": "0.0.10",
-    "@react-email/tailwind": "0.0.13-canary.2",
+    "@react-email/tailwind": "0.0.13-canary.3",
     "@react-email/text": "0.0.6"
   },
   "peerDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
     "@react-email/render": "0.0.9",
     "@react-email/row": "0.0.6",
     "@react-email/section": "0.0.10",
-    "@react-email/tailwind": "0.0.13-canary.3",
+    "@react-email/tailwind": "0.0.13-canary.4",
     "@react-email/text": "0.0.6"
   },
   "peerDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/components",
-  "version": "0.0.12-canary.0",
+  "version": "0.0.12-canary.1",
   "description": "All react-email components",
   "sideEffects": false,
   "main": "./dist/index.js",
@@ -56,7 +56,7 @@
     "@react-email/render": "0.0.9",
     "@react-email/row": "0.0.6",
     "@react-email/section": "0.0.10",
-    "@react-email/tailwind": "0.0.13-canary.1",
+    "@react-email/tailwind": "0.0.13-canary.2",
     "@react-email/text": "0.0.6"
   },
   "peerDependencies": {

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/tailwind",
-  "version": "0.0.13-canary.2",
+  "version": "0.0.13-canary.3",
   "description": "A React component to wrap emails with Tailwind CSS",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -52,9 +52,6 @@
     "react": "18.2.0"
   },
   "devDependencies": {
-    "tailwindcss": "3.3.2",
-    "postcss-css-variables": "0.19.0",
-
     "@babel/core": "7.21.8",
     "@babel/preset-react": "7.22.5",
     "@react-email/head": "workspace:*",
@@ -64,7 +61,10 @@
     "@types/postcss-css-variables": "0.18.2",
     "eslint-config-custom": "workspace:*",
     "eslint-plugin-regex": "1.10.0",
+    "postcss-css-variables": "0.19.0",
+    "tailwindcss": "3.3.2",
     "tsconfig": "workspace:*",
+    "tsup": "7.2.0",
     "typescript": "5.1.6"
   },
   "publishConfig": {

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/tailwind",
-  "version": "0.0.13-canary.1",
+  "version": "0.0.13-canary.2",
   "description": "A React component to wrap emails with Tailwind CSS",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@babel/core": "7.21.8",
     "@babel/preset-react": "7.22.5",
+    "@react-email/button": "workspace:^",
     "@react-email/head": "workspace:*",
     "@react-email/hr": "workspace:*",
     "@react-email/html": "workspace:*",

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/tailwind",
-  "version": "0.0.13-canary.3",
+  "version": "0.0.13-canary.4",
   "description": "A React component to wrap emails with Tailwind CSS",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -23,9 +23,9 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --external react",
+    "build": "tsup src/index.ts  --config tsup.config.ts",
     "clean": "rm -rf dist",
-    "dev": "tsup src/index.ts --format esm,cjs --dts --external react --watch",
+    "dev": "pnpm build --watch",
     "lint": "eslint .",
     "test:watch": "vitest",
     "test": "vitest run"
@@ -45,15 +45,16 @@
   },
   "dependencies": {
     "postcss": "8.4.31",
-    "postcss-css-variables": "0.19.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "tailwindcss": "3.3.2"
+    "react-dom": "18.2.0"
   },
   "peerDependencies": {
     "react": "18.2.0"
   },
   "devDependencies": {
+    "tailwindcss": "3.3.2",
+    "postcss-css-variables": "0.19.0",
+
     "@babel/core": "7.21.8",
     "@babel/preset-react": "7.22.5",
     "@react-email/head": "workspace:*",

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup as render } from "react-dom/server";
 import { Hr } from "@react-email/hr";
 import { Html } from "@react-email/html";
 import { Head } from "@react-email/head";
+import { Button } from "@react-email/button";
 import { Tailwind } from ".";
 import type { TailwindConfig } from ".";
 
@@ -18,6 +19,18 @@ describe("Tailwind component", () => {
 
       expect(actualOutput).not.toBeNull();
     });
+  });
+
+  test.only('<Button className="mt-8 rounded-md bg-blue-600 px-3 py-2 text-sm text-gray-200">', () => {
+    const actualOutput = render(
+      <Tailwind>
+        <Button className="mt-8 rounded-md bg-blue-600 px-3 py-2 text-sm text-gray-200">
+          Testing button
+        </Button>
+      </Tailwind>
+    );
+
+    expect(actualOutput).toMatchInlineSnapshot(`"<a style=\\"margin-top:2rem;border-radius:0.375rem;background-color:rgb(37,99,235);padding-left:0.75rem;padding-right:0.75rem;padding-top:0.5rem;padding-bottom:0.5rem;font-size:0.875rem;line-height:100%;color:rgb(229,231,235);text-decoration:none;display:inline-block;max-width:100%;padding:8px 12px 8px 12px\\" target=\\"_blank\\"><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%;mso-text-raise:12\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:6px\\">Testing button</span><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>"`);
   });
 
   it("should work with custom components with fragment at the root", () => {

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -21,7 +21,7 @@ describe("Tailwind component", () => {
     });
   });
 
-  test.only('<Button className="mt-8 rounded-md bg-blue-600 px-3 py-2 text-sm text-gray-200">', () => {
+  test('<Button className="mt-8 rounded-md bg-blue-600 px-3 py-2 text-sm text-gray-200">', () => {
     const actualOutput = render(
       <Tailwind>
         <Button className="mt-8 rounded-md bg-blue-600 px-3 py-2 text-sm text-gray-200">

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -27,10 +27,12 @@ describe("Tailwind component", () => {
         <Button className="mt-8 rounded-md bg-blue-600 px-3 py-2 text-sm text-gray-200">
           Testing button
         </Button>
-      </Tailwind>
+      </Tailwind>,
     );
 
-    expect(actualOutput).toMatchInlineSnapshot(`"<a style=\\"margin-top:2rem;border-radius:0.375rem;background-color:rgb(37,99,235);padding-left:0.75rem;padding-right:0.75rem;padding-top:0.5rem;padding-bottom:0.5rem;font-size:0.875rem;line-height:100%;color:rgb(229,231,235);text-decoration:none;display:inline-block;max-width:100%;padding:8px 12px 8px 12px\\" target=\\"_blank\\"><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%;mso-text-raise:12\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:6px\\">Testing button</span><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>"`);
+    expect(actualOutput).toMatchInlineSnapshot(
+      `"<a style=\\"margin-top:2rem;border-radius:0.375rem;background-color:rgb(37,99,235);padding-left:0.75rem;padding-right:0.75rem;padding-top:0.5rem;padding-bottom:0.5rem;font-size:0.875rem;line-height:100%;color:rgb(229,231,235);text-decoration:none;display:inline-block;max-width:100%;padding:8px 12px 8px 12px\\" target=\\"_blank\\"><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%;mso-text-raise:12\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:6px\\">Testing button</span><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>"`,
+    );
   });
 
   it("should work with custom components with fragment at the root", () => {

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -106,7 +106,7 @@ describe("Tailwind component", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<div style=\\"background-color:rgb(0 0 0 / 1);font-size:16px\\"></div>"',
+      '"<div style=\\"background-color:rgb(0,0,0);font-size:16px\\"></div>"',
     );
   });
 
@@ -135,7 +135,7 @@ describe("Responsive styles", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<html lang=\\"en\\"><head><style>@media(min-width:640px){.sm\\\\:bg-red-300{background-color:rgb(252 165 165 / 1)!important}}@media(min-width:768px){.md\\\\:bg-red-400{background-color:rgb(248 113 113 / 1)!important}}@media(min-width:1024px){.lg\\\\:bg-red-500{background-color:rgb(239 68 68 / 1)!important}}</style></head><body><div class=\\"sm:bg-red-300 md:bg-red-400 lg:bg-red-500\\" style=\\"background-color:rgb(254 202 202 / 1)\\"></div></body></html>"',
+      '"<html lang=\\"en\\"><head><style>@media(min-width:640px){.sm\\\\:bg-red-300{background-color:rgb(252,165,165)!important}}@media(min-width:768px){.md\\\\:bg-red-400{background-color:rgb(248,113,113)!important}}@media(min-width:1024px){.lg\\\\:bg-red-500{background-color:rgb(239,68,68)!important}}</style></head><body><div class=\\"sm:bg-red-300 md:bg-red-400 lg:bg-red-500\\" style=\\"background-color:rgb(254,202,202)\\"></div></body></html>"',
     );
   });
 
@@ -171,7 +171,7 @@ describe("Responsive styles", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<html lang=\\"en\\"><head><style></style><link/><style>@media(min-width:640px){.sm\\\\:bg-red-500{background-color:rgb(239 68 68 / 1)!important}}</style></head><body><div class=\\"sm:bg-red-500\\" style=\\"background-color:rgb(254 202 202 / 1)\\"></div></body></html>"',
+      '"<html lang=\\"en\\"><head><style></style><link/><style>@media(min-width:640px){.sm\\\\:bg-red-500{background-color:rgb(239,68,68)!important}}</style></head><body><div class=\\"sm:bg-red-500\\" style=\\"background-color:rgb(254,202,202)\\"></div></body></html>"',
     );
   });
 });
@@ -195,7 +195,7 @@ describe("Custom theme config", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<div style=\\"color:rgb(31 182 255 / 1);background-color:rgb(31 182 255 / 1)\\"></div>"',
+      '"<div style=\\"color:rgb(31,182,255);background-color:rgb(31,182,255)\\"></div>"',
     );
   });
 
@@ -362,7 +362,7 @@ describe("<Tailwind> component", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<html dir=\\"ltr\\" lang=\\"en\\"><head><meta content=\\"text/html; charset=UTF-8\\" http-equiv=\\"Content-Type\\"/><style>@media(min-width:640px){.sm\\\\:bg-red-50{background-color:rgb(254 242 242 / 1)!important}.sm\\\\:text-sm{font-size:0.875rem!important;line-height:1.25rem!important}}@media(min-width:768px){.md\\\\:text-lg{font-size:1.125rem!important;line-height:1.75rem!important}}</style></head><span><!--[if mso]><i style=\\"letter-spacing: 10px;mso-font-width:-100%;\\" hidden>&nbsp;</i><![endif]--></span><div class=\\"sm:bg-red-50 sm:text-sm md:text-lg custom-class\\" style=\\"background-color:rgb(255 255 255 / 1)\\"></div></html>"',
+      '"<html dir=\\"ltr\\" lang=\\"en\\"><head><meta content=\\"text/html; charset=UTF-8\\" http-equiv=\\"Content-Type\\"/><style>@media(min-width:640px){.sm\\\\:bg-red-50{background-color:rgb(254,242,242)!important}.sm\\\\:text-sm{font-size:0.875rem!important;line-height:1.25rem!important}}@media(min-width:768px){.md\\\\:text-lg{font-size:1.125rem!important;line-height:1.75rem!important}}</style></head><span><!--[if mso]><i style=\\"letter-spacing: 10px;mso-font-width:-100%;\\" hidden>&nbsp;</i><![endif]--></span><div class=\\"sm:bg-red-50 sm:text-sm md:text-lg custom-class\\" style=\\"background-color:rgb(255,255,255)\\"></div></html>"',
     );
   });
 
@@ -389,7 +389,7 @@ describe("<Tailwind> component", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<html dir=\\"ltr\\" lang=\\"en\\"><head><meta content=\\"text/html; charset=UTF-8\\" http-equiv=\\"Content-Type\\"/><style>@media(min-width:1280px){.xl\\\\:bg-green-500{background-color:rgb(34 197 94 / 1)!important}}@media(min-width:1536px){.\\\\32xl\\\\:bg-blue-500{background-color:rgb(59 130 246 / 1)!important}}</style></head><div class=\\"xl:bg-green-500\\" style=\\"background-color:rgb(254 226 226 / 1)\\">Test</div><div class=\\"2xl:bg-blue-500\\">Test</div></html>"',
+      '"<html dir=\\"ltr\\" lang=\\"en\\"><head><meta content=\\"text/html; charset=UTF-8\\" http-equiv=\\"Content-Type\\"/><style>@media(min-width:1280px){.xl\\\\:bg-green-500{background-color:rgb(34,197,94)!important}}@media(min-width:1536px){.\\\\32xl\\\\:bg-blue-500{background-color:rgb(59,130,246)!important}}</style></head><div class=\\"xl:bg-green-500\\" style=\\"background-color:rgb(254,226,226)\\">Test</div><div class=\\"2xl:bg-blue-500\\">Test</div></html>"',
     );
   });
 
@@ -403,7 +403,7 @@ describe("<Tailwind> component", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<div style=\\"max-height:calc(50px + 3rem);background-color:rgb(254 226 226 / 1)\\"><div style=\\"height:200px\\">something tall</div></div>"',
+      '"<div style=\\"max-height:calc(50px + 3rem);background-color:rgb(254,226,226)\\"><div style=\\"height:200px\\">something tall</div></div>"',
     );
   });
 });

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -133,7 +133,7 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
   const markupCSS = useRgbNonSpacedSyntax(
     getCssForMarkup(markupWithTailwindClasses, config),
   );
-  
+
   const nonMediaQueryCSS = markupCSS.replaceAll(
     /@media\s*\(.*\)\s*{\s*\.(.*)\s*{[\s\S]*}\s*}/gm,
     (mediaQuery, _className) => {

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -9,6 +9,7 @@ import { getCssForMarkup } from "./utils/get-css-for-markup";
 import { minifyCss } from "./utils/minify-css";
 import { getStylesPerClassMap } from "./utils/get-css-class-properties-map";
 import { escapeClassName } from "./utils/escape-class-name";
+import { useRgbNonSpacedSyntax } from "./utils/use-rgb-non-spaced-syntax";
 
 export type TailwindConfig = Omit<TailwindOriginalConfig, "content">;
 
@@ -129,7 +130,9 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
   let headStyles: string[] = [];
 
   const markupWithTailwindClasses = renderToStaticMarkup(<>{children}</>);
-  const markupCSS = getCssForMarkup(markupWithTailwindClasses, config);
+  const markupCSS = useRgbNonSpacedSyntax(
+    getCssForMarkup(markupWithTailwindClasses, config),
+  );
 
   const nonMediaQueryCSS = markupCSS.replaceAll(
     /@media\s*\(.*\)\s*{\s*\.(.*)\s*{[\s\S]*}\s*}/gm,

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -57,8 +57,8 @@ function processElement(
     });
 
     resultingStyle = {
-      ...cssToJsxStyle(styles.join(" ")),
       ...(modifiedElement.props.style as Record<string, string>),
+      ...cssToJsxStyle(styles.join(" ")),
     };
     resultingClassName =
       classNamesToKeep.length > 0 ? classNamesToKeep.join(" ") : undefined;

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -57,8 +57,8 @@ function processElement(
     });
 
     resultingStyle = {
-      ...(modifiedElement.props.style as Record<string, string>),
       ...cssToJsxStyle(styles.join(" ")),
+      ...(modifiedElement.props.style as Record<string, string>),
     };
     resultingClassName =
       classNamesToKeep.length > 0 ? classNamesToKeep.join(" ") : undefined;
@@ -133,7 +133,7 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
   const markupCSS = useRgbNonSpacedSyntax(
     getCssForMarkup(markupWithTailwindClasses, config),
   );
-
+  
   const nonMediaQueryCSS = markupCSS.replaceAll(
     /@media\s*\(.*\)\s*{\s*\.(.*)\s*{[\s\S]*}\s*}/gm,
     (mediaQuery, _className) => {

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -88,6 +88,7 @@ function processElement(
     ...resultingChildren,
   );
 
+  // if this is a component, then we render it and recurse it through processElement
   if (typeof modifiedElement.type === "function") {
     const component = modifiedElement.type as React.FC;
     const renderedComponent = component(modifiedElement.props);

--- a/packages/tailwind/src/utils/css-to-jsx-style.spec.ts
+++ b/packages/tailwind/src/utils/css-to-jsx-style.spec.ts
@@ -11,44 +11,44 @@ gb(37,99,235); padding-left: 0.75rem; padding-right: 0.75rem; padding-top: 0.5re
   `;
   expect(getCssDeclarations(css)).toEqual([
     {
-      property: 'margin-top',
-      value: '2rem'
+      property: "margin-top",
+      value: "2rem",
     },
     {
-      property: 'border-radius',
-      value: '0.375rem'
+      property: "border-radius",
+      value: "0.375rem",
     },
     {
-      property: 'background-color',
-      value: 'rgb(37,99,235)'
+      property: "background-color",
+      value: "rgb(37,99,235)",
     },
     {
-      property: 'padding-left',
-      value: '0.75rem'
+      property: "padding-left",
+      value: "0.75rem",
     },
     {
-      property: 'padding-right',
-      value: '0.75rem'
+      property: "padding-right",
+      value: "0.75rem",
     },
     {
-      property: 'padding-top',
-      value: '0.5rem'
+      property: "padding-top",
+      value: "0.5rem",
     },
     {
-      property: 'padding-bottom',
-      value: '0.5rem'
+      property: "padding-bottom",
+      value: "0.5rem",
     },
     {
-      property: 'font-size',
-      value: '0.875rem'
+      property: "font-size",
+      value: "0.875rem",
     },
     {
-      property: 'line-height',
-      value: '1.25rem'
+      property: "line-height",
+      value: "1.25rem",
     },
     {
-      property: 'color',
-      value: 'rgb(229,231,235)'
+      property: "color",
+      value: "rgb(229,231,235)",
     },
   ]);
 });

--- a/packages/tailwind/src/utils/css-to-jsx-style.spec.ts
+++ b/packages/tailwind/src/utils/css-to-jsx-style.spec.ts
@@ -1,7 +1,56 @@
-import { cssToJsxStyle } from "./css-to-jsx-style";
+import { cssToJsxStyle, getCssDeclarations } from "./css-to-jsx-style";
 
 test("transforms a rule", () => {
   expect(cssToJsxStyle("color: red")).toEqual({ color: "red" });
+});
+
+test("getCssDeclarations()", () => {
+  const css = `
+margin-top: 2rem; border-radius: 0.375rem; background-color: r
+gb(37,99,235); padding-left: 0.75rem; padding-right: 0.75rem; padding-top: 0.5rem; padding-bottom: 0.5rem; font-size: 0.875rem; line-height: 1.25rem; color: rgb(229,231,235);
+  `;
+  expect(getCssDeclarations(css)).toEqual([
+    {
+      property: 'margin-top',
+      value: '2rem'
+    },
+    {
+      property: 'border-radius',
+      value: '0.375rem'
+    },
+    {
+      property: 'background-color',
+      value: 'rgb(37,99,235)'
+    },
+    {
+      property: 'padding-left',
+      value: '0.75rem'
+    },
+    {
+      property: 'padding-right',
+      value: '0.75rem'
+    },
+    {
+      property: 'padding-top',
+      value: '0.5rem'
+    },
+    {
+      property: 'padding-bottom',
+      value: '0.5rem'
+    },
+    {
+      property: 'font-size',
+      value: '0.875rem'
+    },
+    {
+      property: 'line-height',
+      value: '1.25rem'
+    },
+    {
+      property: 'color',
+      value: 'rgb(229,231,235)'
+    },
+  ]);
 });
 
 test("transforms multiple rules", () => {

--- a/packages/tailwind/src/utils/css-to-jsx-style.ts
+++ b/packages/tailwind/src/utils/css-to-jsx-style.ts
@@ -23,12 +23,19 @@ const convertPropertyName = (prop: string) => {
   return camelCase(modifiedProp);
 };
 
+export const getCssDeclarations = (cssText: string) => {
+  return Array.from(cssText.matchAll(
+    /([a-zA-Z0-9\-_]+)\s*:\s*('[^']*'[^;]*|"[^"]*"[^;]*|[^;]*?\([^)]*\)[^;]*|[^;(]*);?/gm,
+  )).map(([_declaration, property, value]) => ({
+    property, value: value.replaceAll(/[\r\n|\r|\n]+/g, "")
+      .replaceAll(/\s+/g, " ")
+  }));
+};
+
 export const cssToJsxStyle = (cssText: string) => {
   const style: Record<string, string> = {};
-  const declarations = cssText.matchAll(
-    /([a-zA-Z0-9\-_]+)\s*:\s*('[^']*'[^;]*|"[^"]*"[^;]*|.*?\([^)]*\)[^;]*|[^;]*);?/gm,
-  );
-  for (const [_declaration, property, value] of declarations) {
+  const declarations = getCssDeclarations(cssText);
+  for (const { property, value } of declarations) {
     if (property.length > 0 && value.trim().length > 0) {
       style[convertPropertyName(property)] = value.trim();
     }

--- a/packages/tailwind/src/utils/css-to-jsx-style.ts
+++ b/packages/tailwind/src/utils/css-to-jsx-style.ts
@@ -24,11 +24,13 @@ const convertPropertyName = (prop: string) => {
 };
 
 export const getCssDeclarations = (cssText: string) => {
-  return Array.from(cssText.matchAll(
-    /([a-zA-Z0-9\-_]+)\s*:\s*('[^']*'[^;]*|"[^"]*"[^;]*|[^;]*?\([^)]*\)[^;]*|[^;(]*);?/gm,
-  )).map(([_declaration, property, value]) => ({
-    property, value: value.replaceAll(/[\r\n|\r|\n]+/g, "")
-      .replaceAll(/\s+/g, " ")
+  return Array.from(
+    cssText.matchAll(
+      /([a-zA-Z0-9\-_]+)\s*:\s*('[^']*'[^;]*|"[^"]*"[^;]*|[^;]*?\([^)]*\)[^;]*|[^;(]*);?/gm,
+    ),
+  ).map(([_declaration, property, value]) => ({
+    property,
+    value: value.replaceAll(/[\r\n|\r|\n]+/g, "").replaceAll(/\s+/g, " "),
   }));
 };
 

--- a/packages/tailwind/src/utils/get-css-for-markup.ts
+++ b/packages/tailwind/src/utils/get-css-for-markup.ts
@@ -2,8 +2,8 @@ import tailwindcss from "tailwindcss";
 import type { CorePluginsConfig } from "tailwindcss/types/config";
 import postcssCssVariables from "postcss-css-variables";
 import type { TailwindConfig } from "../tailwind";
-// this is to avoid Server Action problems
 
+// this is to avoid Server Action problems
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports, @typescript-eslint/no-var-requires
 const postcss = require("postcss") as import("postcss").Postcss;
 

--- a/packages/tailwind/src/utils/get-css-for-markup.ts
+++ b/packages/tailwind/src/utils/get-css-for-markup.ts
@@ -1,4 +1,5 @@
-import postcss from "postcss";
+// this is to avoid Server Action problems
+const postcss = require("postcss");
 import tailwindcss from "tailwindcss";
 import type { CorePluginsConfig } from "tailwindcss/types/config";
 import postcssCssVariables from "postcss-css-variables";
@@ -43,5 +44,5 @@ export const getCssForMarkup = (
       `,
     { from: undefined }, // no need to use from since the `content` context is sent into tailwind
   );
-  return result.css;
+  return result.css as string;
 };

--- a/packages/tailwind/src/utils/get-css-for-markup.ts
+++ b/packages/tailwind/src/utils/get-css-for-markup.ts
@@ -1,9 +1,11 @@
-// this is to avoid Server Action problems
-const postcss = require("postcss");
 import tailwindcss from "tailwindcss";
 import type { CorePluginsConfig } from "tailwindcss/types/config";
 import postcssCssVariables from "postcss-css-variables";
 import type { TailwindConfig } from "../tailwind";
+// this is to avoid Server Action problems
+ 
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports, @typescript-eslint/no-var-requires
+const postcss = require("postcss") as import('postcss').Postcss;
 
 declare global {
   // eslint-disable-next-line no-var
@@ -44,5 +46,5 @@ export const getCssForMarkup = (
       `,
     { from: undefined }, // no need to use from since the `content` context is sent into tailwind
   );
-  return result.css as string;
+  return result.css;
 };

--- a/packages/tailwind/src/utils/get-css-for-markup.ts
+++ b/packages/tailwind/src/utils/get-css-for-markup.ts
@@ -3,9 +3,9 @@ import type { CorePluginsConfig } from "tailwindcss/types/config";
 import postcssCssVariables from "postcss-css-variables";
 import type { TailwindConfig } from "../tailwind";
 // this is to avoid Server Action problems
- 
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports, @typescript-eslint/no-var-requires
-const postcss = require("postcss") as import('postcss').Postcss;
+const postcss = require("postcss") as import("postcss").Postcss;
 
 declare global {
   // eslint-disable-next-line no-var

--- a/packages/tailwind/src/utils/minify-css.ts
+++ b/packages/tailwind/src/utils/minify-css.ts
@@ -1,7 +1,8 @@
 export const minifyCss = (css: string): string => {
+  // Thanks tw-to-css!
+  // from https://github.com/vinicoder/tw-to-css/blob/main/src/util/format-css.ts
   return (
     css
-
       // Remove comments
       .replace(/\/\*[\s\S]*?\*\//gm, "")
 

--- a/packages/tailwind/src/utils/use-rgb-non-spaced-syntax.spec.ts
+++ b/packages/tailwind/src/utils/use-rgb-non-spaced-syntax.spec.ts
@@ -1,0 +1,12 @@
+import { useRgbNonSpacedSyntax } from "./use-rgb-non-spaced-syntax";
+
+test("useRgbNonSpacedSyntax", () => {
+  const css = `.bg-red-500{
+  background-color: rgb(239 68 68 / 1);
+  color: rgb(239 68 68 / 0.1)
+}`;
+  expect(useRgbNonSpacedSyntax(css)).toBe(`.bg-red-500{
+  background-color: rgb(239,68,68);
+  color: rgb(239,68,68,0.1)
+}`);
+});

--- a/packages/tailwind/src/utils/use-rgb-non-spaced-syntax.ts
+++ b/packages/tailwind/src/utils/use-rgb-non-spaced-syntax.ts
@@ -1,0 +1,16 @@
+/**
+ * This is to avoid problems on email clients that don't allow for spaced syntax on
+ * rgb.
+ *
+ * See https://www.caniemail.com/features/css-rgb/
+ */
+export const useRgbNonSpacedSyntax = (css: string) => {
+  // Thanks tw-to-css!
+  // from https://github.com/vinicoder/tw-to-css/blob/main/src/util/format-css.ts
+  const regex = /rgb\(\s*(\d+)\s*(\d+)\s*(\d+)(?:\s*\/\s*([\d%.]+))?\s*\)/gm;
+
+  return css.replaceAll(regex, (_match, r, g, b, a) => {
+    const alpha = a === "1" || typeof a === "undefined" ? "" : `,${a}`;
+    return `rgb(${r},${g},${b}${alpha})`;
+  });
+};

--- a/packages/tailwind/tsconfig.json
+++ b/packages/tailwind/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "tsconfig/react-library.json",
   "include": ["."],
   "exclude": ["dist", "build", "node_modules"],

--- a/packages/tailwind/tsup.config.ts
+++ b/packages/tailwind/tsup.config.ts
@@ -1,15 +1,15 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['cjs', 'esm'],
-  external: ['react'],
-  target: 'es2020',
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  external: ["react"],
+  target: "es2020",
 
   dts: true,
 
   // we need to bundle these two in because of the pnpm patches
   // we apply to them to fix issues and make the experience
   // for the component smoother
-  noExternal: ['tailwindcss', 'postcss-css-variables']
+  noExternal: ["tailwindcss", "postcss-css-variables"],
 });

--- a/packages/tailwind/tsup.config.ts
+++ b/packages/tailwind/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  external: ['react'],
+  target: 'es2020',
+
+  dts: true,
+
+  // we need to bundle these two in because of the pnpm patches
+  // we apply to them to fix issues and make the experience
+  // for the component smoother
+  noExternal: ['tailwindcss', 'postcss-css-variables']
+});

--- a/patches/tailwindcss@3.3.2.patch
+++ b/patches/tailwindcss@3.3.2.patch
@@ -1,0 +1,33 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index fd899dc532aad7a64d72a4150b522fe77893af47..0000000000000000000000000000000000000000
+diff --git a/lib/util/validateConfig.js b/lib/util/validateConfig.js
+index 8624025be3f577a00e041543670c54729d8e16db..6148dec3f5ec0482b138be297014644ff11f707e 100644
+--- a/lib/util/validateConfig.js
++++ b/lib/util/validateConfig.js
+@@ -23,15 +23,15 @@ function validateConfig(config) {
+         ]);
+     }
+     // Warn if the line-clamp plugin is installed
+-    try {
+-        let plugin = require("@tailwindcss/line-clamp");
+-        if (config.plugins.includes(plugin)) {
+-            _log.default.warn("line-clamp-in-core", [
+-                "As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.",
+-                "Remove it from the `plugins` array in your configuration to eliminate this warning."
+-            ]);
+-            config.plugins = config.plugins.filter((p)=>p !== plugin);
+-        }
+-    } catch  {}
++    // try {
++    //     let plugin = require("@tailwindcss/line-clamp");
++    //     if (config.plugins.includes(plugin)) {
++    //         _log.default.warn("line-clamp-in-core", [
++    //             "As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.",
++    //             "Remove it from the `plugins` array in your configuration to eliminate this warning."
++    //         ]);
++    //         config.plugins = config.plugins.filter((p)=>p !== plugin);
++    //     }
++    // } catch  {}
+     return config;
+ }

--- a/patches/tailwindcss@3.3.2.patch
+++ b/patches/tailwindcss@3.3.2.patch
@@ -1,6 +1,30 @@
 diff --git a/CHANGELOG.md b/CHANGELOG.md
 deleted file mode 100644
 index fd899dc532aad7a64d72a4150b522fe77893af47..0000000000000000000000000000000000000000
+diff --git a/lib/cli/build/deps.js b/lib/cli/build/deps.js
+deleted file mode 100644
+index 1aa8116365aaaea5697382c8cabef9f17486a24b..0000000000000000000000000000000000000000
+diff --git a/lib/cli/build/index.js b/lib/cli/build/index.js
+deleted file mode 100644
+index 60304f69673670c1828dc0816986bb11cabd5f23..0000000000000000000000000000000000000000
+diff --git a/lib/cli/build/plugin.js b/lib/cli/build/plugin.js
+deleted file mode 100644
+index d36ac019cd17744028fc5d96465880cfb42a44c6..0000000000000000000000000000000000000000
+diff --git a/lib/cli/build/utils.js b/lib/cli/build/utils.js
+deleted file mode 100644
+index 3bed06041d7abf44044256b5fc2a807b8205587f..0000000000000000000000000000000000000000
+diff --git a/lib/cli/build/watching.js b/lib/cli/build/watching.js
+deleted file mode 100644
+index 0c2ef7689a5c8a7359ed2e2167f8a90fb606665f..0000000000000000000000000000000000000000
+diff --git a/lib/cli/help/index.js b/lib/cli/help/index.js
+deleted file mode 100644
+index 030997fab28d0f2b570f43898f1fd9c74b7486a9..0000000000000000000000000000000000000000
+diff --git a/lib/cli/index.js b/lib/cli/index.js
+deleted file mode 100644
+index e6e2e27c78fea167c19fcdada6a2e8d4065e27ca..0000000000000000000000000000000000000000
+diff --git a/lib/cli/init/index.js b/lib/cli/init/index.js
+deleted file mode 100644
+index 47caf30abcbd11043b2f8f1f36893e5e51271552..0000000000000000000000000000000000000000
 diff --git a/lib/util/validateConfig.js b/lib/util/validateConfig.js
 index 8624025be3f577a00e041543670c54729d8e16db..6148dec3f5ec0482b138be297014644ff11f707e 100644
 --- a/lib/util/validateConfig.js
@@ -31,3 +55,21 @@ index 8624025be3f577a00e041543670c54729d8e16db..6148dec3f5ec0482b138be297014644f
 +    // } catch  {}
      return config;
  }
+diff --git a/scripts/create-plugin-list.js b/scripts/create-plugin-list.js
+deleted file mode 100644
+index f38cf5036e39cd1b3da8f846b35b844c9d87a4fc..0000000000000000000000000000000000000000
+diff --git a/scripts/generate-types.js b/scripts/generate-types.js
+deleted file mode 100644
+index d3e0d303eefc05d592ac7c2b2332b48388474f0f..0000000000000000000000000000000000000000
+diff --git a/scripts/release-channel.js b/scripts/release-channel.js
+deleted file mode 100644
+index 0c827f3fda8c55e90ed6267c633c8c6bd8ab1a21..0000000000000000000000000000000000000000
+diff --git a/scripts/release-notes.js b/scripts/release-notes.js
+deleted file mode 100644
+index bd29e952d889f72860faa9c744a0b90d59688140..0000000000000000000000000000000000000000
+diff --git a/scripts/swap-engines.js b/scripts/swap-engines.js
+deleted file mode 100644
+index ef8308aeb8515bb27f7b6c22f9821d1d9eaee905..0000000000000000000000000000000000000000
+diff --git a/scripts/type-utils.js b/scripts/type-utils.js
+deleted file mode 100644
+index d9d0e6133c7644d4ad29f1708ee34c15b0811694..0000000000000000000000000000000000000000

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
         version: link:packages/tsconfig
       tsup:
         specifier: 7.2.0
-        version: 7.2.0
+        version: 7.2.0(postcss@8.4.31)(typescript@5.1.6)
       turbo:
         specifier: 1.10.14
         version: 1.10.14
@@ -278,7 +278,7 @@ importers:
         specifier: 0.0.10
         version: link:../section
       '@react-email/tailwind':
-        specifier: 0.0.13-canary.1
+        specifier: 0.0.13-canary.2
         version: link:../tailwind
       '@react-email/text':
         specifier: 0.0.6
@@ -6461,41 +6461,6 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
-
-  /tsup@7.2.0:
-    resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
-    engines: {node: '>=16.14'}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.1.0'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 4.0.2(esbuild@0.18.20)
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4
-      esbuild: 0.18.20
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 4.0.1(postcss@8.4.26)
-      resolve-from: 5.0.0
-      rollup: 3.29.4
-      source-map: 0.8.0-beta.0
-      sucrase: 3.34.0
-      tree-kill: 1.2.2
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    dev: true
 
   /tsup@7.2.0(postcss@8.4.31)(typescript@5.1.6):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,7 +278,7 @@ importers:
         specifier: 0.0.10
         version: link:../section
       '@react-email/tailwind':
-        specifier: 0.0.13-canary.3
+        specifier: 0.0.13-canary.4
         version: link:../tailwind
       '@react-email/text':
         specifier: 0.0.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: 2wxqv7k2gzlwmmem3fifiqjawa
     path: patches/postcss-css-variables@0.19.0.patch
   tailwindcss@3.3.2:
-    hash: my57d4zbnceffnwfeovs2acie4
+    hash: 2ecqyyb3nnd4sclcv6omjvweii
     path: patches/tailwindcss@3.3.2.patch
 
 importers:
@@ -39,7 +39,7 @@ importers:
         version: link:packages/tsconfig
       tsup:
         specifier: 7.2.0
-        version: 7.2.0
+        version: 7.2.0(postcss@8.4.31)(typescript@5.1.6)
       turbo:
         specifier: 1.10.14
         version: 1.10.14
@@ -758,7 +758,7 @@ importers:
         version: 0.19.0(patch_hash=2wxqv7k2gzlwmmem3fifiqjawa)(postcss@8.4.31)
       tailwindcss:
         specifier: 3.3.2
-        version: 3.3.2(patch_hash=my57d4zbnceffnwfeovs2acie4)
+        version: 3.3.2(patch_hash=2ecqyyb3nnd4sclcv6omjvweii)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -6297,7 +6297,7 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /tailwindcss@3.3.2(patch_hash=my57d4zbnceffnwfeovs2acie4):
+  /tailwindcss@3.3.2(patch_hash=2ecqyyb3nnd4sclcv6omjvweii):
     resolution: {integrity: sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==}
     engines: {node: '>=14.0.0'}
     hasBin: true
@@ -6465,41 +6465,6 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsup@7.2.0:
-    resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
-    engines: {node: '>=16.14'}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.1.0'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 4.0.2(esbuild@0.18.20)
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4
-      esbuild: 0.18.20
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 4.0.1(postcss@8.4.26)
-      resolve-from: 5.0.0
-      rollup: 3.29.4
-      source-map: 0.8.0-beta.0
-      sucrase: 3.34.0
-      tree-kill: 1.2.2
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    dev: true
-
   /tsup@7.2.0(postcss@8.4.31)(typescript@5.1.6):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
     engines: {node: '>=16.14'}
@@ -6613,7 +6578,7 @@ packages:
     dependencies:
       postcss: 8.4.31
       postcss-css-variables: 0.18.0(postcss@8.4.31)
-      tailwindcss: 3.3.2(patch_hash=my57d4zbnceffnwfeovs2acie4)
+      tailwindcss: 3.3.2(patch_hash=2ecqyyb3nnd4sclcv6omjvweii)
     transitivePeerDependencies:
       - ts-node
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
         version: link:packages/tsconfig
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(postcss@8.4.31)(typescript@5.1.6)
+        version: 7.2.0
       turbo:
         specifier: 1.10.14
         version: 1.10.14
@@ -759,6 +759,9 @@ importers:
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
+      tsup:
+        specifier: 7.2.0
+        version: 7.2.0(postcss@8.4.31)(typescript@5.1.6)
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -6458,6 +6461,41 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+
+  /tsup@7.2.0:
+    resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
+    engines: {node: '>=16.14'}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.1.0'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 4.0.2(esbuild@0.18.20)
+      cac: 6.7.14
+      chokidar: 3.5.3
+      debug: 4.3.4
+      esbuild: 0.18.20
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 4.0.1(postcss@8.4.26)
+      resolve-from: 5.0.0
+      rollup: 3.29.4
+      source-map: 0.8.0-beta.0
+      sucrase: 3.34.0
+      tree-kill: 1.2.2
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
 
   /tsup@7.2.0(postcss@8.4.31)(typescript@5.1.6):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,7 +278,7 @@ importers:
         specifier: 0.0.10
         version: link:../section
       '@react-email/tailwind':
-        specifier: 0.0.13-canary.2
+        specifier: 0.0.13-canary.3
         version: link:../tailwind
       '@react-email/text':
         specifier: 0.0.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   postcss-css-variables@0.19.0:
     hash: 2wxqv7k2gzlwmmem3fifiqjawa
     path: patches/postcss-css-variables@0.19.0.patch
+  tailwindcss@3.3.2:
+    hash: my57d4zbnceffnwfeovs2acie4
+    path: patches/tailwindcss@3.3.2.patch
 
 importers:
 
@@ -713,18 +716,12 @@ importers:
       postcss:
         specifier: 8.4.31
         version: 8.4.31
-      postcss-css-variables:
-        specifier: 0.19.0
-        version: 0.19.0(patch_hash=2wxqv7k2gzlwmmem3fifiqjawa)(postcss@8.4.31)
       react:
         specifier: 18.2.0
         version: 18.2.0
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
-      tailwindcss:
-        specifier: 3.3.2
-        version: 3.3.2
     devDependencies:
       '@babel/core':
         specifier: 7.21.8
@@ -753,6 +750,12 @@ importers:
       eslint-plugin-regex:
         specifier: 1.10.0
         version: 1.10.0(eslint@8.50.0)
+      postcss-css-variables:
+        specifier: 0.19.0
+        version: 0.19.0(patch_hash=2wxqv7k2gzlwmmem3fifiqjawa)(postcss@8.4.31)
+      tailwindcss:
+        specifier: 3.3.2
+        version: 3.3.2(patch_hash=my57d4zbnceffnwfeovs2acie4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -3917,7 +3920,6 @@ packages:
 
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-    dev: false
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -5475,7 +5477,7 @@ packages:
       escape-string-regexp: 1.0.5
       extend: 3.0.2
       postcss: 8.4.31
-    dev: false
+    dev: true
     patched: true
 
   /postcss-import@15.1.0(postcss@8.4.26):
@@ -5500,7 +5502,6 @@ packages:
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.6
-    dev: false
 
   /postcss-js@4.0.1(postcss@8.4.26):
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
@@ -5520,7 +5521,6 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.31
-    dev: false
 
   /postcss-load-config@4.0.1(postcss@8.4.26):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
@@ -5573,7 +5573,6 @@ packages:
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
-    dev: false
 
   /postcss-selector-parser@6.0.13:
     resolution: {integrity: sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==}
@@ -6292,7 +6291,7 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /tailwindcss@3.3.2:
+  /tailwindcss@3.3.2(patch_hash=my57d4zbnceffnwfeovs2acie4):
     resolution: {integrity: sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==}
     engines: {node: '>=14.0.0'}
     hasBin: true
@@ -6322,7 +6321,7 @@ packages:
       sucrase: 3.34.0
     transitivePeerDependencies:
       - ts-node
-    dev: false
+    patched: true
 
   /tailwindcss@3.3.3:
     resolution: {integrity: sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==}
@@ -6573,7 +6572,7 @@ packages:
     dependencies:
       postcss: 8.4.31
       postcss-css-variables: 0.18.0(postcss@8.4.31)
-      tailwindcss: 3.3.2
+      tailwindcss: 3.3.2(patch_hash=my57d4zbnceffnwfeovs2acie4)
     transitivePeerDependencies:
       - ts-node
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
         version: link:packages/tsconfig
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(postcss@8.4.31)(typescript@5.1.6)
+        version: 7.2.0
       turbo:
         specifier: 1.10.14
         version: 1.10.14
@@ -729,6 +729,9 @@ importers:
       '@babel/preset-react':
         specifier: 7.22.5
         version: 7.22.5(@babel/core@7.21.8)
+      '@react-email/button':
+        specifier: workspace:^
+        version: link:../button
       '@react-email/head':
         specifier: workspace:*
         version: link:../head
@@ -6461,6 +6464,41 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+
+  /tsup@7.2.0:
+    resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
+    engines: {node: '>=16.14'}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.1.0'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 4.0.2(esbuild@0.18.20)
+      cac: 6.7.14
+      chokidar: 3.5.3
+      debug: 4.3.4
+      esbuild: 0.18.20
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 4.0.1(postcss@8.4.26)
+      resolve-from: 5.0.0
+      rollup: 3.29.4
+      source-map: 0.8.0-beta.0
+      sucrase: 3.34.0
+      tree-kill: 1.2.2
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
 
   /tsup@7.2.0(postcss@8.4.31)(typescript@5.1.6):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}


### PR DESCRIPTION
This fixes problems a user from Discord had with server actions and bundles the packages
that we have fixed internally through patches so that the patches are sent to the users
and so that the Tailwind component works the same for users as it does running in dev locally.

This also replaces all `rgb(red green blue / alpha)` with `rgb(red,green,blue,alpha)` that works better for some more email clients like gmail.

Now fixes a parsing problem we had when generating the object for the styles and another problem that was happening with vite builds due to tailwind's CLI code being bundled in as well.