### PR TITLE
fix(ci): use node --import tsx/esm for release script

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -6,5 +6,5 @@
     "module": "esnext",
     "moduleResolution": "bundler"
   },
-  "include": ["./*.ts", "release.mts"]
+  "include": ["./*.ts"]
 }


### PR DESCRIPTION
## Summary

The release workflow was failing with:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /__w/react-email/react-email/node_modules/@actions/core/package.json
```

in https://github.com/resend/react-email/actions/runs/22922336055/job/66523762070

This happens because `@actions/core@3.0.0`, `@actions/exec@3.0.0`, and `@actions/github@9.0.0` are all **ESM-only** packages — their `exports` field only defines an `"import"` condition with no `"require"` fallback:

```json
"type": "module",
"exports": {
  ".": {
    "types": "./lib/core.d.ts",
    "import": "./lib/core.js"
  }
}
```

When the `tsx` CLI (`pnpm tsx ./scripts/release.ts`) runs a script, it registers itself via a CJS-based loader hook. Node's CJS `require()` then looks at the `exports` map, finds no `"require"` condition, and throws `ERR_PACKAGE_PATH_NOT_EXPORTED`.

The fix is to use `node --import tsx/esm` instead, which registers tsx as a proper ESM loader so Node uses native ESM resolution and correctly follows the `"import"` condition.

## References

**tsx documentation — `node --import tsx/esm` for Module-only mode:**
- https://tsx.is/dev-api/node-cli

**tsx issue confirming ESM/CJS interop discrepancy when using the tsx CLI:**
- https://github.com/privatenumber/tsx/issues/657

**`@actions/core` package.json showing ESM-only exports (source):**
- https://github.com/actions/toolkit/blob/main/packages/core/package.json

**Node.js docs — `--import` flag (the modern replacement for `--loader`):**
- https://nodejs.org/api/cli.html#--importmodule

## Test plan

- [ ] Verify the release workflow succeeds on the next push to `main` or `canary`


Made with [Cursor](https://cursor.com)