### PR TITLE
fix(react-email): installation failure in build when bumping @react-email/tailwind

### DIFF
--- a/packages/react-email/src/commands/build.ts
+++ b/packages/react-email/src/commands/build.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getPackages } from '@manypkg/get-packages';
 import logSymbols from 'log-symbols';
 import { installDependencies, type PackageManagerName, runScript } from 'nypm';
@@ -16,7 +17,8 @@ interface Args {
   packageManager: PackageManagerName;
 }
 
-const isInReactEmailMonorepo = !import.meta.dirname.includes('node_modules');
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const isInReactEmailMonorepo = !dirname.includes('node_modules');
 
 const setNextEnvironmentVariablesForBuild = async (
   emailsDirRelativePath: string,


### PR DESCRIPTION
This has the trade-off of our *current* CI not dogfooding the build workflow, but it's the only way currently to avoid the demo build not working when `@react-email/tailwind` is bumped, like https://vercel.com/resend/react-email-demo/GYaeyCR2Am9jCGnsV9uw3gv7Tsvu

This is equivalent to this exact workaround we had in #2924 that was indeed working.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preview build by copying node_modules only when running inside the React Email monorepo and skipping dependency installs there. Also sets Turbopack and tracing roots to the monorepo to avoid broken demo builds after package bumps.

- **Bug Fixes**
  - Detects monorepo context and copies node_modules into .react-email only in that case.
  - Skips installDependencies in monorepo; keeps installs outside the monorepo.
  - Sets turbopack.root and outputFileTracingRoot to the monorepo root for correct tracing.
  - Normalizes paths and updates copy filter to ignore .next/.turbo and conditionally node_modules.

<sup>Written for commit 9b5a238862ec60641f54a673d4a8e12d5ed4d7c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

