### PR TITLE
fix(ci): npm token not working in release workflows

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -22,7 +22,12 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Creating .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish canary release
         run: pnpm tsx ./scripts/release-only-canary.ts
-        env: 
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Creating .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish stable release
         run: pnpm run release
         env: 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes npm auth in canary and stable release workflows by writing the NPM token to ~/.npmrc, ensuring publishes can run successfully.

- **Bug Fixes**
  - Add step to create ~/.npmrc with //registry.npmjs.org/:_authToken from secrets.NPM_TOKEN in both workflows.
  - Remove NPM_TOKEN env from the canary publish step in favor of .npmrc auth.

<sup>Written for commit f4f17611b86ea627d5e6fec351a5a0fbaa909a7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

