### PR TITLE
fix(web): missing Toaster usage

### DIFF
--- a/apps/web/src/app/components/[slug]/page.tsx
+++ b/apps/web/src/app/components/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { Toaster } from 'sonner';
 import { Heading } from '@/components/heading';
 import { PageWrapper } from '@/components/page-wrapper';
 import { componentsStructure } from '../../../../components/structure';
@@ -8,7 +9,6 @@ import { IconArrowLeft } from '../../../components/icons/icon-arrow-left';
 import { PageTransition } from '../../../components/page-transition';
 import { slugify } from '../../../utils/slugify';
 import { getImportedComponentsFor } from '../get-imported-components-for';
-import { Toaster } from 'sonner';
 
 interface ComponentPageParams {
   params: Promise<{
@@ -97,7 +97,7 @@ export default async function ComponentPage({ params }: ComponentPageParams) {
         </div>
       </PageTransition>
 
-      <Toaster/>
+      <Toaster />
     </PageWrapper>
   );
 }


### PR DESCRIPTION
Added the missing `<Toaster/>` component usage to finish up #2629 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore toast notifications on the component page by rendering the Toaster from sonner. Completes #2629 by ensuring toasts display where triggered.

- **Bug Fixes**
  - Import and mount Toaster in ComponentPage so existing toast calls render.

<sup>Written for commit cfedfa46fa4fa045bf17e7af6316e5845ead20cf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

