### PR TITLE
fix: standardize border-radius

### DIFF
--- a/apps/web/components/article-with-multiple-authors/inline-styles.tsx
+++ b/apps/web/components/article-with-multiple-authors/inline-styles.tsx
@@ -53,7 +53,7 @@ export const component = (
                 height={48}
                 src={author.imgSrc}
                 style={{
-                  borderRadius: 9999,
+                  borderRadius: '9999px',
                   display: 'block',
                   objectFit: 'cover',
                   objectPosition: 'center',

--- a/apps/web/components/avatars-circular/inline-styles.tsx
+++ b/apps/web/components/avatars-circular/inline-styles.tsx
@@ -13,7 +13,7 @@ export const component = (
           display: 'inline-block',
           width: '30px',
           height: '30px',
-          borderRadius: '100%',
+          borderRadius: '9999px',
         }}
       />
     </Column>
@@ -27,7 +27,7 @@ export const component = (
           display: 'inline-block',
           width: '42px',
           height: '42px',
-          borderRadius: '100%',
+          borderRadius: '9999px',
         }}
       />
     </Column>
@@ -41,7 +41,7 @@ export const component = (
           display: 'inline-block',
           width: '54px',
           height: '54px',
-          borderRadius: '100%',
+          borderRadius: '9999px',
         }}
       />
     </Column>
@@ -55,7 +55,7 @@ export const component = (
           display: 'inline-block',
           width: '66px',
           height: '66px',
-          borderRadius: '100%',
+          borderRadius: '9999px',
         }}
       />
     </Column>

--- a/apps/web/components/avatars-group-stacked/inline-styles.tsx
+++ b/apps/web/components/avatars-group-stacked/inline-styles.tsx
@@ -28,7 +28,7 @@ export const component = (
           height: '100%',
           width: '100%',
           overflow: 'hidden',
-          borderRadius: '100%',
+          borderRadius: '9999px',
           border: '4px solid white',
           backgroundColor: '#030712',
         }}
@@ -68,7 +68,7 @@ export const component = (
           height: '100%',
           width: '100%',
           overflow: 'hidden',
-          borderRadius: '100%',
+          borderRadius: '9999px',
           border: '4px solid white',
           backgroundColor: '#030712',
         }}
@@ -108,7 +108,7 @@ export const component = (
           height: '100%',
           width: '100%',
           overflow: 'hidden',
-          borderRadius: '100%',
+          borderRadius: '9999px',
           border: '4px solid white',
           backgroundColor: '#030712',
         }}

--- a/apps/web/components/header-and-numbered-list-items/inline-styles.tsx
+++ b/apps/web/components/header-and-numbered-list-items/inline-styles.tsx
@@ -51,7 +51,7 @@ export const component = (
                 height: 40,
                 width: 40,
                 backgroundColor: 'rgb(199,210,254)',
-                borderRadius: 9999,
+                borderRadius: '9999px',
                 padding: '0px',
               }}
             >
@@ -116,7 +116,7 @@ export const component = (
                 height: 40,
                 width: 40,
                 backgroundColor: 'rgb(199,210,254)',
-                borderRadius: 9999,
+                borderRadius: '9999px',
                 padding: '0px',
               }}
             >
@@ -181,7 +181,7 @@ export const component = (
                 height: 40,
                 width: 40,
                 backgroundColor: 'rgb(199,210,254)',
-                borderRadius: 9999,
+                borderRadius: '9999px',
                 padding: '0px',
               }}
             >
@@ -246,7 +246,7 @@ export const component = (
                 height: 40,
                 width: 40,
                 backgroundColor: 'rgb(199,210,254)',
-                borderRadius: 9999,
+                borderRadius: '9999px',
                 padding: '0px',
               }}
             >


### PR DESCRIPTION
🔧 Converts inline `border-radius` to `9999px` (`rounded-full` equivalent TW. v3) across components.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized inline border-radius to "9999px" to ensure perfect circles and match Tailwind’s rounded-full. This fixes inconsistent rendering across components and browsers.

- **Refactors**
  - Replaced numeric 9999 and "100%" with "9999px" in avatar and badge elements.
  - Updated: article-with-multiple-authors, avatars-circular, avatars-group-stacked, header-and-numbered-list-items.

<!-- End of auto-generated description by cubic. -->

