### PR TITLE
chore(web): skip checkSpam tests if SPAM_ASSASSIN_HOST or SPAM_ASSASSIN_PORT are not defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-email-monorepo ",
+  "name": "react-email-monorepo",
   "version": "0.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
When someone comes in with a contribution from a fork they won't have the same secrets as us, unless they set it up themselves, which is highly unlikely, this makes it, so their pull requests can only be merged if we bypassed branch rules as the CI will not be passing. See one example here https://github.com/resend/react-email/pull/2868#pullrequestreview-3681857185

To avoid this from happening, the best way I can come up with is simply to skip the tests when the env is not there. That way it can still be tested on `canary` once it's merged, but without disrupting us from merging pull requests from the community.

 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Conditionally skip checkSpam tests when SPAM_ASSASSIN_HOST or SPAM_ASSASSIN_PORT are not set to prevent CI failures on forked PRs without secrets. Tests still run on canary when env vars are present.

<sup>Written for commit 98eb7a5a2b76942c10411c6dc9fdac3b5b6861f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

