### PR TITLE
feat: issue template changes to nudge users to making better issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -2,6 +2,10 @@ name: Bug Report
 description: Create a bug report for React Email
 labels: ["Type: Bug"]
 body:
+  - type: input
+    attributes:
+      label: What versions are you using? (if relevant)
+      value: "@react-email/components@x.y.z, react-email@x.y.z, etc."
   - type: textarea
     attributes:
       label: Describe the Bug
@@ -10,45 +14,47 @@ body:
       required: true
   - type: dropdown
     attributes:
-      label: Which package is affected (leave empty if unsure)
+      label: What is affected (leave empty if unsure)
       multiple: true
       options:
-        - "@react-email/body"
-        - "@react-email/button"
-        - "@react-email/column"
-        - "@react-email/components"
-        - "@react-email/container"
-        - "@react-email/font"
-        - "@react-email/head"
-        - "@react-email/heading"
-        - "@react-email/hr"
-        - "@react-email/html"
-        - "@react-email/img"
-        - "@react-email/link"
-        - "@react-email/preview"
-        - "@react-email/render"
-        - "@react-email/row"
-        - "@react-email/section"
-        - "@react-email/tailwind"
-        - "@react-email/text"
-        - "client"
-        - "create-email"
-        - "demo"
-        - "docs"
-        - "examples"
-        - "react-email"
-        - "web"
-  - type: input
+        - "Preview Server"
+        - "CLI"
+        - "Html Component"
+        - "Body Component"
+        - "Head Component"
+        - "Button Component"
+        - "Container Component"
+        - "CodeBlock Component"
+        - "CodeInline Component"
+        - "Column Component"
+        - "Row Component"
+        - "Font Component"
+        - "Heading Component"
+        - "Hr Component"
+        - "Img Component"
+        - "Link Component"
+        - "Markdown Component"
+        - "Preview Component"
+        - "Section Component"
+        - "Tailwind Component"
+        - "Text Component"
+        - "Render Utility"
+        - "@react-email/components package"
+        - "npx create-email"
+        - "Demo"
+        - "Website"
+        - "Examples"
+  - type: textarea
     attributes:
       label: Link to the code that reproduces this issue
-      description: |
-        A link to a GitHub repository minimal reproduction. A minimal reproduction code is really helpful to understand the issue.
+      value: |
+        A link to a GitHub repository minimal reproduction. Not your entire project, just the code necessary to reproduce the issue. Try going from the starter `npx create-email@latest` and adding only what's needed to cause the issue. If you don't share a reproduction, we might close the issue or it will take significantly longer for things to get sorted out.
     validations:
       required: true
   - type: textarea
     attributes:
       label: To Reproduce
-      description: Steps to reproduce the behavior, please provide a clear description of how to reproduce the issue, based on the linked minimal reproduction. Screenshots can be provided in the issue body below. If using code blocks, make sure that [syntax highlighting is correct](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) and double check that the rendered preview is not broken.
+      value: Steps to reproduce the behavior, please provide a clear description of how to reproduce the issue, based on the linked minimal reproduction. Screenshots can be provided in the issue body below. If using code blocks, make sure that [syntax highlighting is correct](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) and double check that the rendered preview is not broken.
     validations:
       required: true
   - type: textarea
@@ -67,3 +73,4 @@ body:
     attributes:
       label: What's your node version? (if relevant)
       description: "Please specify the exact version."
+


### PR DESCRIPTION
The problems happening with the current issue template:
- Users not providing a link to a reproduction
    - #2726 (can reproduce, but harder)
    - #2712 (can't reproduce until someone commented details)
    - #2429
    - #2687
- Users don't select the right package that has the issue
    - #2429 (just selecting components)
    - #2734
    - #2726
    - #2714 (just selected `react-email` without relation, which is very common)

This pull requests changes the description for the `link to reproduce issue` input to a value, so it feels clunkier to just ignore it. This is inspired by how tailwindcss does it, since they don't include examples/descriptions as markdown comments, but rather as raw markdown so users have to delete.

It also updates the values for "affected package" to include some missing packages, and to be more clear on what is what. Changing `react-email` to `CLI`, and moving `@react-email/components` to one of the last options so users pick it less.

This does indeed add more friction to the issue creation process and I think it's a trade-off that's worth it, at least for now with our bandwidth. A possible negative side to this is it might cause users to not create the issues at all, but that's very hard to predict, and I think we should try it out and see if it does indeed or no.

Also taking the chance to add a "package version" input at the top, so users can fill it in, which is a common question for me to ask when following up to issues.

All in all, the new version looks like this (test screenshot from a private repo of me trying it out):
<img width="1554" height="3046" alt="image" src="https://github.com/user-attachments/assets/47751c5c-7249-445b-b706-bbe3bdb42e5d" />





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the bug report template to push for a minimal reproduction and clearer “what is affected” selection, reducing triage time and incomplete issues. Also adds a versions field to capture package versions upfront.

- **New Features**
  - Added “What versions are you using?” input with example values.
  - Prefilled guidance in “Link to reproduction” and “To Reproduce” to make skipping harder and set expectations (issues without a repro may be closed).
  - Reworked “What is affected” dropdown with clearer labels (e.g., CLI, Preview Server, component names), added missing items, and reordered to reduce misselection.

<sup>Written for commit 569eff40f538b089d44ccef0f6db540d8faf0b9b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

