### PR TITLE
fix(preview): increase max length from 150 to 200 chars

### DIFF
--- a/packages/preview/src/preview.tsx
+++ b/packages/preview/src/preview.tsx
@@ -6,7 +6,7 @@ export type PreviewProps = Readonly<
   }
 >;
 
-const PREVIEW_MAX_LENGTH = 150;
+const PREVIEW_MAX_LENGTH = 200;
 
 export const Preview = React.forwardRef<HTMLDivElement, PreviewProps>(
   ({ children = '', ...props }, ref) => {


### PR DESCRIPTION
## Summary

Fixes #2268

Gmail Web displays up to 200 characters in email previews, but the `<Preview>` component was only padding whitespace up to 150 characters. This caused body content to leak into the preview when preview text was between ~135-150 characters.

## The Problem

When preview text is close to 150 chars:
1. Component pads whitespace to reach 150 total
2. Gmail shows 200 chars in preview area
3. Gmail pulls the remaining ~50 chars from `<body>` content
4. Result: body content appears in preview (see issue screenshots)

## The Fix

```typescript
// Before
const PREVIEW_MAX_LENGTH = 150;

// After  
const PREVIEW_MAX_LENGTH = 200;
```

Simple one-line change to match Gmail's actual preview length.

## Testing

This should be verified by:
1. Creating an email with ~150 char preview text
2. Sending to Gmail
3. Confirming body content no longer leaks into preview

---
*PR submitted by Woz 🤖*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase preview length to 200 chars in the Preview component to match Gmail Web and stop body content from leaking into the preview (fixes #2268).

<sup>Written for commit b7ad5340a37ed9bc765e788a04618ab10d82d05d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

