### PR TITLE
fix(tailwind): hsl and hsla colors for ms outlook

### DIFF
--- a/packages/tailwind/src/utils/css/sanitize-declarations.spec.ts
+++ b/packages/tailwind/src/utils/css/sanitize-declarations.spec.ts
@@ -148,6 +148,165 @@ describe('sanitizeDeclarations', () => {
     );
   });
 
+  test('hsl to rgb conversion', () => {
+    let stylesheet = parse('div { color: hsl(198, 65%, 45%); }');
+    sanitizeDeclarations(stylesheet);
+    expect(
+      generate(stylesheet),
+      'conversion without alpha',
+    ).toMatchInlineSnapshot(`"div{color:rgb(40,145,189)}"`);
+
+    stylesheet = parse('div { color: hsl(0, 100%, 50%); }');
+    sanitizeDeclarations(stylesheet);
+    expect(generate(stylesheet), 'pure red').toMatchInlineSnapshot(
+      `"div{color:rgb(255,0,0)}"`,
+    );
+
+    stylesheet = parse('div { color: hsl(120, 100%, 50%); }');
+    sanitizeDeclarations(stylesheet);
+    expect(generate(stylesheet), 'pure green').toMatchInlineSnapshot(
+      `"div{color:rgb(0,255,0)}"`,
+    );
+
+    stylesheet = parse('div { color: hsl(240, 100%, 50%); }');
+    sanitizeDeclarations(stylesheet);
+    expect(generate(stylesheet), 'pure blue').toMatchInlineSnapshot(
+      `"div{color:rgb(0,0,255)}"`,
+    );
+
+    stylesheet = parse('div { color: hsl(0, 0%, 0%); }');
+    sanitizeDeclarations(stylesheet);
+    expect(generate(stylesheet), 'black').toMatchInlineSnapshot(
+      `"div{color:rgb(0,0,0)}"`,
+    );
+
+    stylesheet = parse('div { color: hsl(0, 0%, 100%); }');
+    sanitizeDeclarations(stylesheet);
+    expect(generate(stylesheet), 'white').toMatchInlineSnapshot(
+      `"div{color:rgb(255,255,255)}"`,
+    );
+
+    stylesheet = parse('div { color: hsl(0, 0%, 50%); }');
+    sanitizeDeclarations(stylesheet);
+    expect(generate(stylesheet), 'grey with no saturation').toMatchInlineSnapshot(
+      `"div{color:rgb(128,128,128)}"`,
+    );
+
+    stylesheet = parse('div { color: hsl(198deg, 65%, 45%); }');
+    sanitizeDeclarations(stylesheet);
+    expect(
+      generate(stylesheet),
+      'conversion with deg unit',
+    ).toMatchInlineSnapshot(`"div{color:rgb(40,145,189)}"`);
+
+    stylesheet = parse('div { color: hsl(198 65% 45%); }');
+    sanitizeDeclarations(stylesheet);
+    expect(
+      generate(stylesheet),
+      'space syntax without alpha',
+    ).toMatchInlineSnapshot(`"div{color:rgb(40,145,189)}"`);
+
+    stylesheet = parse('div { color: hsl(198 65% 45% / 0.5); }');
+    sanitizeDeclarations(stylesheet);
+    expect(
+      generate(stylesheet),
+      'space syntax with alpha',
+    ).toMatchInlineSnapshot(`"div{color:rgb(40,145,189,0.5)}"`);
+
+    stylesheet = parse('div { color: hsl(198 65% 45% / 50%); }');
+    sanitizeDeclarations(stylesheet);
+    expect(
+      generate(stylesheet),
+      'space syntax with percentage alpha',
+    ).toMatchInlineSnapshot(`"div{color:rgb(40,145,189,0.5)}"`);
+
+    stylesheet = parse(
+      'div { background: linear-gradient(hsl(0, 100%, 50%), hsl(120, 100%, 50%)); }',
+    );
+    sanitizeDeclarations(stylesheet);
+    expect(
+      generate(stylesheet),
+      'hsl inside linear-gradient',
+    ).toMatchInlineSnapshot(
+      `"div{background:linear-gradient(rgb(255,0,0),rgb(0,255,0))}"`,
+    );
+
+    stylesheet = parse(`
+      div {
+        color: hsl(0, 100%, 50%);
+        background-color: hsl(120, 100%, 50%);
+        border-color: hsl(240, 100%, 50%);
+      }
+    `);
+    sanitizeDeclarations(stylesheet);
+    expect(
+      generate(stylesheet),
+      'multiple hsl declarations',
+    ).toMatchInlineSnapshot(
+      `"div{color:rgb(255,0,0);background-color:rgb(0,255,0);border-color:rgb(0,0,255)}"`,
+    );
+  });
+
+  test('hsla to rgb conversion', () => {
+    let stylesheet = parse('div { color: hsla(90, 80%, 50%, 0.5); }');
+    sanitizeDeclarations(stylesheet);
+    expect(
+      generate(stylesheet),
+      'comma syntax with alpha',
+    ).toMatchInlineSnapshot(`"div{color:rgb(128,230,25,0.5)}"`);
+
+    stylesheet = parse('div { color: hsla(0, 100%, 50%, 1); }');
+    sanitizeDeclarations(stylesheet);
+    expect(generate(stylesheet), 'alpha of 1').toMatchInlineSnapshot(
+      `"div{color:rgb(255,0,0)}"`,
+    );
+
+    stylesheet = parse('div { color: hsla(0, 100%, 50%, 0); }');
+    sanitizeDeclarations(stylesheet);
+    expect(
+      generate(stylesheet),
+      'fully transparent',
+    ).toMatchInlineSnapshot(`"div{color:rgb(255,0,0,0)}"`);
+
+    stylesheet = parse('div { color: hsla(240, 100%, 50%, 0.75); }');
+    sanitizeDeclarations(stylesheet);
+    expect(generate(stylesheet), 'blue with alpha').toMatchInlineSnapshot(
+      `"div{color:rgb(0,0,255,0.75)}"`,
+    );
+
+    stylesheet = parse('div { color: hsla(198deg, 65%, 45%, 0.8); }');
+    sanitizeDeclarations(stylesheet);
+    expect(
+      generate(stylesheet),
+      'deg unit with alpha',
+    ).toMatchInlineSnapshot(`"div{color:rgb(40,145,189,0.8)}"`);
+
+    stylesheet = parse('div { color: hsla(198 65% 45% / 0.3); }');
+    sanitizeDeclarations(stylesheet);
+    expect(
+      generate(stylesheet),
+      'space syntax with slash alpha',
+    ).toMatchInlineSnapshot(`"div{color:rgb(40,145,189,0.3)}"`);
+
+    stylesheet = parse('div { color: hsla(198 65% 45% / 70%); }');
+    sanitizeDeclarations(stylesheet);
+    expect(
+      generate(stylesheet),
+      'space syntax with percentage alpha',
+    ).toMatchInlineSnapshot(`"div{color:rgb(40,145,189,0.7)}"`);
+
+    stylesheet = parse(
+      'div { background: linear-gradient(hsla(0, 100%, 50%, 0), hsla(0, 100%, 50%, 1)); }',
+    );
+    sanitizeDeclarations(stylesheet);
+    expect(
+      generate(stylesheet),
+      'hsla inside linear-gradient',
+    ).toMatchInlineSnapshot(
+      `"div{background:linear-gradient(rgb(255,0,0,0),rgb(255,0,0))}"`,
+    );
+  });
+
   test('rgba space syntax to comma syntax conversion', () => {
     let stylesheet = parse('div { color: rgb(255 0 128); }');
     sanitizeDeclarations(stylesheet);


### PR DESCRIPTION
Fixes https://github.com/resend/react-email/issues/2947 partially.
When using tailwind it converts hsl and hsla similar to existing rgb sanitization

If you can suggest me how you wish this to be handled for non-tailwind react-email, I can fix it there as well.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts hsl() and hsla() colors to rgb during Tailwind CSS sanitization to ensure correct rendering in Microsoft Outlook. Adds tests covering multiple syntaxes and alpha formats.

- **Bug Fixes**
  - Parse and convert hsl/hsla (comma and space syntax, deg units, numeric and percentage alpha) to rgb with optional alpha.
  - Support hsl/hsla inside nested functions like linear-gradient.
  - Added unit tests for pure colors, grayscale, alpha cases, and multiple declarations.

<sup>Written for commit 7d5fb1fe966d86aa02b9d1daa990b667276edd03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

