### PR TITLE
fix: linting

### DIFF
--- a/packages/preview-server/src/actions/email-validation/check-images.spec.tsx
+++ b/packages/preview-server/src/actions/email-validation/check-images.spec.tsx
@@ -1,5 +1,4 @@
 import type { IncomingMessage } from 'node:http';
-import { Readable } from 'node:stream';
 import { checkImages, type ImageCheckingResult } from './check-images';
 
 vi.mock('./quick-fetch', () => ({


### PR DESCRIPTION
fixing linting warnings that don't break CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused Readable import in packages/preview-server/src/actions/email-validation/check-images.spec.tsx to clear lint warnings. No test or runtime behavior changes.

<sup>Written for commit f216277d0f235f5552a91be46dd7e476d8561785. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

