### PR TITLE
fix(ci): missing OIDC env for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,5 @@ jobs:
         run: pnpm tsx ./scripts/release.ts
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTIONS_ID_TOKEN_REQUEST_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}
+          ACTIONS_ID_TOKEN_REQUEST_TOKEN: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}


### PR DESCRIPTION
see #2931 and https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-cloud-providers#requesting-the-jwt-using-environment-variables for reference

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN in the release workflow to enable OIDC JWT requests. Fixes release runs failing to obtain an ID token.

<sup>Written for commit 5a22a048db5d877ce805c6583311786665c102a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

