### PR TITLE
fix(ci): changeset bump action failing

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Create "version packages" pull request
-        uses: changesets/action@a7c500273b5be4fb897d21ceededa4767223a843
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf
         with:
           version: pnpm run version
           title: "chore(root): version packages"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
```
fix(github-actions): Fix bump action failing due to incorrect changesets/action pin

The `bump` workflow was failing because `changesets/action` was pinned to a "Version Packages" merge commit (`a7c500273b5be4fb897d21ceededa4767223a843`). This commit does not include the compiled `dist/index.js` required for the action to execute.

This PR updates the pin in `.github/workflows/bump.yml` to the actual `v1.7.0` release tag commit (`6a0a831ff30acef54f2c6aa1cbbc1096b066edaf`), which contains the necessary compiled artifacts.
```

---
[Slack Thread](https://resend.slack.com/archives/C0AG3A0TP7W/p1772739257083489?thread_ts=1772739257.083489&cid=C0AG3A0TP7W)

<p><a href="https://cursor.com/agents/bc-eabc4802-60a8-5063-b26a-228ee56525ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eabc4802-60a8-5063-b26a-228ee56525ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin changesets/action in .github/workflows/bump.yml to the v1.7.0 release so the action includes compiled dist files. This fixes the failing bump workflow and restores creation of “version packages” PRs.

<sup>Written for commit 49032f50e3576e6cae0fab0827055058bb39aeb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

