### PR TITLE
fix(biome): breaking line endings for Windows

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -18,6 +18,7 @@
     "useIgnoreFile": false
   },
   "formatter": {
+    "lineEnding": "auto",
     "indentStyle": "space",
     "indentWidth": 2,
     "lineWidth": 80


### PR DESCRIPTION
By default, git converts all LF (\n) to CRLF (\r\n) during checkout on Windows, and converts back to LF (\n) when pushing to the repo. But, when running `pnpm lint:fix`, biome was converting everything to LF which was modifying all files in the repository in a way that makes no sense really, causing warnings like:

```sh
warning: in the working copy of '.changeset/config.json', LF will be replaced by CRLF the next time Git touches it
```

if running `git diff` after. To avoid this from happening, just setting `"linEnding": "auto"` for biome uses the right line ending depending on the OS letting git handle them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set Biome formatter "lineEnding" to "auto" so it respects the OS and stops rewriting files to LF on Windows. This prevents noisy diffs and Git LF/CRLF warnings after running pnpm lint:fix.

<sup>Written for commit 15d0e4ba987d641e6fa6f3d2d2f5b731a035971d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

