### PR TITLE
refactor(all): remove unnecessary eslint disable

### DIFF
--- a/apps/web/components/article-with-image-on-right/inline-styles.tsx
+++ b/apps/web/components/article-with-image-on-right/inline-styles.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unescaped-entities */
 import { Img, Link, Section, Text } from '@react-email/components';
 import { Layout } from '../_components/layout';
 

--- a/apps/web/components/article-with-image-on-right/tailwind.tsx
+++ b/apps/web/components/article-with-image-on-right/tailwind.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unescaped-entities */
 import { Img, Link, Section, Text } from '@react-email/components';
 import { Layout } from '../_components/layout';
 

--- a/apps/web/components/article-with-two-cards/inline-styles.tsx
+++ b/apps/web/components/article-with-two-cards/inline-styles.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unescaped-entities */
 import { Column, Img, Row, Section, Text } from '@react-email/components';
 import { Layout } from '../_components/layout';
 

--- a/apps/web/components/article-with-two-cards/tailwind.tsx
+++ b/apps/web/components/article-with-two-cards/tailwind.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unescaped-entities */
 import { Column, Img, Row, Section, Text } from '@react-email/components';
 import { Layout } from '../_components/layout';
 

--- a/apps/web/components/ensure-matching-variants.spec.tsx
+++ b/apps/web/components/ensure-matching-variants.spec.tsx
@@ -64,7 +64,6 @@ describe.skip('copy-paste components', () => {
     if (component.slug === 'simple-code-inline') continue;
     if (component.slug === 'code-inline-with-different-colors') continue;
 
-    // eslint-disable-next-line @typescript-eslint/no-loop-func
     test(`${component.slug}'s variants should all match`, async () => {
       const componentPath = getComponentPathFromSlug(component.slug);
       const tailwindVariantPath = path.join(componentPath, 'tailwind.tsx');

--- a/apps/web/components/header-and-four-paragraphs/inline-styles.tsx
+++ b/apps/web/components/header-and-four-paragraphs/inline-styles.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unescaped-entities */
 import { Column, Img, Row, Section, Text } from '@react-email/components';
 import { Layout } from '../_components/layout';
 

--- a/apps/web/components/header-and-four-paragraphs/tailwind.tsx
+++ b/apps/web/components/header-and-four-paragraphs/tailwind.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unescaped-entities */
 import { Column, Img, Row, Section, Text } from '@react-email/components';
 import { Layout } from '../_components/layout';
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -92,7 +92,6 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
       <body className="h-screen-ios overflow-x-hidden bg-black font-sans text-slate-11 text-sm selection:bg-cyan-5 selection:text-cyan-12">
         <div
           className="relative mx-auto flex min-h-[100dvh] flex-col justify-between px-2 md:max-w-7xl md:px-4"
-          // eslint-disable-next-line react/no-unknown-property
           vaul-drawer-wrapper=""
         >
           <Topbar />

--- a/apps/web/src/components/component-view.tsx
+++ b/apps/web/src/components/component-view.tsx
@@ -64,7 +64,6 @@ export const ComponentView: React.FC<ComponentViewProps> = ({
 
   React.useEffect(() => {
     setActiveView(activeView);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/packages/code-block/src/prism.ts
+++ b/packages/code-block/src/prism.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // @ts-nocheck
 import * as PrismImport from "prismjs";
 // this avoids an issue that was happening when importing inside of

--- a/packages/create-email/src/index.js
+++ b/packages/create-email/src/index.js
@@ -85,7 +85,6 @@ const init = async (name, { tag }) => {
     text: 'React Email Starter files ready',
   });
 
-  // eslint-disable-next-line no-console
   console.info(
     await tree(resolvedProjectPath, 4, (dirent) => {
       return !path

--- a/packages/preview/src/preview.spec.tsx
+++ b/packages/preview/src/preview.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-irregular-whitespace */
 import { render } from '@react-email/render';
 import { Preview, renderWhiteSpace } from './index';
 
@@ -37,7 +36,6 @@ describe('renderWhiteSpace', () => {
     const html = renderWhiteSpace(text);
     expect(html).not.toBeNull();
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
     const actualTextContent = html?.props.children;
     const expectedTextContent = whiteSpaceCharacters.repeat(150 - text.length);
     expect(actualTextContent).toBe(expectedTextContent);

--- a/packages/react-email/src/commands/build.ts
+++ b/packages/react-email/src/commands/build.ts
@@ -154,9 +154,9 @@ const forceSSGForEmailPreviews = async (
   emailsDirPath: string,
   builtPreviewAppPath: string,
 ) => {
-  const emailDirectoryMetadata =
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    (await getEmailsDirectoryMetadata(emailsDirPath))!;
+  const emailDirectoryMetadata = (await getEmailsDirectoryMetadata(
+    emailsDirPath,
+  ))!;
 
   const parameters = getEmailSlugsFromEmailDirectory(
     emailDirectoryMetadata,

--- a/packages/react-email/src/utils/get-emails-directory-metadata.ts
+++ b/packages/react-email/src/utils/get-emails-directory-metadata.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import fs from 'node:fs';
 import path from 'node:path';
 

--- a/packages/react-email/src/utils/preview/serve-static-file.ts
+++ b/packages/react-email/src/utils/preview/serve-static-file.ts
@@ -1,5 +1,4 @@
 import { existsSync, promises as fs } from 'node:fs';
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type http from 'node:http';
 import path from 'node:path';
 import type url from 'node:url';

--- a/packages/react-email/src/utils/preview/start-dev-server.ts
+++ b/packages/react-email/src/utils/preview/start-dev-server.ts
@@ -83,8 +83,6 @@ export const startDevServer = async (
   const { portAlreadyInUse } = await safeAsyncServerListen(devServer, port);
 
   if (!portAlreadyInUse) {
-    // this errors when linting but doesn't on the editor so ignore the warning on this
-    /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access */
     console.log(
       styleText('greenBright', `    React Email ${packageJson.version}`),
     );

--- a/packages/render/src/shared/utils/pretty.ts
+++ b/packages/render/src/shared/utils/pretty.ts
@@ -62,7 +62,6 @@ function recursivelyMapDoc(
 
 const modifiedHtml = { ...html } as Plugin;
 if (modifiedHtml.printers) {
-  // eslint-disable-next-line @typescript-eslint/unbound-method
   const previousPrint = modifiedHtml.printers.html.print;
   modifiedHtml.printers.html.print = (path, options, print, args) => {
     const node = path.getNode() as HtmlNode;

--- a/packages/row/src/row.spec.tsx
+++ b/packages/row/src/row.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-children-prop */
 import { render } from '@react-email/render';
 import { Row } from './index';
 

--- a/packages/tailwind/src/hooks/use-suspensed-promise.ts
+++ b/packages/tailwind/src/hooks/use-suspensed-promise.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-throw-literal */
 interface PromiseState {
   promise: Promise<unknown>;
   error?: unknown;

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -130,34 +130,6 @@ describe('Tailwind component', () => {
     });
   });
 
-  // test("with React context and custom components", () => {
-  //   const SharedDataContext = React.createContext<{ name: string } | undefined>(undefined);
-  //
-  //   const IsGreat = () => {
-  //     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  //     const sharedData = React.useContext(SharedDataContext)!;
-  //
-  //     expect(sharedData).toBeDefined();
-  //
-  //     return <p className="text-red-500 sm:text-blue-300">
-  //       {sharedData.name} is great!
-  //     </p>;
-  //   };
-  //
-  //   render(
-  //     <Html>
-  //       <Tailwind>
-  //         <Head/>
-  //         <SharedDataContext.Provider value={{ name: 'React Email' }}>
-  //           <body className="bg-slate-900 text-gray-200">
-  //             <IsGreat/>
-  //           </body>
-  //         </SharedDataContext.Provider>
-  //       </Tailwind>
-  //     </Html>
-  //   );
-  // });
-
   test('<Button className="px-3 py-2 mt-8 text-sm text-gray-200 bg-blue-600 rounded-md">', async () => {
     const actualOutput = await render(
       <Tailwind>

--- a/packages/tailwind/src/utils/tailwindcss/setup-tailwind.ts
+++ b/packages/tailwind/src/utils/tailwindcss/setup-tailwind.ts
@@ -41,9 +41,6 @@ export function setupTailwind(config: TailwindConfig) {
         .clone()
         .append(...bigIntRuleTuples.map(([, rule]) => rule));
       partitionApplyAtRules()(root);
-      // This is fine because the internal await is never actually called out
-      // because of there not being any `changedContent` files on the context
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       expandTailwindAtRules(tailwindContext)(root);
       partitionApplyAtRules()(root);
       expandApplyAtRules(tailwindContext)(root);

--- a/packages/tailwind/src/utils/tailwindcss/tailwind-internals.d.ts
+++ b/packages/tailwind/src/utils/tailwindcss/tailwind-internals.d.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 declare module "tailwindcss/lib/lib/evaluateTailwindFunctions" {
   import type { JitContext } from "tailwindcss/lib/lib/setupContextUtils";
   import type { Root } from "postcss";


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed unnecessary ESLint disable comments across apps/web and packages to re-enable lint rules and tidy the codebase. No runtime or API changes.

- **Refactors**
  - Deleted superfluous eslint-disable and disable-next-line directives across components, utils, and tests.
  - Cleaned up a commented-out test block in packages/tailwind/src/tailwind.spec.tsx.
  - No logic changes; code behavior remains the same.

<!-- End of auto-generated description by cubic. -->

