### PR TITLE
fix(preview-server): localStoraget.getItem is not a function error

### DIFF
--- a/packages/preview-server/src/components/toolbar/use-cached-state.ts
+++ b/packages/preview-server/src/components/toolbar/use-cached-state.ts
@@ -23,7 +23,7 @@ export const useCachedState = <T>(key: string) => {
 
   return [
     useSyncExternalStore(
-      () => () => { },
+      () => () => {},
       () => value,
       () => undefined,
     ),


### PR DESCRIPTION
Fixing the error

```zig
 ⨯ TypeError: a.g.localStorage.getItem is not a function
    at bf (turbopack:///[project]/packages/preview-server/src/components/toolbar/use-cached-state.ts:6:45)
    at bh (turbopack:///[project]/packages/preview-server/src/components/toolbar.tsx:81:5)
  4 |   let value: T | undefined;
  5 |   if ('localStorage' in global) {
> 6 |     const storedValue = global.localStorage.getItem(key);
    |                                             ^
  7 |     if (storedValue !== null && storedValue !== 'undefined') {
  8 |       try {
  9 |         value = JSON.parse(storedValue) as T; {
  digest: '3099065385'
}
```

Only got this when using Node.js 25, so I'm assuming it's probably related. Can confirm the issue's gone after this when running locally.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix preview-server crash in Node.js 25 by guarding against non-function localStorage.getItem in useCachedState. This prevents the TypeError and lets the toolbar render without failing.

<sup>Written for commit b91cafc3411059d947b970ae9813f8cabdcbe46e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



