### PR TITLE
fix(ci): release workflows

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       pull-requests: write
     container:
-      image: node:22-slim
+      image: node:22
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       pull-requests: write
     container:
-      image: node:22-slim
+      image: node:22
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Here's it failing https://github.com/resend/react-email/actions/runs/18974274379/job/54189489124

node-slim doesn't include git, which causes that to happen

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CI release workflows from node:22-slim to node:22 so git is available. This fixes failing release jobs that require git during checkout and tagging.

<sup>Written for commit 7197dc5fb49c5ca44a3c8cb06331fb0a293a467c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

