### PR TITLE
fix(react-email): installPreviewServer test failing with unreleased version

### DIFF
--- a/packages/react-email/src/utils/get-preview-server-location.spec.ts
+++ b/packages/react-email/src/utils/get-preview-server-location.spec.ts
@@ -1,16 +1,17 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { installPreviewServer } from './get-preview-server-location.js';
-import { packageJson } from './packageJson.js';
 
 test.sequential('installPreviewServer()', { timeout: 60_000 }, async () => {
   const testDirectory = path.join(import.meta.dirname, '.test');
-  await installPreviewServer(testDirectory, packageJson.version);
+  // Pinned version here because the one in `package.json` might be unreleased
+  const version = '5.2.5';
+  await installPreviewServer(testDirectory, version);
   expect(fs.existsSync(testDirectory)).toBe(true);
 
   const importedModule = await import(path.join(testDirectory, 'index.mjs'));
   expect({ ...importedModule }).toEqual({
-    version: packageJson.version,
+    version,
   });
   await fs.promises.rm(testDirectory, { recursive: true, force: true });
 });


### PR DESCRIPTION
https://github.com/resend/react-email/actions/runs/21294480971/job/61296595314?pr=2878

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the installPreviewServer test to version 5.2.5 instead of using package.json’s version to avoid failures when package.json points to an unreleased version. This stabilizes CI and ensures the test imports the expected module.

<sup>Written for commit 87531e3167a2c2ed2d968140302b7c5a0838a6a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

