### PR TITLE
chore: exit canary

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "canary",
   "initialVersions": {
     "demo": "0.0.0",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Exited canary prerelease by setting Changesets mode to "exit" for the "canary" tag. This ends the canary cycle and resumes the normal release flow.

<sup>Written for commit efc62c554959a7edb8701d88c32d3c11ee702678. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

