### PR TITLE
fix(ci): duplicated (canary) in version bump title

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           version: pnpm run version
           publish: pnpm run release
-          title: "chore(root): version packages (canary)"
+          title: "chore(root): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Meant to avoid the duplicated `(canary)` in the title like we had in #2459

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed "(canary)" from the version bump PR title in the canary release workflow to prevent duplicate "(canary)" in the final PR title.

<!-- End of auto-generated description by cubic. -->

