### PR TITLE
fix(playground): errors with Tailwind due to csstree

### DIFF
--- a/playground/components.ts
+++ b/playground/components.ts
@@ -1,3 +1,4 @@
+export * from '@react-email/tailwind';
 export * from '../packages/body/src';
 export * from '../packages/button/src';
 export * from '../packages/code-block/src';
@@ -15,5 +16,4 @@ export * from '../packages/markdown/src';
 export * from '../packages/preview/src';
 export * from '../packages/row/src';
 export * from '../packages/section/src';
-export * from '../packages/tailwind/src';
 export * from '../packages/text/src';

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@react-email/render": "workspace:*",
+    "@react-email/tailwind": "workspace:*",
     "react": "^19",
     "react-dom": "^19"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1090,6 +1090,9 @@ importers:
       '@react-email/render':
         specifier: workspace:*
         version: link:../packages/render
+      '@react-email/tailwind':
+        specifier: workspace:*
+        version: link:../packages/tailwind
       react:
         specifier: ^19.0.0
         version: 19.0.0


### PR DESCRIPTION
<img width="2233" height="1202" alt="image" src="https://github.com/user-attachments/assets/e7fd16ba-2c4f-4ffb-b3a5-7048c8bcbfc4" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Tailwind errors in the playground caused by csstree by switching to the @react-email/tailwind package. Removes the direct src export and adds the proper dependency.

- **Bug Fixes**
  - Export Tailwind from @react-email/tailwind in playground/components.ts.
  - Add @react-email/tailwind to playground/package.json and update lockfile.

<sup>Written for commit 2fc9d0bc59e0cb4e333b5142ffe86eee883c2555. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

