### PR TITLE
fix(react-email): nodejs 25 warning about argument concatenation

### DIFF
--- a/packages/react-email/dev/index.js
+++ b/packages/react-email/dev/index.js
@@ -10,7 +10,6 @@ const root = path.resolve(dirname, '../src/index.ts');
 const tsxPath = path.resolve(dirname, '../../../node_modules/.bin/tsx');
 
 const tsx = child_process.spawn(tsxPath, [root, ...process.argv.slice(2)], {
-  shell: true,
   cwd: process.cwd(),
   stdio: 'inherit',
 });


### PR DESCRIPTION
I've been trying to use Node.js 25 and I've noticed that every time I used the `email-dev` script, there was a warning:  

```zig
(node:93213) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
    at normalizeSpawnArguments (node:child_process:644:15)
    at Object.spawn (node:child_process:789:13)
    at .../react-email/packages/react-email/dev/index.js:12:27
    at ModuleJob.run (node:internal/modules/esm/module_job:377:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:671:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5) 
```

This is referring to:

https://github.com/resend/react-email/blob/30724df7c4ac987ab68faff1b92d6ed6637e6c37/packages/react-email/dev/index.js#L12-L16

Which is using `shell: true` here, and which causes the warning. In this specific use case, we can simply remove `shell: true` since we're using the direct path to the binary and aren't using any shell specific features.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed shell: true from the react-email dev script to stop the Node.js 25 DEP0190 warning and avoid unsafe argument concatenation. We now spawn tsx directly via its path; no shell features are needed.

<sup>Written for commit 5cbab69a28f41868bfbaf507ba1fe6ad53852012. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

