### PR TITLE
chore(ci): install dependencies for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,5 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run Lint
         run: pnpm lint
-        e
-         nv:
+        env:
           SKIP_ENV_VALIDATION: true


### PR DESCRIPTION
It can fail when things involve types from dependencies. Example where it fails in CI, but works locally:

https://github.com/resend/react-email/actions/runs/22586052876/job/65431858338

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install dependencies before running lint in CI and switch to the repo’s lint script. This makes type-aware linting consistent with local runs and prevents CI-only failures.

- **Bug Fixes**
  - Install deps in the lint job: pnpm install --frozen-lockfile --prefer-offline.
  - Use pnpm lint instead of pnpm dlx biome to leverage local config and types.
  - Fix workflow YAML so the lint job runs reliably in CI.

<sup>Written for commit 0ee01af18927923a5e9d4597f0270ea8f26aedad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

