### PR TITLE
fix(body): Use css type selector for body background for outlook

### DIFF
--- a/packages/body/src/body.tsx
+++ b/packages/body/src/body.tsx
@@ -5,9 +5,20 @@ export type BodyProps = Readonly<React.HtmlHTMLAttributes<HTMLBodyElement>>;
 export const Body = React.forwardRef<HTMLBodyElement, BodyProps>(
   ({ children, style, ...props }, ref) => {
     return (
-      <body {...props} ref={ref} style={style}>
-        {children}
-      </body>
+      <>
+        {style?.backgroundColor && (
+          <style>
+            {`
+              body {
+                  background-color: ${style.backgroundColor}
+              }
+            `}
+          </style>
+        )}
+        <body {...props} ref={ref} style={style}>
+          {children}
+        </body>
+      </>
     );
   },
 );


### PR DESCRIPTION
Background color style in body doesn't work in outlook web. Outlook converts body to a div and strips styles. For example the stripe-welcome demo email doesn't render correctly in outlook, there is no background. Outlook seems to respect type selectors so adding a style tag with body type selector fixes this.

See https://github.com/resend/react-email/issues/662

May need to do this for every style applied to the body.
