### PR TITLE
chore(monorepo): add `.vscode` folder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit"
+  }
+}


### PR DESCRIPTION
this helps with VSCode/Cursor so it uses the correct linter and helps to make sure contributors PR follow our linting rules by default 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add VS Code workspace settings to enforce Biome formatting and organize imports on save. This ensures consistent formatting and linting so contributor PRs follow our rules by default.

<!-- End of auto-generated description by cubic. -->

