### PR TITLE
feat(editor): delete when doing backspace in next empty node

### DIFF
--- a/packages/editor/src/extensions/columns.tsx
+++ b/packages/editor/src/extensions/columns.tsx
@@ -187,6 +187,35 @@ export const ColumnsColumn = EmailNode.create({
 
   addKeyboardShortcuts() {
     return {
+      Backspace: ({ editor }) => {
+        const { state } = editor;
+        const { selection } = state;
+        const { empty, $from } = selection;
+
+        if (!empty) return false;
+
+        for (let depth = $from.depth; depth >= 1; depth--) {
+          if ($from.pos !== $from.start(depth)) break;
+
+          const indexInParent = $from.index(depth - 1);
+
+          if (indexInParent === 0) continue;
+
+          const parent = $from.node(depth - 1);
+          const prevNode = parent.child(indexInParent - 1);
+
+          if (COLUMN_PARENT_SET.has(prevNode.type.name)) {
+            const deleteFrom = $from.before(depth) - prevNode.nodeSize;
+            const deleteTo = $from.before(depth);
+            editor.view.dispatch(state.tr.delete(deleteFrom, deleteTo));
+            return true;
+          }
+
+          break;
+        }
+
+        return false;
+      },
       'Mod-a': ({ editor }) => {
         const { state } = editor;
         const { $from } = state.selection;


### PR DESCRIPTION
When the cursor is positioned right after a columns node and the user presses backspace, the entire columns node is now deleted. This works by walking up the document tree from the cursor position to find if the previous sibling at any ancestor level is a columns parent node (twoColumns, threeColumns, or fourColumns), and if so, deleting it.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backspace now deletes the entire columns block when the cursor is immediately after it. This makes deletion predictable for two-, three-, and four-column nodes, including inside nested wrappers.

- **Bug Fixes**
  - Added a Backspace shortcut that walks up the selection to find a previous sibling columns parent (twoColumns, threeColumns, fourColumns) and deletes it in one action.

<sup>Written for commit a26ae43d66eea7c687f330085a031d31136d6834. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

