### PR TITLE
chore: remove unsused imports causing linting warns

### DIFF
--- a/packages/preview-server/src/actions/render-email-by-path.tsx
+++ b/packages/preview-server/src/actions/render-email-by-path.tsx
@@ -1,6 +1,5 @@
 'use server';
 
-import { log } from 'node:console';
 import fs from 'node:fs';
 import path from 'node:path';
 import logSymbols from 'log-symbols';

--- a/packages/preview-server/src/utils/run-bundled-code.spec.ts
+++ b/packages/preview-server/src/utils/run-bundled-code.spec.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { err, isErr, isOk } from './result';
+import { isErr, isOk } from './result';
 import { runBundledCode } from './run-bundled-code';
 
 describe('runBundledCode()', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed unused imports from render-email-by-path.tsx and run-bundled-code.spec.ts to eliminate lint warnings and keep the code clean.

<sup>Written for commit 19f49448a1882cac59e7e7a0eac8cd0d9c6cc55b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

