### PR TITLE
chore(docs): remove deprecated pill for plainText and pretty

### DIFF
--- a/apps/docs/utilities/render.mdx
+++ b/apps/docs/utilities/render.mdx
@@ -103,10 +103,6 @@ This is important because not all email clients and devices can display HTML ema
 
 Here's how to convert a React component into plain text.
 
-<Warning>
-The `plainText` option in the `render` function is deprecated since [@react-email/render@1.2.0](https://github.com/resend/react-email/releases/tag/%40react-email%2Frender%401.2.0). Use the `toPlainText` function instead.
-</Warning>
-
 ```jsx
 import { MyTemplate } from './email';
 import { toPlainText, render } from '@react-email/render';


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the render docs to remove the deprecated flag from the pretty and plainText options, and removed the plainText deprecation warning. These options are supported, and this change avoids confusion in the API docs.

<sup>Written for commit 31a6a32921460ffbb788fe3c065e4cf6c0885ff5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

