### PR TITLE
chore(tailwind): add peer dependencies as dev dependencies

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -32,7 +32,8 @@ jobs:
           dir_names_max_depth: 2
       - name: Run Build
         if: steps.changed_packages.outputs.all_changed_and_modified_files != ''
-        run: pnpm build
+        run: |
+          pnpm build --filter=[HEAD^1]
         env:
           SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
           SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,14 +27,16 @@ jobs:
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run Build
-        run: pnpm build
+        run: |
+          pnpm build --filter=[HEAD^1]
         env:
           SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
           SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       - name: Run Tests
-        run: pnpm test
+        run: |
+          pnpm test --filter=[HEAD^1]
         env:
           SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
           SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}


### PR DESCRIPTION
I noticed the tests were failing in https://github.com/resend/react-email/actions/runs/21145041455/job/60816878885?pr=2858 because it wouldn't build the peer dependencies of `@react-email/tailwind` which was causing the errors to fail, this pull requests adds them in which, after running `pnpm turbo test --filter="[HEAD^1]"` locally, I can confirm it does work.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing @react-email peer dependencies to @react-email/tailwind as devDependencies to ensure peers build during tests and prevent failures.

- **Dependencies**
  - Added: @react-email/body, @react-email/code-block, @react-email/code-inline, @react-email/container, @react-email/img, @react-email/preview, @react-email/text.

<sup>Written for commit fa3e22a0402f8021336c90b6b3f7300b3855b967. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

