### PR TITLE
feat(web): remove height: 100vh for copy-paste HTML

### DIFF
--- a/apps/web/src/components/component-code-view.tsx
+++ b/apps/web/src/components/component-code-view.tsx
@@ -35,6 +35,8 @@ export function ComponentCodeView({
     } else if (component.code.react) {
       code = component.code.react;
     }
+  } else {
+    code = code.replace(/height\s*:\s*100vh;?/, '');
   }
   code = convertUrisIntoUrls(code);
 

--- a/apps/web/src/components/component-view.tsx
+++ b/apps/web/src/components/component-view.tsx
@@ -115,7 +115,10 @@ export function ComponentView({ component, className }: ComponentViewProps) {
             </TabTriggetWithTooltip>
             <Send
               className="ml-2"
-              markup={convertUrisIntoUrls(component.code.html)}
+              markup={convertUrisIntoUrls(component.code.html).replace(
+                /height\s*:\s*100vh;?/,
+                '',
+              )}
               defaultSubject={component.title}
             />
           </Tabs.List>


### PR DESCRIPTION
If users were to copy-paste the HTML from one of our copy-paste components, it'd come with a `height: 100vh` in one of the first elements coming from 

https://github.com/resend/react-email/blob/d4d9efdbdb6f87918fa1062c1aa78d10f3168ae2/apps/web/components/_components/layout.tsx#L63-L63

This will cause them to look badly, specially if they're trying to send it to themselves with the new Send button. This fixes that by simply replacing the `height:100vh` with nothing in the copy-paste component's HTML

The main reason we have that `100vh` in the first place is just so that the copy-paste components look good in the iframes that we render them in on https://react.email/components, so this is ok.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the height: 100vh style from copy-paste component HTML and Send markup so emails don’t render full-viewport height. This keeps iframe-only styling out of exported HTML, ensuring copied/sent templates display correctly in email clients.

<sup>Written for commit 60019e05701c41478b22bad0d07211713d0e2c50. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

