### PR TITLE
fix(markdown,font): sanitize HTML attributes and CSS values to prevent XSS and injection

### DIFF
--- a/packages/font/src/font.tsx
+++ b/packages/font/src/font.tsx
@@ -23,6 +23,10 @@ type FontFormat =
 type FontWeight = React.CSSProperties['fontWeight'];
 type FontStyle = React.CSSProperties['fontStyle'];
 
+function sanitizeCssValue(value: string): string {
+  return value.replace(/[';}{\\<>]/g, '');
+}
+
 export interface FontProps {
   /** The font you want to use. NOTE: Do not insert multiple fonts here, use fallbackFontFamily for that */
   fontFamily: string;
@@ -47,29 +51,28 @@ export const Font: React.FC<Readonly<FontProps>> = ({
   fontStyle = 'normal',
   fontWeight = 400,
 }) => {
+  const safeFontFamily = sanitizeCssValue(fontFamily);
+  const safeFontStyle = sanitizeCssValue(String(fontStyle));
+  const safeFontWeight = sanitizeCssValue(String(fontWeight));
+  const safeFallbacks = Array.isArray(fallbackFontFamily)
+    ? fallbackFontFamily.map(sanitizeCssValue)
+    : [sanitizeCssValue(fallbackFontFamily)];
+
   const src = webFont
-    ? `src: url(${webFont.url}) format('${webFont.format}');`
+    ? `src: url(${sanitizeCssValue(webFont.url)}) format('${sanitizeCssValue(webFont.format)}');`
     : '';
 
   const style = `
     @font-face {
-      font-family: '${fontFamily}';
-      font-style: ${fontStyle};
-      font-weight: ${fontWeight};
-      mso-font-alt: '${
-        Array.isArray(fallbackFontFamily)
-          ? fallbackFontFamily[0]
-          : fallbackFontFamily
-      }';
+      font-family: '${safeFontFamily}';
+      font-style: ${safeFontStyle};
+      font-weight: ${safeFontWeight};
+      mso-font-alt: '${safeFallbacks[0]}';
       ${src}
     }
 
     * {
-      font-family: '${fontFamily}', ${
-        Array.isArray(fallbackFontFamily)
-          ? fallbackFontFamily.join(', ')
-          : fallbackFontFamily
-      };
+      font-family: '${safeFontFamily}', ${safeFallbacks.join(', ')};
     }
   `;
   return <style dangerouslySetInnerHTML={{ __html: style }} />;

--- a/packages/markdown/src/markdown.spec.tsx
+++ b/packages/markdown/src/markdown.spec.tsx
@@ -116,7 +116,7 @@ console.log(\`Hello, $\{name}!\`);
       </Markdown>,
     );
     expect(actualOutput).toMatchInlineSnapshot(`
-      "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div data-id="react-email-markdown"><p><strong style="font:700 23px / 32px &#x27;Roobert PRO&#x27;, system-ui, sans-serif;background:url(&#x27;path/to/image&#x27;)">This is sample bold text in markdown</strong> and <em style="font-style:italic">this is italic text</em></p>
+      "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div data-id="react-email-markdown"><p><strong style="font:700 23px / 32px &quot;Roobert PRO&quot;, system-ui, sans-serif;background:url(&quot;path/to/image&quot;)">This is sample bold text in markdown</strong> and <em style="font-style:italic">this is italic text</em></p>
       </div><!--/$-->"
     `);
   });

--- a/packages/markdown/src/markdown.tsx
+++ b/packages/markdown/src/markdown.tsx
@@ -3,6 +3,15 @@ import * as React from 'react';
 import { type StylesType, styles } from './styles';
 import { parseCssInJsToInlineCss } from './utils/parse-css-in-js-to-inline-css';
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export type MarkdownProps = Readonly<{
   children: string;
   markdownCustomStyles?: StylesType;
@@ -37,7 +46,7 @@ export const Markdown = React.forwardRef<HTMLDivElement, MarkdownProps>(
 
     // TODO: Support all options
     renderer.code = ({ text }) => {
-      text = `${text.replace(/\n$/, '')}\n`;
+      text = `${escapeHtml(text).replace(/\n$/, '')}\n`;
 
       return `<pre${
         parseCssInJsToInlineCss(finalStyles.codeBlock) !== ''
@@ -97,8 +106,8 @@ export const Markdown = React.forwardRef<HTMLDivElement, MarkdownProps>(
     };
 
     renderer.image = ({ href, text, title }) => {
-      return `<img src="${href.replaceAll('"', '&quot;')}" alt="${text.replaceAll('"', '&quot;')}"${
-        title ? ` title="${title}"` : ''
+      return `<img src="${escapeHtml(href)}" alt="${escapeHtml(text)}"${
+        title ? ` title="${escapeHtml(title)}"` : ''
       }${
         parseCssInJsToInlineCss(finalStyles.image) !== ''
           ? ` style="${parseCssInJsToInlineCss(finalStyles.image)}"`
@@ -109,8 +118,8 @@ export const Markdown = React.forwardRef<HTMLDivElement, MarkdownProps>(
     renderer.link = ({ href, title, tokens }) => {
       const text = renderer.parser.parseInline(tokens);
 
-      return `<a href="${href}" target="_blank"${
-        title ? ` title="${title}"` : ''
+      return `<a href="${escapeHtml(href)}" target="_blank"${
+        title ? ` title="${escapeHtml(title)}"` : ''
       }${
         parseCssInJsToInlineCss(finalStyles.link) !== ''
           ? ` style="${parseCssInJsToInlineCss(finalStyles.link)}"`

--- a/packages/markdown/src/utils/parse-css-in-js-to-inline-css.ts
+++ b/packages/markdown/src/utils/parse-css-in-js-to-inline-css.ts
@@ -4,7 +4,7 @@ function camelToKebabCase(str: string): string {
 
 function escapeQuotes(value: unknown) {
   if (typeof value === 'string' && value.includes('"')) {
-    return value.replace(/"/g, '&#x27;');
+    return value.replace(/"/g, '&quot;');
   }
   return value;
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

## Summary

Fixes 5 security vulnerabilities found in the `@react-email/markdown` and `@react-email/font` packages:

1. **XSS via Markdown link `href`** — `href` in the link renderer was interpolated into HTML without any escaping, allowing attribute injection.
2. **XSS via Markdown `title` attribute** — Both image and link `title` attributes were inserted raw, enabling event handler injection (e.g. `"onmouseover=alert(1)`).
3. **XSS via Markdown code blocks** — Content inside fenced code blocks was rendered as raw HTML, so `<script>` tags would execute.
4. **CSS injection via Font component** — All Font props (`fontFamily`, `fontStyle`, `fontWeight`, `fallbackFontFamily`, `webFont.url/format`) were interpolated directly into `<style dangerouslySetInnerHTML>` without sanitization.
5. **Wrong HTML entity in CSS quote escaping** — `escapeQuotes()` in `parse-css-in-js-to-inline-css.ts` replaced `"` with `&#x27;` (single quote entity) instead of `&quot;` (double quote entity), producing incorrect CSS values.

## Changes

### `packages/markdown/src/markdown.tsx`
- Added `escapeHtml()` utility that escapes `&`, `<`, `>`, `"`, `'`
- Applied `escapeHtml()` to link `href`, link `title`, image `src`, image `alt`, image `title`, and code block `text`

### `packages/markdown/src/utils/parse-css-in-js-to-inline-css.ts`
- Fixed `&#x27;` → `&quot;` in `escapeQuotes()`

### `packages/font/src/font.tsx`
- Added `sanitizeCssValue()` that strips `' ; { } \ < >` characters
- Applied to all values interpolated into the `<style>` tag: `fontFamily`, `fontStyle`, `fontWeight`, `fallbackFontFamily`, `webFont.url`, `webFont.format`

### `packages/markdown/src/markdown.spec.tsx`
- Updated inline snapshot to reflect corrected `&quot;` entity

## Test plan

- [x] Existing `@react-email/markdown` tests pass with updated snapshots
- [x] Existing `@react-email/font` tests pass (no snapshot changes needed)
- [ ] Verify markdown with special characters in links, titles, and code blocks renders safely
- [ ] Verify Font component with normal font families renders correctly
- [ ] Verify CSS custom styles with quoted values (e.g. `font-family: "Roobert PRO"`) use `&quot;` not `&#x27;`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes markdown attributes and Font CSS values to block XSS and CSS injection. Also fixes quote escaping to use &quot; in inline CSS.

- **Bug Fixes**
  - Escape HTML in markdown: link href/title, image src/alt/title, and fenced code text.
  - Sanitize Font props before injecting CSS by stripping unsafe characters from fontFamily, fontStyle, fontWeight, fallbackFontFamily, webFont.url/format.
  - Replace incorrect &#x27; with &quot; for double quotes in CSS; updated snapshot.

