### PR TITLE
chore(ci): use github-hosted runner for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     permissions: 
       id-token: write
       contents: write


### PR DESCRIPTION
[Provenance](https://docs.npmjs.com/generating-provenance-statements) is not supported on runners that aren't hosted by GitHub, so I think it's worth it for us to use GItHub's just for the release workflow.

https://github.com/resend/react-email/actions/runs/21676909109/job/62499778929



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the release workflow to a GitHub-hosted runner to enable npm provenance when publishing packages. Updated runs-on to ubuntu-latest in .github/workflows/release.yml.

<sup>Written for commit da3e2733e210b71d06ab1d7858f1faed5cc54f21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

