### PR TITLE
feat(editor): scope Ctrl+A/Cmd+A selection to code block content

### DIFF
--- a/packages/editor/src/extensions/code-block.tsx
+++ b/packages/editor/src/extensions/code-block.tsx
@@ -6,6 +6,7 @@ import {
 import { mergeAttributes } from '@tiptap/core';
 import type { CodeBlockOptions } from '@tiptap/extension-code-block';
 import CodeBlock from '@tiptap/extension-code-block';
+import { TextSelection } from '@tiptap/pm/state';
 import { EmailNode } from '../core/email-node';
 import { PrismPlugin } from './prism-plugin';
 
@@ -90,6 +91,38 @@ export const CodeBlockPrism = EmailNode.from(
           0,
         ],
       ];
+    },
+
+    addKeyboardShortcuts() {
+      return {
+        ...this.parent?.(),
+        'Mod-a': ({ editor }) => {
+          const { state } = editor;
+          const { selection } = state;
+          const { $from } = selection;
+
+          for (let depth = $from.depth; depth >= 1; depth--) {
+            if ($from.node(depth).type.name === this.name) {
+              const blockStart = $from.start(depth);
+              const blockEnd = $from.end(depth);
+
+              const alreadyFullySelected =
+                selection.from === blockStart && selection.to === blockEnd;
+              if (alreadyFullySelected) {
+                return false;
+              }
+
+              const tr = state.tr.setSelection(
+                TextSelection.create(state.doc, blockStart, blockEnd),
+              );
+              editor.view.dispatch(tr);
+              return true;
+            }
+          }
+
+          return false;
+        },
+      };
     },
 
     addProseMirrorPlugins() {


### PR DESCRIPTION
When the cursor is inside a code block, pressing Ctrl+A (or Cmd+A on Mac) now selects only the content within that code block instead of the entire document. Pressing Ctrl+A again when the full code block is already selected falls through to the default select-all behavior.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ctrl/Cmd+A now selects only the content of the current code block when your cursor is inside it. Pressing it again selects the entire document.

<sup>Written for commit d6562b619e0cc97fc4892272ea2f450f0dd0afeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

