### PR TITLE
fix(ci): e2e failing because of not building first

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,13 @@ jobs:
         uses: pnpm/action-setup@9b5745cdf0a2e8c2620f0746130f809adb911c19
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Run Build
+        run: pnpm build
+        env:
+          SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
+          SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       - name: Run Tailwind integration tests
         run: pnpm turbo test:e2e
         env:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update e2e GitHub Actions workflow to build the project before running tests, fixing failures caused by missing build artifacts. The build step uses repository secrets (SPAM_ASSASSIN_HOST/PORT, TURBO_TOKEN, TURBO_TEAM) to ensure a complete build.

<sup>Written for commit 282b95590bce72da31fba0a2d4bb8ec9aa88c398. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

