### PR TITLE
chore(ci): only build packages/* in preview-release

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -21,11 +21,7 @@ jobs:
       - name: Install packages
         run: pnpm install --frozen-lockfile
       - name: Run Build
-        run: pnpm build
-        env:
-          SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
-          SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}
-            # Add step to find changed package directories within ./packages
+        run: pnpm turbo run build --filter=./packages/*
       - name: Find changed packages
         id: changed_packages
         uses: tj-actions/changed-files@212f9a7760ad2b8eb511185b841f3725a62c2ae0


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit preview-release CI to build only packages/* to speed up runs and avoid unnecessary work. Switched to pnpm turbo run build --filter=./packages/* and removed unused SpamAssassin env vars from the build step.

<sup>Written for commit b398c3721d159ce1fd84d19020222f524d81d875. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

