### PR TITLE
fix: use `devEngines` for `node >=22` instead of `engines`

### DIFF
--- a/benchmarks/preview-server/package.json
+++ b/benchmarks/preview-server/package.json
@@ -13,7 +13,10 @@
     "directory": "benchmarks/preview-server"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "dependencies": {
     "react-email": "workspace:*",

--- a/benchmarks/tailwind-component/package.json
+++ b/benchmarks/tailwind-component/package.json
@@ -16,7 +16,10 @@
     "directory": "benchmarks/tailwind-component"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "dependencies": {
     "@react-email/components": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "scripts": {
     "build": "turbo run build",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"

--- a/packages/code-block/package.json
+++ b/packages/code-block/package.json
@@ -40,7 +40,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"

--- a/packages/code-inline/package.json
+++ b/packages/code-inline/package.json
@@ -31,7 +31,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/column/package.json
+++ b/packages/column/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,7 +40,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "dependencies": {
     "@react-email/body": "workspace:0.2.0",

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -27,7 +27,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "bin": {
     "create-email": "src/index.js"

--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"

--- a/packages/heading/package.json
+++ b/packages/heading/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"

--- a/packages/hr/package.json
+++ b/packages/hr/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -27,7 +27,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "dependencies": {
     "@babel/parser": "^7.27.0",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -114,7 +114,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "dependencies": {
     "html-to-text": "^9.0.5",

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"

--- a/packages/section/package.json
+++ b/packages/section/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -43,7 +43,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -42,7 +42,10 @@
     "node": ">=20.0.0"
   },
   "devEngines": {
-    "node": ">=22.0.0"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"


### PR DESCRIPTION
We set engines to >=22.0.0 before with the intent of only requireing it for dev, and not to stop supporting Node 20 per se. But the `engines` field actually enforces it for end users, and `npm install` warns:

```zig
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@react-email/components@1.0.1',
npm warn EBADENGINE   required: { node: '>=22.0.0' },
npm warn EBADENGINE   current: { node: 'v20.17.0', npm: '10.9.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'react-email@5.0.4',
npm warn EBADENGINE   required: { node: '>=22.0.0' },
npm warn EBADENGINE   current: { node: 'v20.17.0', npm: '10.9.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@react-email/code-block@0.2.0',
npm warn EBADENGINE   required: { node: '>=22.0.0' },
npm warn EBADENGINE   current: { node: 'v20.17.0', npm: '10.9.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@react-email/markdown@0.0.17',
npm warn EBADENGINE   required: { node: '>=22.0.0' },
npm warn EBADENGINE   current: { node: 'v20.17.0', npm: '10.9.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@react-email/render@2.0.0',
npm warn EBADENGINE   required: { node: '>=22.0.0' },
npm warn EBADENGINE   current: { node: 'v20.17.0', npm: '10.9.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@react-email/tailwind@2.0.1',
npm warn EBADENGINE   required: { node: '>=22.0.0' },
npm warn EBADENGINE   current: { node: 'v20.17.0', npm: '10.9.2' }
npm warn EBADENGINE }
```