### PR TITLE
fix(render): suspense tests

### DIFF
--- a/packages/render/src/browser/render-web.spec.tsx
+++ b/packages/render/src/browser/render-web.spec.tsx
@@ -152,7 +152,9 @@ describe('render on the browser environment', () => {
 
     const renderedTemplate = await render(<EmailTemplate />);
 
-    expect(renderedTemplate).toMatchInlineSnapshot(`"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$?--><template id="B:0"></template><!--/$--><div hidden id="S:0"><div><p>example content with some multibyte characters: 情報Ⅰ</p></div></div><script>$RC=function(b,c,e){c=document.getElementById(c);c.parentNode.removeChild(c);var a=document.getElementById(b);if(a){b=a.previousSibling;if(e)b.data="$!",a.setAttribute("data-dgst",e);else{e=b.parentNode;a=b.nextSibling;var f=0;do{if(a&&8===a.nodeType){var d=a.data;if("/$"===d)if(0===f)break;else f--;else"$"!==d&&"$?"!==d&&"$!"!==d||f++}d=a.nextSibling;e.removeChild(a);a=d}while(a);for(;c.firstChild;)e.insertBefore(c.firstChild,a);b.data="$"}b._reactRetry&&b._reactRetry()}};$RC("B:0","S:0")</script>"`);
+    expect(renderedTemplate).toMatchInlineSnapshot(
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$?--><template id="B:0"></template><!--/$--><div hidden id="S:0"><div><p>example content with some multibyte characters: 情報Ⅰ</p></div></div><script>$RC=function(b,c,e){c=document.getElementById(c);c.parentNode.removeChild(c);var a=document.getElementById(b);if(a){b=a.previousSibling;if(e)b.data="$!",a.setAttribute("data-dgst",e);else{e=b.parentNode;a=b.nextSibling;var f=0;do{if(a&&8===a.nodeType){var d=a.data;if("/$"===d)if(0===f)break;else f--;else"$"!==d&&"$?"!==d&&"$!"!==d||f++}d=a.nextSibling;e.removeChild(a);a=d}while(a);for(;c.firstChild;)e.insertBefore(c.firstChild,a);b.data="$"}b._reactRetry&&b._reactRetry()}};$RC("B:0","S:0")</script>"`,
+    );
   });
 
   // See https://github.com/resend/react-email/issues/2263

--- a/packages/render/src/node/render-node.spec.tsx
+++ b/packages/render/src/node/render-node.spec.tsx
@@ -116,7 +116,9 @@ describe('render on node environments', () => {
       </Suspense>,
     );
 
-    expect(renderedTemplate).toMatchInlineSnapshot(`"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><!--$--><div><p>example content with some multibyte characters: 情報Ⅰ</p></div><!--/$--><!--/$-->"`);
+    expect(renderedTemplate).toMatchInlineSnapshot(
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><!--$--><div><p>example content with some multibyte characters: 情報Ⅰ</p></div><!--/$--><!--/$-->"`,
+    );
   });
 
   it('converts a React component into HTML', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilized Suspense rendering tests by replacing external fetches with a controlled promise and updating snapshots. This removes network dependency, reduces flakiness, and verifies multibyte content rendering.

- **Bug Fixes**
  - Replaced fetch with a 500ms Promise returning HTML.
  - Updated inline snapshots and linted specs in browser and node tests to match final Suspense output.
  - Ensures tests reliably wait for Suspense to resolve before asserting.

<sup>Written for commit 333256311307ed2c1295a9e35275846859033c94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

