### PR TITLE
chore(docs): guide users to opening pull requests directly to canary

### DIFF
--- a/apps/docs/contributing/opening-pull-requests.mdx
+++ b/apps/docs/contributing/opening-pull-requests.mdx
@@ -34,12 +34,8 @@ Please create your pull request using the following steps:
 
 1. Create [a fork](https://github.com/resend/react-email/fork) of the repo
 2. Create a new branch that represents your changes
-    * If your PR is for anything inside `apps/*`, you should create your new branch from `main`
-    * Otherwise, switch to the `canary` branch to create your new branch from it
 3. Make your changes and commit them to your branch
-4. Create the pull request from your fork
-    * If the PR is for anything inside `apps/*`, open a PR into `main`
-    * Otherwise, open a PR into the `canary` branch
+4. Create the pull request from your fork pointing to the `canary` branch
 
 ## Writing a good description
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update contributing guide to simplify the PR flow: always open pull requests to the canary branch and remove the apps/* vs main exception.

<sup>Written for commit 94e06fda005be105a4670fbb093a38090209b97b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

