### PR TITLE
fix: linting

### DIFF
--- a/packages/markdown/src/markdown.tsx
+++ b/packages/markdown/src/markdown.tsx
@@ -37,13 +37,13 @@ export const Markdown = React.forwardRef<HTMLDivElement, MarkdownProps>(
 
     // TODO: Support all options
     renderer.code = ({ text }) => {
-      text = `${text.replace(/\n$/, '')}\n`;
+      const normalizedText = `${text.replace(/\n$/, '')}\n`;
 
       return `<pre${
         parseCssInJsToInlineCss(finalStyles.codeBlock) !== ''
           ? ` style="${parseCssInJsToInlineCss(finalStyles.codeBlock)}"`
           : ''
-      }><code>${text}</code></pre>\n`;
+      }><code>${normalizedText}</code></pre>\n`;
     };
 
     renderer.codespan = ({ text }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
fix(react-email): linting

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

This PR addresses a `noParameterAssign` linting error in `packages/markdown/src/markdown.tsx`. The `text` parameter within the `renderer.code` callback was being reassigned, which violates a Biome rule configured as an error.

The fix introduces a new `normalizedText` variable to store the modified value, preventing direct parameter reassignment and resolving the linting issue.

[Slack Thread](https://resend.slack.com/archives/C058BM22A13/p1773239790980779?thread_ts=1773239790.980779&cid=C058BM22A13)

<div><a href="https://cursor.com/agents/bc-6cfbba03-a821-5ffa-bdae-6f902b63dab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cfbba03-a821-5ffa-bdae-6f902b63dab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Biome lint error in `packages/markdown/src/markdown.tsx` by avoiding parameter reassignment in the `renderer.code` callback. Introduces `normalizedText` to keep the same output while satisfying the `noParameterAssign` rule.

<sup>Written for commit 4bcb818f925fbac21a515a416080398f971ee6ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

