### PR TITLE
fix(web): update check spam snapshot

### DIFF
--- a/apps/web/src/app/api/check-spam/__snapshots__/check-spam.spec.tsx.snap
+++ b/apps/web/src/app/api/check-spam/__snapshots__/check-spam.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`checkSpam() > with most spammy email 1`] = `
     {
       "description": "BODY: Money back guarantee",
       "name": "MONEY_BACK",
-      "points": 2.5,
+      "points": 1,
     },
     {
       "description": "BODY: HTML and text parts are different",
@@ -19,8 +19,8 @@ exports[`checkSpam() > with most spammy email 1`] = `
       "points": 2.2,
     },
   ],
-  "isSpam": true,
-  "points": 5.4,
+  "isSpam": false,
+  "points": 3.9000000000000004,
 }
 `;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update checkSpam snapshot to match the new scoring rules and fix the failing test. MONEY_BACK now scores 1 (was 2.5), total points are 3.9, and the sample email is no longer marked as spam.

<sup>Written for commit b0f7ef827a9638ce8b72f19fdf132f93a098c48e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

