### PR TITLE
fix(react-email): Make the userProjectLocation generic.

### DIFF
--- a/packages/react-email/src/commands/build.ts
+++ b/packages/react-email/src/commands/build.ts
@@ -78,14 +78,15 @@ const setNextEnvironmentVariablesForBuild = async (
   const nextConfigContents = `
 const path = require('path');
 const emailsDirRelativePath = path.normalize('${emailsDirRelativePath}');
-const userProjectLocation = '${process.cwd().replace(/\\/g, '/')}';
+const userProjectLocation = path.resolve(__dirname, "../");
+const reactEmailDir = ".react-email";
 /** @type {import('next').NextConfig} */
 module.exports = {
   env: {
     NEXT_PUBLIC_IS_BUILDING: 'true',
     EMAILS_DIR_RELATIVE_PATH: emailsDirRelativePath,
     EMAILS_DIR_ABSOLUTE_PATH: path.resolve(userProjectLocation, emailsDirRelativePath),
-    PREVIEW_SERVER_LOCATION: '${builtPreviewAppPath.replace(/\\/g, '/')}',
+    PREVIEW_SERVER_LOCATION: path.join(userProjectLocation, reactEmailDir),
     USER_PROJECT_LOCATION: userProjectLocation
   },
   serverExternalPackages: ['esbuild'],


### PR DESCRIPTION
To able to build locally and use NextJS just changing the root dir.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made path handling in the React Email build generic so local Next.js builds work even if the project root changes. Preview server path now points to .react-email in the project root instead of a hard-coded build output.

- **Bug Fixes**
  - Set USER_PROJECT_LOCATION via path.resolve(__dirname, "../") instead of process.cwd.
  - Set PREVIEW_SERVER_LOCATION to path.join(userProjectLocation, ".react-email") instead of builtPreviewAppPath.

<sup>Written for commit 1287ded97ecce49e7135be5e2d6ba6ed7e88fb02. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

