### PR TITLE
fix(tailwind): line-clamp module not found for next

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "pnpm": {
     "patchedDependencies": {
       "postcss-css-variables@0.19.0": "patches/postcss-css-variables@0.19.0.patch",
-      "process@0.11.10": "patches/process@0.11.10.patch"
+      "process@0.11.10": "patches/process@0.11.10.patch",
+      "tailwindcss@3.3.2": "patches/tailwindcss@3.3.2.patch"
     }
   }
 }

--- a/packages/tailwind/vite.config.ts
+++ b/packages/tailwind/vite.config.ts
@@ -16,6 +16,13 @@ export default defineConfig({
   ],
   build: {
     rollupOptions: {
+      // in summary, this bundles the following since vite defaults to bundling
+      // - tailwindcss
+      // - postcss
+      // - postcss-css-variables
+      // - polyfill libraries
+      //   - process
+      //   - memfs
       external: ["react", "react-dom", /react-dom\/.*/],
     },
     lib: {

--- a/patches/tailwindcss@3.3.2.patch
+++ b/patches/tailwindcss@3.3.2.patch
@@ -1,0 +1,354 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index fd899dc532aad7a64d72a4150b522fe77893af47..0000000000000000000000000000000000000000
+diff --git a/lib/util/validateConfig.js b/lib/util/validateConfig.js
+index 8624025be3f577a00e041543670c54729d8e16db..f3d369cea4667aea94a45ffa13b0cdfaa0c74123 100644
+--- a/lib/util/validateConfig.js
++++ b/lib/util/validateConfig.js
+@@ -22,16 +22,18 @@ function validateConfig(config) {
+             "https://tailwindcss.com/docs/content-configuration"
+         ]);
+     }
++    // Commented this out since this hack doesn't work properly with Nextjs 
++    //
+     // Warn if the line-clamp plugin is installed
+-    try {
+-        let plugin = require("@tailwindcss/line-clamp");
+-        if (config.plugins.includes(plugin)) {
+-            _log.default.warn("line-clamp-in-core", [
+-                "As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.",
+-                "Remove it from the `plugins` array in your configuration to eliminate this warning."
+-            ]);
+-            config.plugins = config.plugins.filter((p)=>p !== plugin);
+-        }
+-    } catch  {}
++    // try {
++    //     let plugin = require("@tailwindcss/line-clamp");
++    //     if (config.plugins.includes(plugin)) {
++    //         _log.default.warn("line-clamp-in-core", [
++    //             "As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.",
++    //             "Remove it from the `plugins` array in your configuration to eliminate this warning."
++    //         ]);
++    //         config.plugins = config.plugins.filter((p)=>p !== plugin);
++    //     }
++    // } catch  {}
+     return config;
+ }
+diff --git a/src/cli/build/deps.js b/src/cli/build/deps.js
+deleted file mode 100644
+index 9435b929a2bc0ac9aab69ec93cddeb5006f065b4..0000000000000000000000000000000000000000
+diff --git a/src/cli/build/index.js b/src/cli/build/index.js
+deleted file mode 100644
+index 62c020e59f1a3f1cddea5a579bf47c271ce2aa62..0000000000000000000000000000000000000000
+diff --git a/src/cli/build/plugin.js b/src/cli/build/plugin.js
+deleted file mode 100644
+index 9f3f6f52ff27be0b37900a9be59ca16f4bc24d36..0000000000000000000000000000000000000000
+diff --git a/src/cli/build/utils.js b/src/cli/build/utils.js
+deleted file mode 100644
+index 3462a97935bb6782161c043cc3685e88033d9bd7..0000000000000000000000000000000000000000
+diff --git a/src/cli/build/watching.js b/src/cli/build/watching.js
+deleted file mode 100644
+index e69cd9f8598ca8112090013c1aa12013d5548531..0000000000000000000000000000000000000000
+diff --git a/src/cli/help/index.js b/src/cli/help/index.js
+deleted file mode 100644
+index ea4137a10d4c4877f97b73f3854926ef05364f6c..0000000000000000000000000000000000000000
+diff --git a/src/cli/index.js b/src/cli/index.js
+deleted file mode 100644
+index fc1497f6272e552abf2755e2fd97b04db5dcf46f..0000000000000000000000000000000000000000
+diff --git a/src/cli/init/index.js b/src/cli/init/index.js
+deleted file mode 100644
+index 6bd7e41e2ced5a41b255c30ce8113393f2f19c42..0000000000000000000000000000000000000000
+diff --git a/src/cli-peer-dependencies.js b/src/cli-peer-dependencies.js
+deleted file mode 100644
+index 6b9f986aab286e2683e2594740c24d27b3fbb794..0000000000000000000000000000000000000000
+diff --git a/src/cli.js b/src/cli.js
+deleted file mode 100644
+index 4b73accbbbdd90a142a5d8b1777b150d01767897..0000000000000000000000000000000000000000
+diff --git a/src/corePluginList.js b/src/corePluginList.js
+deleted file mode 100644
+index f172ceb7b1e415e149465503273ee412d107fe37..0000000000000000000000000000000000000000
+diff --git a/src/corePlugins.js b/src/corePlugins.js
+deleted file mode 100644
+index e4d2ff279a305f2d1d20b484fc9da4f4f4f37be5..0000000000000000000000000000000000000000
+diff --git a/src/css/LICENSE b/src/css/LICENSE
+deleted file mode 100644
+index a1fb0394c924dc25311888ab85a5a5a1b4b9f20c..0000000000000000000000000000000000000000
+diff --git a/src/css/preflight.css b/src/css/preflight.css
+deleted file mode 100644
+index fab875d9590456f1767a8028d7ea8c22ebab4f2f..0000000000000000000000000000000000000000
+diff --git a/src/featureFlags.js b/src/featureFlags.js
+deleted file mode 100644
+index dc9f2d7c46e2bfddb01c661660469a46405979f7..0000000000000000000000000000000000000000
+diff --git a/src/index.js b/src/index.js
+deleted file mode 100644
+index d0b329bf22968d832868bc0fe1f7814bef1fc535..0000000000000000000000000000000000000000
+diff --git a/src/lib/cacheInvalidation.js b/src/lib/cacheInvalidation.js
+deleted file mode 100644
+index fa13702e8897afb00134e6584162c81a608c7f8a..0000000000000000000000000000000000000000
+diff --git a/src/lib/collapseAdjacentRules.js b/src/lib/collapseAdjacentRules.js
+deleted file mode 100644
+index 119f59226f4d668bdfef2beef89521a350a6707c..0000000000000000000000000000000000000000
+diff --git a/src/lib/collapseDuplicateDeclarations.js b/src/lib/collapseDuplicateDeclarations.js
+deleted file mode 100644
+index d310d58b88b6a1b7b30b0154bfd68786b70af4c3..0000000000000000000000000000000000000000
+diff --git a/src/lib/content.js b/src/lib/content.js
+deleted file mode 100644
+index e814efe4d34ea773551212267c698a41f851a96b..0000000000000000000000000000000000000000
+diff --git a/src/lib/defaultExtractor.js b/src/lib/defaultExtractor.js
+deleted file mode 100644
+index 6382ca7cf3dc103f693d488b131f6e2e80f4e4bc..0000000000000000000000000000000000000000
+diff --git a/src/lib/detectNesting.js b/src/lib/detectNesting.js
+deleted file mode 100644
+index 03252e2006bbce390b668519c44325589cff6f8a..0000000000000000000000000000000000000000
+diff --git a/src/lib/evaluateTailwindFunctions.js b/src/lib/evaluateTailwindFunctions.js
+deleted file mode 100644
+index 7e04ef42817418597449f1fed226a07bc824d6a7..0000000000000000000000000000000000000000
+diff --git a/src/lib/expandApplyAtRules.js b/src/lib/expandApplyAtRules.js
+deleted file mode 100644
+index 3763809e003e8f809aaa2ae754acabee73eb232e..0000000000000000000000000000000000000000
+diff --git a/src/lib/expandTailwindAtRules.js b/src/lib/expandTailwindAtRules.js
+deleted file mode 100644
+index bf7d8f17f8eda2169a17f75fa7cc902e8b731789..0000000000000000000000000000000000000000
+diff --git a/src/lib/findAtConfigPath.js b/src/lib/findAtConfigPath.js
+deleted file mode 100644
+index ac0adab456980f10b2f420a7abf3b9ada03ff70e..0000000000000000000000000000000000000000
+diff --git a/src/lib/generateRules.js b/src/lib/generateRules.js
+deleted file mode 100644
+index 60da2323fc945c3b82db3ce0676f3f636b5eedae..0000000000000000000000000000000000000000
+diff --git a/src/lib/getModuleDependencies.js b/src/lib/getModuleDependencies.js
+deleted file mode 100644
+index e6a38a89d21f3e278db3c5d97043eccd156dae28..0000000000000000000000000000000000000000
+diff --git a/src/lib/load-config.ts b/src/lib/load-config.ts
+deleted file mode 100644
+index 645e8e1d55c4c6d91e001124eafea727f6892133..0000000000000000000000000000000000000000
+diff --git a/src/lib/normalizeTailwindDirectives.js b/src/lib/normalizeTailwindDirectives.js
+deleted file mode 100644
+index 3349a7e3a3da0de96f7b002d695059e2443e25ce..0000000000000000000000000000000000000000
+diff --git a/src/lib/offsets.js b/src/lib/offsets.js
+deleted file mode 100644
+index a43ebe4f36b8fe0eb31e807b818597507a87c3af..0000000000000000000000000000000000000000
+diff --git a/src/lib/partitionApplyAtRules.js b/src/lib/partitionApplyAtRules.js
+deleted file mode 100644
+index 34813c695799e026270b8e79cf35f02a06329ac9..0000000000000000000000000000000000000000
+diff --git a/src/lib/regex.js b/src/lib/regex.js
+deleted file mode 100644
+index 5db7657be7cd037a8ce94981abaf36ca75242b33..0000000000000000000000000000000000000000
+diff --git a/src/lib/remap-bitfield.js b/src/lib/remap-bitfield.js
+deleted file mode 100644
+index 3ddaf20234c4007cb4d88174944600e205fa153a..0000000000000000000000000000000000000000
+diff --git a/src/lib/resolveDefaultsAtRules.js b/src/lib/resolveDefaultsAtRules.js
+deleted file mode 100644
+index 389ea4bacac7880d45562ab4fc4f49579b1ef587..0000000000000000000000000000000000000000
+diff --git a/src/lib/setupContextUtils.js b/src/lib/setupContextUtils.js
+deleted file mode 100644
+index 0749da68dbdc5a02708ea486147b1b4d2c63e2d7..0000000000000000000000000000000000000000
+diff --git a/src/lib/setupTrackingContext.js b/src/lib/setupTrackingContext.js
+deleted file mode 100644
+index 2b281377d5f1a351a0aafe4cd5bf474fa5279c2f..0000000000000000000000000000000000000000
+diff --git a/src/lib/sharedState.js b/src/lib/sharedState.js
+deleted file mode 100644
+index 97bdf09c5c43255333d9335bc5d47755fe8150de..0000000000000000000000000000000000000000
+diff --git a/src/lib/substituteScreenAtRules.js b/src/lib/substituteScreenAtRules.js
+deleted file mode 100644
+index 5a45cff222ef54c1d5d8e1713728f0170b726cd5..0000000000000000000000000000000000000000
+diff --git a/src/oxide/cli/build/deps.ts b/src/oxide/cli/build/deps.ts
+deleted file mode 100644
+index 2b4355b17f8f4447dd9c61e293f301fe58c0231f..0000000000000000000000000000000000000000
+diff --git a/src/oxide/cli/build/index.ts b/src/oxide/cli/build/index.ts
+deleted file mode 100644
+index ba7c87459603f2e8fe74eb1850cc6b5f7d5d3e5c..0000000000000000000000000000000000000000
+diff --git a/src/oxide/cli/build/plugin.ts b/src/oxide/cli/build/plugin.ts
+deleted file mode 100644
+index 4141ec439b0e445cc2e4804761e4a60a7175de34..0000000000000000000000000000000000000000
+diff --git a/src/oxide/cli/build/utils.ts b/src/oxide/cli/build/utils.ts
+deleted file mode 100644
+index 001857a91145d8bab34e0c75d3c70f8892e6c843..0000000000000000000000000000000000000000
+diff --git a/src/oxide/cli/build/watching.ts b/src/oxide/cli/build/watching.ts
+deleted file mode 100644
+index 9d5680a163006fbbc2408045246e951feeaf98c9..0000000000000000000000000000000000000000
+diff --git a/src/oxide/cli/help/index.ts b/src/oxide/cli/help/index.ts
+deleted file mode 100644
+index c36042a650ff3f02ed26b7372c279133283b1621..0000000000000000000000000000000000000000
+diff --git a/src/oxide/cli/index.ts b/src/oxide/cli/index.ts
+deleted file mode 100644
+index 96b284db9393d97d123fe86f4ecd62b00f14eb29..0000000000000000000000000000000000000000
+diff --git a/src/oxide/cli/init/index.ts b/src/oxide/cli/init/index.ts
+deleted file mode 100644
+index abc93cdc13510202b70046de0a95f73b03b0d8b5..0000000000000000000000000000000000000000
+diff --git a/src/oxide/cli.ts b/src/oxide/cli.ts
+deleted file mode 100644
+index 17552ecb106b99472c12d6638ffeb985ea6f7025..0000000000000000000000000000000000000000
+diff --git a/src/oxide/postcss-plugin.ts b/src/oxide/postcss-plugin.ts
+deleted file mode 100644
+index 1be3203f968800b414b39e64977215955006fd86..0000000000000000000000000000000000000000
+diff --git a/src/plugin.js b/src/plugin.js
+deleted file mode 100644
+index 59f5fab014c65d613610dfa55a509709d9f6180e..0000000000000000000000000000000000000000
+diff --git a/src/postcss-plugins/nesting/README.md b/src/postcss-plugins/nesting/README.md
+deleted file mode 100644
+index 49cdbb5b41fb3b3d82bc2bbbe54f69071fda5579..0000000000000000000000000000000000000000
+diff --git a/src/postcss-plugins/nesting/index.js b/src/postcss-plugins/nesting/index.js
+deleted file mode 100644
+index 9fbcddf35f1c0c9044ffa3780e934dbfbf71429a..0000000000000000000000000000000000000000
+diff --git a/src/postcss-plugins/nesting/plugin.js b/src/postcss-plugins/nesting/plugin.js
+deleted file mode 100644
+index a13cfd454ec75da6ec605a39f171a174abb972a1..0000000000000000000000000000000000000000
+diff --git a/src/processTailwindFeatures.js b/src/processTailwindFeatures.js
+deleted file mode 100644
+index 952e17a1376203ed42b35919cf4e94f7e43088df..0000000000000000000000000000000000000000
+diff --git a/src/public/colors.js b/src/public/colors.js
+deleted file mode 100644
+index 0764bfa96b637f4782714d43945884fe7c540e36..0000000000000000000000000000000000000000
+diff --git a/src/public/create-plugin.js b/src/public/create-plugin.js
+deleted file mode 100644
+index 4124fc3886dfef66814f33770bbe85434a6d4dad..0000000000000000000000000000000000000000
+diff --git a/src/public/default-config.js b/src/public/default-config.js
+deleted file mode 100644
+index 4c7e90712959e2d44067ce284300f246c7c9d584..0000000000000000000000000000000000000000
+diff --git a/src/public/default-theme.js b/src/public/default-theme.js
+deleted file mode 100644
+index 582edc303e5e2b971d21d1168cda631a8b3e1153..0000000000000000000000000000000000000000
+diff --git a/src/public/load-config.js b/src/public/load-config.js
+deleted file mode 100644
+index d5d37127132405a28b89cca04458a798d0be625c..0000000000000000000000000000000000000000
+diff --git a/src/public/resolve-config.js b/src/public/resolve-config.js
+deleted file mode 100644
+index 891d90a9db73b4e548f7919f28a471a71bd2445f..0000000000000000000000000000000000000000
+diff --git a/src/util/applyImportantSelector.js b/src/util/applyImportantSelector.js
+deleted file mode 100644
+index ff9ec4f4b343fa496ba403a34fddef58239ba4de..0000000000000000000000000000000000000000
+diff --git a/src/util/bigSign.js b/src/util/bigSign.js
+deleted file mode 100644
+index 8514aefb9cc91c5f31d85bf11136cdf322c6beb6..0000000000000000000000000000000000000000
+diff --git a/src/util/buildMediaQuery.js b/src/util/buildMediaQuery.js
+deleted file mode 100644
+index 8489dd4bc9f4a475b631fb5b90838dcdc1e1529d..0000000000000000000000000000000000000000
+diff --git a/src/util/cloneDeep.js b/src/util/cloneDeep.js
+deleted file mode 100644
+index 47a121765cd9b224abb010bb8a578bded84dc896..0000000000000000000000000000000000000000
+diff --git a/src/util/cloneNodes.js b/src/util/cloneNodes.js
+deleted file mode 100644
+index 299dd63b3e2e71d9119ca4d3bd189a2243062da1..0000000000000000000000000000000000000000
+diff --git a/src/util/color.js b/src/util/color.js
+deleted file mode 100644
+index ea6f752b3c1da6732bd776cabd72fb53d9332f87..0000000000000000000000000000000000000000
+diff --git a/src/util/colorNames.js b/src/util/colorNames.js
+deleted file mode 100644
+index a056cceb63796c40a955c2e6f92d994a348ed864..0000000000000000000000000000000000000000
+diff --git a/src/util/configurePlugins.js b/src/util/configurePlugins.js
+deleted file mode 100644
+index 4220eae10627dc4139cad759e0f620f0f43e62c9..0000000000000000000000000000000000000000
+diff --git a/src/util/createPlugin.js b/src/util/createPlugin.js
+deleted file mode 100644
+index c2c7f5fa8e6c6af79cc4c1be174170d90662c02f..0000000000000000000000000000000000000000
+diff --git a/src/util/createUtilityPlugin.js b/src/util/createUtilityPlugin.js
+deleted file mode 100644
+index 32c2c8ae3f1ea4127572a4e7ad7e0eb069b37d40..0000000000000000000000000000000000000000
+diff --git a/src/util/dataTypes.js b/src/util/dataTypes.js
+deleted file mode 100644
+index 55cc005799f66325bec03102098d8002552ed797..0000000000000000000000000000000000000000
+diff --git a/src/util/defaults.js b/src/util/defaults.js
+deleted file mode 100644
+index 1d4aa7b45cfddcb0078c68e101adbc5591c12d93..0000000000000000000000000000000000000000
+diff --git a/src/util/escapeClassName.js b/src/util/escapeClassName.js
+deleted file mode 100644
+index cb5924a9f9d5f044dd9c922e3bad84399871d80c..0000000000000000000000000000000000000000
+diff --git a/src/util/escapeCommas.js b/src/util/escapeCommas.js
+deleted file mode 100644
+index e7f1c733967892a9e6f185412f203f0935a01e7c..0000000000000000000000000000000000000000
+diff --git a/src/util/flattenColorPalette.js b/src/util/flattenColorPalette.js
+deleted file mode 100644
+index c1259a7426ecee701e7e063cbf9583f3b2d54af0..0000000000000000000000000000000000000000
+diff --git a/src/util/formatVariantSelector.js b/src/util/formatVariantSelector.js
+deleted file mode 100644
+index e3016e804779f47ced34f77d4ac7ff1d74c6a3e9..0000000000000000000000000000000000000000
+diff --git a/src/util/getAllConfigs.js b/src/util/getAllConfigs.js
+deleted file mode 100644
+index ce3665b977d0cd9e403a09e84d0afbc09abb8a53..0000000000000000000000000000000000000000
+diff --git a/src/util/hashConfig.js b/src/util/hashConfig.js
+deleted file mode 100644
+index 543e0205d940d404bd1357a16a5a761f160e4a72..0000000000000000000000000000000000000000
+diff --git a/src/util/isKeyframeRule.js b/src/util/isKeyframeRule.js
+deleted file mode 100644
+index a745e979b33ab4a8f134917bca5be4be877db0ee..0000000000000000000000000000000000000000
+diff --git a/src/util/isPlainObject.js b/src/util/isPlainObject.js
+deleted file mode 100644
+index 7563f3218fcda0243e973f4760fea51ce92124a0..0000000000000000000000000000000000000000
+diff --git a/src/util/isSyntacticallyValidPropertyValue.js b/src/util/isSyntacticallyValidPropertyValue.js
+deleted file mode 100644
+index ff0007455df70f0560ca5da9ab7ab627e391d60b..0000000000000000000000000000000000000000
+diff --git a/src/util/log.js b/src/util/log.js
+deleted file mode 100644
+index 0df5c87192a1aced242f1a428dacc43db602fdd2..0000000000000000000000000000000000000000
+diff --git a/src/util/nameClass.js b/src/util/nameClass.js
+deleted file mode 100644
+index cb37dba20d0990052c49247c95e85830cce36177..0000000000000000000000000000000000000000
+diff --git a/src/util/negateValue.js b/src/util/negateValue.js
+deleted file mode 100644
+index b1cdf78eaee5b61a9a5f191727d686a15de9fe33..0000000000000000000000000000000000000000
+diff --git a/src/util/normalizeConfig.js b/src/util/normalizeConfig.js
+deleted file mode 100644
+index 7e1a592decda2529f1355d5eeb466df8ac831ea8..0000000000000000000000000000000000000000
+diff --git a/src/util/normalizeScreens.js b/src/util/normalizeScreens.js
+deleted file mode 100644
+index 559f7ccb691362001bf5524c01803c19102eab9f..0000000000000000000000000000000000000000
+diff --git a/src/util/parseAnimationValue.js b/src/util/parseAnimationValue.js
+deleted file mode 100644
+index 990e7aa8c8bcd5e82395fc2f2df8b7ad82569e02..0000000000000000000000000000000000000000
+diff --git a/src/util/parseBoxShadowValue.js b/src/util/parseBoxShadowValue.js
+deleted file mode 100644
+index 4be3efa04c7c7e4f4f1376980e1307a8a706f529..0000000000000000000000000000000000000000
+diff --git a/src/util/parseDependency.js b/src/util/parseDependency.js
+deleted file mode 100644
+index f26eb1a29b154c39365b7dd4f9fbca5e8f4c335e..0000000000000000000000000000000000000000
+diff --git a/src/util/parseGlob.js b/src/util/parseGlob.js
+deleted file mode 100644
+index 5c03f413d7e2c77f8ba26499fab1c8db14691a97..0000000000000000000000000000000000000000
+diff --git a/src/util/parseObjectStyles.js b/src/util/parseObjectStyles.js
+deleted file mode 100644
+index cb54787dec7a5c637ae4dd88aff54f1186335a46..0000000000000000000000000000000000000000
+diff --git a/src/util/pluginUtils.js b/src/util/pluginUtils.js
+deleted file mode 100644
+index bef9fc1658e70d6dbe4c992f1fc64072962a8be4..0000000000000000000000000000000000000000
+diff --git a/src/util/prefixSelector.js b/src/util/prefixSelector.js
+deleted file mode 100644
+index 0e7bb445bdd95ec80fbd2c51f68d091b851ed6b2..0000000000000000000000000000000000000000
+diff --git a/src/util/pseudoElements.js b/src/util/pseudoElements.js
+deleted file mode 100644
+index 9f0e54c679481a20dee3284653ab89fb89d3d128..0000000000000000000000000000000000000000
+diff --git a/src/util/removeAlphaVariables.js b/src/util/removeAlphaVariables.js
+deleted file mode 100644
+index 76655bea2bbd88aaa35c596633d18b5535b96d87..0000000000000000000000000000000000000000
+diff --git a/src/util/resolveConfig.js b/src/util/resolveConfig.js
+deleted file mode 100644
+index cfeda6ec4128f957b501e18a03619c2c4f560417..0000000000000000000000000000000000000000
+diff --git a/src/util/resolveConfigPath.js b/src/util/resolveConfigPath.js
+deleted file mode 100644
+index 2b5078949761de36e3004abdb9ab77cfbc66892a..0000000000000000000000000000000000000000
+diff --git a/src/util/responsive.js b/src/util/responsive.js
+deleted file mode 100644
+index 29bf9e982c4cfe10ec9556e2e498a6c340e0dad3..0000000000000000000000000000000000000000
+diff --git a/src/util/splitAtTopLevelOnly.js b/src/util/splitAtTopLevelOnly.js
+deleted file mode 100644
+index a749c7932ed9f98f2d2988319fcd257c92703bf4..0000000000000000000000000000000000000000
+diff --git a/src/util/tap.js b/src/util/tap.js
+deleted file mode 100644
+index 0590e4bfd85c4473712735fa005967c0ff3a35fd..0000000000000000000000000000000000000000
+diff --git a/src/util/toColorValue.js b/src/util/toColorValue.js
+deleted file mode 100644
+index 288d907846b54762c3c53a27498903be1b2c87c3..0000000000000000000000000000000000000000
+diff --git a/src/util/toPath.js b/src/util/toPath.js
+deleted file mode 100644
+index 6dce9249a3da611a029698167b6debf178a62849..0000000000000000000000000000000000000000
+diff --git a/src/util/transformThemeValue.js b/src/util/transformThemeValue.js
+deleted file mode 100644
+index 2469612295c1566b377a272ea6cd49af64035b05..0000000000000000000000000000000000000000
+diff --git a/src/util/validateConfig.js b/src/util/validateConfig.js
+deleted file mode 100644
+index 8c22e445035b89949bdbca12ae9688ddfd7f24ec..0000000000000000000000000000000000000000
+diff --git a/src/util/validateFormalSyntax.js b/src/util/validateFormalSyntax.js
+deleted file mode 100644
+index d3dafea1f07f0706a73b74ead4824cceef78e507..0000000000000000000000000000000000000000
+diff --git a/src/util/withAlphaVariable.js b/src/util/withAlphaVariable.js
+deleted file mode 100644
+index 15aedb73b66dc2d10f8b8fb35d4aa05e6a7bc63e..0000000000000000000000000000000000000000

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ patchedDependencies:
   process@0.11.10:
     hash: wpk4cjsj5eh7v5jak26jgis56e
     path: patches/process@0.11.10.patch
+  tailwindcss@3.3.2:
+    hash: y4dimyuqpjfklrxpwrmzzl5mgm
+    path: patches/tailwindcss@3.3.2.patch
 
 importers:
 
@@ -764,7 +767,7 @@ importers:
         version: 0.11.10(patch_hash=wpk4cjsj5eh7v5jak26jgis56e)
       tailwindcss:
         specifier: 3.3.2
-        version: 3.3.2
+        version: 3.3.2(patch_hash=y4dimyuqpjfklrxpwrmzzl5mgm)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -7310,7 +7313,7 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /tailwindcss@3.3.2:
+  /tailwindcss@3.3.2(patch_hash=y4dimyuqpjfklrxpwrmzzl5mgm):
     resolution: {integrity: sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==}
     engines: {node: '>=14.0.0'}
     dependencies:
@@ -7339,6 +7342,7 @@ packages:
       sucrase: 3.34.0
     transitivePeerDependencies:
       - ts-node
+    patched: true
 
   /tailwindcss@3.3.3:
     resolution: {integrity: sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==}
@@ -7610,7 +7614,7 @@ packages:
     dependencies:
       postcss: 8.4.31
       postcss-css-variables: 0.18.0(postcss@8.4.31)
-      tailwindcss: 3.3.2
+      tailwindcss: 3.3.2(patch_hash=y4dimyuqpjfklrxpwrmzzl5mgm)
     transitivePeerDependencies:
       - ts-node
     dev: false


### PR DESCRIPTION
The error that this PR addresses occurs due to a hack Tailwind uses to 
detect if the `@tailwindcss/line-clamp` dependency is included or not by requiring 
it and not ignoring the thrown error. To resolve this issue, I just comment out the part
that uses this hack and since we are bundling tailwind through vite this should be fixed.