### PR TITLE
fix(react-email): local demo build failing

### DIFF
--- a/packages/react-email/src/utils/get-preview-server-location.ts
+++ b/packages/react-email/src/utils/get-preview-server-location.ts
@@ -11,7 +11,10 @@ import { extract } from 'tar';
 import { packageJson } from './packageJson.js';
 import { registerSpinnerAutostopping } from './register-spinner-autostopping.js';
 
-const isInMonorepo = !import.meta.dirname.includes('node_modules');
+/**
+ * This is only true in the React Email monorepo, and is meant to improve the DX on our side without affect user's DX.
+ */
+export const isInMonorepo = !import.meta.dirname.includes('node_modules');
 
 export async function installPreviewServer(directory: string, version: string) {
   const spinner = ora({


### PR DESCRIPTION
this is happening because we're copying over the node_modules of our monorepo which, because of pnpm, uses symlinks for the modules and thus requires that the rootDir here be the root of the monorepo itself

this changes only behavior on our side, should not change anything for users

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the local demo build by setting Next.js root to the monorepo root when running inside our pnpm workspace. This only affects our dev setup, not users.

- **Bug Fixes**
  - Detect monorepo via exported isInMonorepo.
  - Resolve rootDir with @manypkg/get-packages and use it in Next config.
  - Set turbopack.root and outputFileTracingRoot to rootDir instead of the preview server path.

<sup>Written for commit 5bfbab635037aaad7e3ee9c09b29ccc5e2ab926c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

