### PR TITLE
fix(preview-server): use 10s timeout for get email component test

### DIFF
--- a/packages/preview-server/src/utils/get-email-component.spec.ts
+++ b/packages/preview-server/src/utils/get-email-component.spec.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { getEmailComponent } from './get-email-component';
 
 describe('getEmailComponent()', () => {
-  test('with a demo email template', async () => {
+  test('with a demo email template', { timeout: 10_000 }, async () => {
     const result = await getEmailComponent(
       path.resolve(__dirname, './testing/vercel-invite-user.tsx'),
       path.resolve(__dirname, '../../jsx-runtime'),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increased the test timeout to 10 seconds for getEmailComponent when using the demo email template to prevent intermittent timeouts in the preview-server spec. This reduces flakiness in CI.

<sup>Written for commit d8d329852ead983498e79e1139587d8a695ce8ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

