### PR TITLE
chore(ci): remove --filter-[HEAD^1] from tests

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
-          fetch-depth: 2
+          fetch-depth: 1
       - run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: pnpm setup
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -32,8 +32,7 @@ jobs:
           dir_names_max_depth: 2
       - name: Run Build
         if: steps.changed_packages.outputs.all_changed_and_modified_files != ''
-        run: |
-          pnpm build --filter=[HEAD^1]
+        run: pnpm build
         env:
           SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
           SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
-          fetch-depth: 2
+          fetch-depth: 1
       - run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: pnpm setup
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,23 +20,21 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
-          fetch-depth: 2
+          fetch-depth: 1
       - run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: pnpm setup
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run Build
-        run: |
-          pnpm build --filter=[HEAD^1]
+        run: pnpm build
         env:
           SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
           SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       - name: Run Tests
-        run: |
-          pnpm test --filter=[HEAD^1]
+        run: pnpm test
         env:
           SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
           SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}


### PR DESCRIPTION
Mainly the reason to remove this is that it compares against the last commit only, making the CI for pull requests not test the entire pull request but just the last commit that it had. We don't have to remove it from everything, only for things that just run on pull requests, we can keep them for commits in branches like canary and main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run full PR builds and tests instead of only the last commit by removing pnpm --filter=[HEAD^1] from PR workflows. Also set checkout fetch-depth to 1 to speed up CI.

- **Refactors**
  - Removed --filter=[HEAD^1] from preview-release and tests workflows so PRs build and test all changes.
  - Set actions/checkout fetch-depth: 1 in bump, release, and tests to reduce clone size and remove dependency on previous commits.

<sup>Written for commit bbe1114da5c4687f5f38a97372fa5ab6b3105fb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

