### PR TITLE
fix(ci): missing return statement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-email-monorepo ",
+  "name": "react-email-monorepo",
   "version": "0.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
missed a return statement 🥲

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a missing return in scripts/release.ts to stop the release workflow when not in prerelease mode, preventing unintended releases.

<sup>Written for commit c1341f02ea4938ff5ce14f62bfaff3bd6d43f490. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

