### PR TITLE
feat(render): add EmailComponent type for type-safe preview props

### DIFF
--- a/apps/docs/cli.mdx
+++ b/apps/docs/cli.mdx
@@ -100,6 +100,30 @@ your email template when you make changes.
     <Email {...Email.PreviewProps} />;
     ```
 
+    For TypeScript users, you can use the `EmailComponent` type for type-safe preview props:
+
+    ```tsx Email template with TypeScript
+    import { EmailComponent } from "@react-email/components";
+
+    interface EmailProps {
+      source: string;
+    }
+
+    const Email: EmailComponent<EmailProps> = ({ source }) => {
+      return (
+        <div>
+          <a src={source}>click here if you want candy 👀</a>
+        </div>
+      );
+    };
+
+    Email.PreviewProps = {
+      source: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    };
+
+    export default Email;
+    ```
+
   </Accordion>
   <Accordion title="How to make the preview server ignore directories?">
     Once the preview server has started and is now open on `localhost`, the preview server

--- a/packages/render/src/shared/options.ts
+++ b/packages/render/src/shared/options.ts
@@ -2,6 +2,10 @@ import type { HtmlToTextOptions } from 'html-to-text';
 import type { pretty } from './utils/pretty';
 import type { toPlainText } from './utils/to-plain-text';
 
+export type EmailComponent<P = Record<string, unknown>> = React.FC<P> & {
+  PreviewProps: P;
+};
+
 export type Options = {
   /**
    * @see {@link pretty}


### PR DESCRIPTION
feat(render): add EmailComponent type for type-safe preview props

## Summary

- Adds `EmailComponent<P>` type that extends `React.FC<P>` with a `PreviewProps` property
- Enables type-safe assignment of preview props to email components
- Updates CLI docs with TypeScript usage example

## Usage

```tsx
import { EmailComponent } from "@react-email/components";

interface NotionMagicLinkEmailProps {
  loginCode?: string;
}

export const NotionMagicLinkEmail: EmailComponent<NotionMagicLinkEmailProps> = ({
  loginCode,
}) => (
  // ...
);

NotionMagicLinkEmail.PreviewProps = { // type-safe & autocomplete
  loginCode: "sparo-ndigo-amurt-secan",
};
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds EmailComponent<P> to enable type-safe PreviewProps on email components. Updates docs with a TypeScript example to guide usage.

- **New Features**
  - Export EmailComponent<P> (React.FC<P> with PreviewProps: P) in render options.
  - Add CLI docs example showing typed PreviewProps for email templates.

<sup>Written for commit b00b24d1e5471c5d342ffca4da3f1aff8fd8fd91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

