### PR TITLE
feat: add CTA section email component

### DIFF
--- a/packages/cta-section/README.md
+++ b/packages/cta-section/README.md
@@ -1,0 +1,22 @@
+# CTA Section Component
+
+A reusable Call To Action (CTA) section for React Email projects.
+
+## Usage
+
+```tsx
+import { CtaSection } from '@react-email/cta-section';
+
+<CtaSection
+  title="Join our newsletter!"
+  description="Get the latest updates and offers."
+  buttonText="Subscribe"
+  buttonUrl="https://example.com/newsletter"
+/>
+```
+
+## Props
+- `title`: string — Main heading for the CTA
+- `description`: string (optional) — Supporting text
+- `buttonText`: string — Text for the CTA button
+- `buttonUrl`: string — URL for the CTA button

--- a/packages/cta-section/package.json
+++ b/packages/cta-section/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@react-email/cta-section",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.0"
+  }
+}

--- a/packages/cta-section/src/CtaSection.test.tsx
+++ b/packages/cta-section/src/CtaSection.test.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { render } from "@testing-library/react";
+import { CtaSection } from "./CtaSection";
+
+describe("CtaSection", () => {
+  it("renders title and button", () => {
+    const { getByText } = render(
+      <CtaSection
+        title="Try React Email"
+        buttonText="Get Started"
+        buttonUrl="https://react.email"
+      />
+    );
+    expect(getByText("Try React Email")).toBeInTheDocument();
+    expect(getByText("Get Started")).toBeInTheDocument();
+  });
+});

--- a/packages/cta-section/src/CtaSection.tsx
+++ b/packages/cta-section/src/CtaSection.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+
+export interface CtaSectionProps {
+  title: string;
+  description?: string;
+  buttonText: string;
+  buttonUrl: string;
+}
+
+export const CtaSection: React.FC<CtaSectionProps> = ({
+  title,
+  description,
+  buttonText,
+  buttonUrl,
+}) => (
+  <section style={{ padding: "24px", textAlign: "center" }}>
+    <h2 style={{ fontSize: "20px", marginBottom: "8px" }}>{title}</h2>
+    {description && <p style={{ marginBottom: "16px" }}>{description}</p>}
+    <a
+      href={buttonUrl}
+      style={{
+        display: "inline-block",
+        padding: "12px 24px",
+        background: "#0070f3",
+        color: "#fff",
+        borderRadius: "4px",
+        textDecoration: "none",
+        fontWeight: "bold",
+      }}
+    >
+      {buttonText}
+    </a>
+  </section>
+);

--- a/packages/cta-section/tsconfig.json
+++ b/packages/cta-section/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
This pull request adds a new reusable Call To Action (CTA) section component to the  directory. The component allows users to easily include a prominent CTA in their email templates, with customizable title, description, button text, and button URL.
Includes documentation and a basic test file for usage and verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable CTA section component for React Email templates to make it easy to add a clear call-to-action with a title, optional description, and button. Improves template consistency and speeds up email creation.

- **New Features**
  - New package: @react-email/cta-section with CtaSection(title, description?, buttonText, buttonUrl).
  - Built-in styles for centered layout and a primary button.
  - README with usage and prop docs.
  - Basic test to verify title and button rendering.

<!-- End of auto-generated description by cubic. -->

