### PR TITLE
docs(resend): update resend code example

### DIFF
--- a/docs/integrations/resend.mdx
+++ b/docs/integrations/resend.mdx
@@ -61,7 +61,7 @@ import { Email } from './email';
 
 const resend = new Resend('re_123456789');
 
-resend.sendEmail({
+await resend.emails.send({
   from: 'you@example.com',
   to: 'user@gmail.com',
   subject: 'hello world',


### PR DESCRIPTION
I think the docs for Resend integration is using an outdated version. According to the https://resend.com/docs/api-reference/emails/send-email it's now

```js
import { Resend } from 'resend';

const resend = new Resend('re_123456789');

await resend.emails.send({
  from: 'Acme <onboarding@resend.dev>',
  to: ['delivered@resend.dev'],
  subject: 'hello world',
  text: 'it works!',
  attachments: [
    {
      filename: 'invoice.pdf',
      content: invoiceBuffer,
    },
  ],
  headers: {
    'X-Entity-Ref-ID': '123456789',
  },
  tags: [
    {
      name: 'category',
      value: 'confirm_email',
    },
  ],
});
```