### PR TITLE
feat(ci): setup trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions: 
       id-token: write
-      contents: read
+      contents: write
     container:
       image: node:22
     steps:


### PR DESCRIPTION
https://docs.npmjs.com/trusted-publishers#recommended-restrict-token-access-when-using-trusted-publishers

I've already enabled the connection between the npm packages and this repo's release.yml. After this, in theory, it should all work without any personal npm token.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the release workflow to npm Trusted Publishing using GitHub OIDC. This removes the personal NPM token and reduces permissions for safer automated releases.

- **New Features**
  - Use OIDC with id-token: write and contents: write; drop pull-requests: write.
  - Remove .npmrc and NPM_TOKEN; publishing uses the Trusted Publisher link.

<sup>Written for commit 941b4e6f8bcdd9aa94f77bf9d709902e8617db1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

