### PR TITLE
fix: missing repository fields

### DIFF
--- a/packages/body/package.json
+++ b/packages/body/package.json
@@ -32,6 +32,11 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/resend/react-email.git",
+    "directory": "packages/body"
+  },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },

--- a/packages/code-inline/package.json
+++ b/packages/code-inline/package.json
@@ -22,6 +22,11 @@
     }
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/resend/react-email.git",
+    "directory": "packages/code-inline"
+  },
   "scripts": {
     "build": "tsdown src/index.ts --format esm,cjs --dts --external react",
     "build:watch": "tsdown src/index.ts --format esm,cjs --dts --external react --watch",

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -25,6 +25,11 @@
     }
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/resend/react-email.git",
+    "directory": "packages/font"
+  },
   "scripts": {
     "build": "tsdown src/index.ts --format esm,cjs --dts --external react",
     "build:watch": "tsdown src/index.ts --format esm,cjs --dts --external react --watch",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add missing repository metadata to three package manifests to fix trusted publishing failures and ensure correct repo links on npm.

- **Bug Fixes**
  - Added "repository" field to `packages/body`, `packages/code-inline`, and `packages/font`.

<sup>Written for commit 1cf93824b106e9dac267b89f8218b035dcea8992. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

