### PR TITLE
chore(editor-examples): upgrade tailwindcss class names to v4 syntax

### DIFF
--- a/packages/editor/examples/src/app.tsx
+++ b/packages/editor/examples/src/app.tsx
@@ -20,9 +20,9 @@ export function App() {
   const ActiveExample = examples.find((e) => e.id === active)!.component;
 
   return (
-    <div className="max-w-[900px] mx-auto p-8 font-sans text-[var(--re-text)]">
+    <div className="max-w-225 mx-auto p-8 font-sans text-(--re-text)">
       <h1 className="text-2xl mb-6">@react-email/editor examples</h1>
-      <nav className="flex gap-1 mb-8 border-b border-[var(--re-border)]">
+      <nav className="flex gap-1 mb-8 border-b border-(--re-border)">
         {examples.map((example) => (
           <button
             key={example.id}
@@ -30,8 +30,8 @@ export function App() {
             type="button"
             className={`px-4 py-2 border-0 bg-transparent cursor-pointer text-sm ${
               active === example.id
-                ? 'font-semibold text-[var(--re-text)] border-b-2 border-b-[var(--re-text)]'
-                : 'font-normal text-[var(--re-text-muted)] border-b-2 border-b-transparent'
+                ? 'font-semibold text-(--re-text) border-b-2 border-b-(--re-text)'
+                : 'font-normal text-(--re-text-muted) border-b-2 border-b-transparent'
             }`}
           >
             {example.label}

--- a/packages/editor/examples/src/examples/basic-editor.tsx
+++ b/packages/editor/examples/src/examples/basic-editor.tsx
@@ -26,11 +26,11 @@ const content = {
 export function BasicEditor() {
   return (
     <div>
-      <p className="text-sm text-[var(--re-text-muted)] mb-4">
+      <p className="text-sm text-(--re-text-muted) mb-4">
         Minimal setup with coreExtensions and all default bubble menus. Select
         text to see the bubble menu.
       </p>
-      <div className="border border-[var(--re-border)] rounded-xl p-4 min-h-[300px]">
+      <div className="border border-(--re-border) rounded-xl p-4 min-h-75">
         <EditorProvider extensions={extensions} content={content}>
           <BubbleMenu.Default />
         </EditorProvider>

--- a/packages/editor/examples/src/examples/column-layouts.tsx
+++ b/packages/editor/examples/src/examples/column-layouts.tsx
@@ -67,7 +67,7 @@ function Toolbar() {
 export function ColumnLayouts() {
   return (
     <div>
-      <p className="text-sm text-[var(--re-text-muted)] mb-4">
+      <p className="text-sm text-(--re-text-muted) mb-4">
         Insert multi-column layouts using the toolbar buttons.
       </p>
       <EditorProvider
@@ -96,7 +96,7 @@ function ToolbarButton({
     <button
       type="button"
       onClick={onClick}
-      className="flex items-center gap-1.5 px-3 py-1.5 border border-[var(--re-border)] rounded-lg bg-[var(--re-bg)] text-[var(--re-text)] cursor-pointer text-[0.8125rem] hover:bg-[var(--re-hover)]"
+      className="flex items-center gap-1.5 px-3 py-1.5 border border-(--re-border) rounded-lg bg-(--re-bg) text-(--re-text) cursor-pointer text-[0.8125rem] hover:bg-(--re-hover)"
     >
       {icon}
       {label}

--- a/packages/editor/examples/src/examples/custom-bubble-menus.tsx
+++ b/packages/editor/examples/src/examples/custom-bubble-menus.tsx
@@ -23,11 +23,11 @@ const content = {
 export function CustomBubbleMenus() {
   return (
     <div>
-      <p className="text-sm text-[var(--re-text-muted)] mb-4">
+      <p className="text-sm text-(--re-text-muted) mb-4">
         Building menus from primitives instead of using .Default. Only bold,
         italic, underline, and alignment controls are shown.
       </p>
-      <div className="border border-[var(--re-border)] rounded-xl p-4 min-h-[300px]">
+      <div className="border border-(--re-border) rounded-xl p-4 min-h-75">
         <EditorProvider extensions={extensions} content={content}>
           <BubbleMenu.Root>
             <BubbleMenu.ItemGroup>

--- a/packages/editor/examples/src/examples/slash-commands.tsx
+++ b/packages/editor/examples/src/examples/slash-commands.tsx
@@ -58,13 +58,12 @@ const content = {
 export function SlashCommands() {
   return (
     <div>
-      <p className="text-sm text-[var(--re-text-muted)] mb-4">
-        Type{' '}
-        <code className="bg-[var(--re-hover)] px-1.5 py-0.5 rounded">/</code> to
-        open the command menu. This example extends the default commands with a
-        custom "Greeting" command.
+      <p className="text-sm text-(--re-text-muted) mb-4">
+        Type <code className="bg-(--re-hover) px-1.5 py-0.5 rounded-sm">/</code>{' '}
+        to open the command menu. This example extends the default commands with
+        a custom "Greeting" command.
       </p>
-      <div className="border border-[var(--re-border)] rounded-xl p-4 min-h-[300px]">
+      <div className="border border-(--re-border) rounded-xl p-4 min-h-75">
         <EditorProvider extensions={extensions} content={content}>
           <SlashCommand.Root
             items={[...defaultSlashCommands, CUSTOM_COMMAND]}


### PR DESCRIPTION
## Summary

Upgraded Tailwind CSS v3 class names to v4 syntax in the editor examples Vite app. Tailwind v4 renamed utility classes to ensure every size has an explicit name. Changed `rounded` to `rounded-sm` (0.25rem baseline for small radius values).

## Testing steps

- [ ] Verify `cd packages/editor/examples && pnpm dev` renders without errors
- [ ] Check IDE no longer flags deprecated Tailwind class names
- [ ] Confirm visual styling appears correct with the new `rounded-sm` class

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `tailwindcss` class names in `packages/editor/examples` to v4 syntax to standardize utilities and explicit sizing. Aligns with PRODUCT-1622 to ensure our examples follow Tailwind v4 conventions.

- **Refactors**
  - Replace v3 CSS var utilities with v4 syntax: `text-[var(--re-text)]` → `text-(--re-text)`, `border-[var(--re-border)]` → `border-(--re-border)`.
  - Convert pixel-based sizes to v4 tokens: `max-w-[900px]` → `max-w-225`, `min-h-[300px]` → `min-h-75`.
  - Use explicit radius: `rounded` → `rounded-sm`; keep other radii (e.g., `rounded-xl`) as-is.

<sup>Written for commit cc79ac45bf7fb2c647f5ee4d1cdf93afb2af6410. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

