### PR TITLE
fix: use <a> tag for external rewrites instead of relying on Next's Link component

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -15,7 +15,7 @@ jobs:
       image: node:22
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
       - run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: pnpm setup
         uses: pnpm/action-setup@f2b2b233b538f500472c7274c7012f57857d8ce0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       image: node:22
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
       - run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: pnpm setup
         uses: pnpm/action-setup@f2b2b233b538f500472c7274c7012f57857d8ce0


### PR DESCRIPTION










<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch external rewrite links to a plain anchor to fix broken navigation to docs on Next.js 16. Replaces Next’s Link in the menu with a SmartLink that falls back to Link for internal routes.

- **Bug Fixes**
  - Add SmartLink: uses <a> for paths like /docs, otherwise uses Next Link.
  - Replace Link with SmartLink in the menu to prevent failed navigation to external docs.

<sup>Written for commit 4d2ef6d2e809927ee7d6eb04ce7ef5bda52785a6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









