### PR TITLE
fix(web): correct homepage layout centering at 1024px

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -8,7 +8,7 @@ import TestimonialSection from '@/components/sections/testimonial';
 import ToolsSection from '@/components/sections/tools';
 
 const Home = () => (
-  <main className="max-lg:overflow-x-clip">
+  <main className="overflow-x-clip">
     <HeroSection />
     <div className="relative mx-auto flex flex-col justify-between px-2 md:max-w-7xl md:px-4">
       <PlaygroundSection />


### PR DESCRIPTION
This PR fixes the homepage layout bug where the content would shift off-center on screen sizes exactly 1024px wide.

### What was the problem?

The root cause was a conditional CSS class (`max-lg:overflow-x-clip`) on the main page container. This class stopped applying right at the 1024px breakpoint, which allowed an element in the Hero section to create horizontal overflow. This stretched the whole page, breaking the `mx-auto` centering logic.

### How does this fix it?

The fix is straightforward: I've changed the class to a permanent `overflow-x-clip`. This ensures that any horizontal overflow is *always* contained, keeping the layout perfectly centered at all screen sizes.

### Testing

I've tested this locally at various viewport widths, and everything looks great:
-   ✅ Mobile screens (< 768px)
-   ✅ Tablet screens (768px - 1023px)
-   ✅ **1024px screens (The bug is gone!)**
-   ✅ Desktop screens (> 1024px)

Here's a quick look at the before and after:

**Before (at 1024px):**
*The layout is pushed to the left.*

<img width="658" height="437" alt="screenshot" src="https://github.com/user-attachments/assets/cc9049a2-bc97-4c9b-8f77-f296091fb937" />

**After (at 1024px):**
*The layout is now perfectly centered.*

<img width="657" height="436" alt="screenshot" src="https://github.com/user-attachments/assets/13958562-7213-411e-b357-59c1731bf644" />

Closes #2607

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes homepage centering at 1024px by always clipping horizontal overflow on the main container. Prevents hero overflow from widening the page, keeping mx-auto centering consistent at all screen sizes.

<!-- End of auto-generated description by cubic. -->

