### PR TITLE
fix(web): move OG images to public CDN

### DIFF
--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -2,7 +2,7 @@
 title: "Changelog"
 sidebarTitle: "Changelog"
 description: "New features, bug fixes, and improvements made to each package."
-"og:image": "https://react.email/static/covers/react-email.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png"
 icon: "list-check"
 ---
 

--- a/apps/docs/cli.mdx
+++ b/apps/docs/cli.mdx
@@ -2,7 +2,7 @@
 title: "CLI"
 sidebarTitle: "CLI"
 description: "After installing the React Email package (or cloning a starter), you can start using the command line interface (CLI)."
-"og:image": "https://react.email/static/covers/react-email.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png"
 icon: "square-terminal"
 ---
 

--- a/apps/docs/components/button.mdx
+++ b/apps/docs/components/button.mdx
@@ -2,7 +2,7 @@
 title: "Button"
 sidebarTitle: "Button"
 description: "A link that is styled to look like a button."
-"og:image": "https://react.email/static/covers/button.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/button.png"
 icon: "b"
 ---
 

--- a/apps/docs/components/column.mdx
+++ b/apps/docs/components/column.mdx
@@ -2,7 +2,7 @@
 title: "Column"
 sidebarTitle: "Column"
 description: "Display a column that separates content areas vertically in your email. A column needs to be used in combination with a Row component."
-"og:image": "https://react.email/static/covers/column.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/column.png"
 icon: "columns-3"
 ---
 

--- a/apps/docs/components/container.mdx
+++ b/apps/docs/components/container.mdx
@@ -2,7 +2,7 @@
 title: "Container"
 sidebarTitle: "Container"
 description: "A layout component that centers your content horizontally on a breaking point."
-"og:image": "https://react.email/static/covers/container.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/container.png"
 icon: "grid"
 ---
 

--- a/apps/docs/components/font.mdx
+++ b/apps/docs/components/font.mdx
@@ -2,7 +2,7 @@
 title: "Font"
 sidebarTitle: "Font"
 description: "A React Font component to set your fonts."
-"og:image": "https://react.email/static/covers/font.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/font.png"
 icon: "book-font"
 ---
 

--- a/apps/docs/components/head.mdx
+++ b/apps/docs/components/head.mdx
@@ -2,7 +2,7 @@
 title: "Head"
 sidebarTitle: "Head"
 description: "Contains head components, related to the document such as style and meta elements."
-"og:image": "https://react.email/static/covers/head.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/head.png"
 icon: "head-side"
 ---
 

--- a/apps/docs/components/heading.mdx
+++ b/apps/docs/components/heading.mdx
@@ -2,7 +2,7 @@
 title: "Heading"
 sidebarTitle: "Heading"
 description: "A block of heading text."
-"og:image": "https://react.email/static/covers/heading.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/heading.png"
 icon: "h1"
 ---
 

--- a/apps/docs/components/hr.mdx
+++ b/apps/docs/components/hr.mdx
@@ -2,7 +2,7 @@
 title: "Hr"
 sidebarTitle: "Hr"
 description: "Display a divider that separates content areas in your email."
-"og:image": "https://react.email/static/covers/hr.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/hr.png"
 icon: "horizontal-rule"
 ---
 

--- a/apps/docs/components/html.mdx
+++ b/apps/docs/components/html.mdx
@@ -2,7 +2,7 @@
 title: "HTML"
 sidebarTitle: "HTML"
 description: "A React html component to wrap emails."
-"og:image": "https://react.email/static/covers/html.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/html.png"
 icon: "file-code"
 ---
 

--- a/apps/docs/components/image.mdx
+++ b/apps/docs/components/image.mdx
@@ -2,7 +2,7 @@
 title: "Image"
 sidebarTitle: "Image"
 description: "Display an image in your email."
-"og:image": "https://react.email/static/covers/img.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/img.png"
 icon: "image"
 ---
 

--- a/apps/docs/components/link.mdx
+++ b/apps/docs/components/link.mdx
@@ -2,7 +2,7 @@
 title: "Link"
 sidebarTitle: "Link"
 description: "A hyperlink to web pages, email addresses, or anything else a URL can address."
-"og:image": "https://react.email/static/covers/link.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/link.png"
 icon: "link"
 ---
 

--- a/apps/docs/components/markdown.mdx
+++ b/apps/docs/components/markdown.mdx
@@ -2,7 +2,7 @@
 title: "Markdown"
 sidebarTitle: "Markdown"
 description: "A Markdown component that converts markdown to valid react-email template code"
-"og:image": "https://react.email/static/covers/markdown.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/markdown.png"
 icon: "file-code"
 ---
 

--- a/apps/docs/components/preview.mdx
+++ b/apps/docs/components/preview.mdx
@@ -2,7 +2,7 @@
 title: "Preview"
 sidebarTitle: "Preview"
 description: "A preview text that will be displayed in the inbox of the recipient."
-"og:image": "https://react.email/static/covers/preview.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/preview.png"
 icon: "input-text"
 ---
 

--- a/apps/docs/components/row.mdx
+++ b/apps/docs/components/row.mdx
@@ -2,7 +2,7 @@
 title: "Row"
 sidebarTitle: "Row"
 description: "Display a row that separates content areas horizontally in your email."
-"og:image": "https://react.email/static/covers/row.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/row.png"
 icon: "table-rows"
 ---
 

--- a/apps/docs/components/section.mdx
+++ b/apps/docs/components/section.mdx
@@ -2,7 +2,7 @@
 title: "Section"
 sidebarTitle: "Section"
 description: "Display a section that can also be formatted using rows and columns."
-"og:image": "https://react.email/static/covers/section.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/section.png"
 icon: "rectangles-mixed"
 ---
 

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -2,7 +2,7 @@
 title: "Tailwind"
 sidebarTitle: "Tailwind"
 description: "A React component to wrap emails with Tailwind CSS."
-"og:image": "https://react.email/static/covers/tailwind.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/tailwind.png"
 icon: "wind"
 ---
 

--- a/apps/docs/components/text.mdx
+++ b/apps/docs/components/text.mdx
@@ -2,7 +2,7 @@
 title: "Text"
 sidebarTitle: "Text"
 description: "A block of text separated by blank spaces."
-"og:image": "https://react.email/static/covers/text.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/text.png"
 icon: "text-size"
 ---
 

--- a/apps/docs/contributing.mdx
+++ b/apps/docs/contributing.mdx
@@ -2,7 +2,7 @@
 title: 'Contributing'
 sidebarTitle: 'Old Contributing'
 description: 'Wanna help? Awesome! There are many ways you can contribute.'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 icon: 'code-pull-request'
 ---
 

--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Codebase overview'
 sidebarTitle: 'Codebase overview'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 description: 'An overview of the React Email codebase'
 icon: 'folder-tree'
 ---

--- a/apps/docs/contributing/development-workflow/1-setup.mdx
+++ b/apps/docs/contributing/development-workflow/1-setup.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Setup'
 sidebarTitle: '1. Setup'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 description: 'Things you will need to do beforehand to setup the project'
 ---
 

--- a/apps/docs/contributing/development-workflow/2-running-tests.mdx
+++ b/apps/docs/contributing/development-workflow/2-running-tests.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Running tests'
 sidebarTitle: '2. Running tests'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 description: 'Everything you need to know about our testing setup and strategy'
 ---
 

--- a/apps/docs/contributing/development-workflow/3-linting.mdx
+++ b/apps/docs/contributing/development-workflow/3-linting.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Linting'
 sidebarTitle: '3. Linting'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 description: 'Everything you need to know about linting and formatting'
 ---
 

--- a/apps/docs/contributing/development-workflow/4-building.mdx
+++ b/apps/docs/contributing/development-workflow/4-building.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Building"
 sidebarTitle: "4. Building"
-"og:image": "https://react.email/static/covers/react-email.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png"
 description: "How we build each package before publishing"
 ---
 

--- a/apps/docs/contributing/development-workflow/5-writing-docs.mdx
+++ b/apps/docs/contributing/development-workflow/5-writing-docs.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Writing docs'
 sidebarTitle: '5. Writing docs'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 We use [Mintlify](https://mintlify.com/) for our documentation.

--- a/apps/docs/contributing/development-workflow/6-editing-the-components.mdx
+++ b/apps/docs/contributing/development-workflow/6-editing-the-components.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Editing the components'
 sidebarTitle: '6. Editing the components'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 To facilitate developing components, use the built-in [playground](https://github.com/resend/react-email/tree/canary/playground), which automatically hot reloads when you make changes to the components during development.

--- a/apps/docs/contributing/introduction.mdx
+++ b/apps/docs/contributing/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Getting Started'
 sidebarTitle: 'Getting Started'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 icon: 'hand-wave'
 ---
 

--- a/apps/docs/contributing/opening-issues.mdx
+++ b/apps/docs/contributing/opening-issues.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Opening issues'
 sidebarTitle: 'Opening issues'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 icon: 'scroll'
 ---
 

--- a/apps/docs/contributing/opening-pull-requests.mdx
+++ b/apps/docs/contributing/opening-pull-requests.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Opening pull requests'
 sidebarTitle: 'Opening pull requests'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 icon: 'code-pull-request'
 ---
 

--- a/apps/docs/deployment.mdx
+++ b/apps/docs/deployment.mdx
@@ -2,7 +2,7 @@
 title: "Deployment"
 sidebarTitle: "Deployment"
 description: "How to deploy the `email dev` preview server to Vercel"
-"og:image": "https://react.email/static/covers/react-email.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png"
 icon: "rocket"
 ---
 

--- a/apps/docs/getting-started/automatic-setup.mdx
+++ b/apps/docs/getting-started/automatic-setup.mdx
@@ -2,7 +2,7 @@
 title: 'Automatic Setup'
 sidebarTitle: 'Automatic Setup'
 description: 'Add React Email to any JavaScript or TypeScript project in minutes.'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 icon: 'download'
 ---
 

--- a/apps/docs/getting-started/manual-setup.mdx
+++ b/apps/docs/getting-started/manual-setup.mdx
@@ -2,7 +2,7 @@
 title: "Manual Setup"
 sidebarTitle: "Manual Setup"
 description: "Create a brand-new folder with packages powered by React Email."
-"og:image": "https://react.email/static/covers/react-email.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png"
 icon: "hammer"
 ---
 

--- a/apps/docs/getting-started/migrating-to-react-email.mdx
+++ b/apps/docs/getting-started/migrating-to-react-email.mdx
@@ -2,7 +2,7 @@
 title: 'Migrating to React Email'
 sidebarTitle: 'Migrating to React Email'
 description: 'Migrate from another email rendering framework to React Email'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 icon: 'paper-plane'
 ---
 

--- a/apps/docs/getting-started/monorepo-setup/bun.mdx
+++ b/apps/docs/getting-started/monorepo-setup/bun.mdx
@@ -2,7 +2,7 @@
 title: 'Setting up for bun workspaces'
 sidebarTitle: 'bun'
 description: 'Configure React Email on a bun monorepo'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 ## 1. Create workspace

--- a/apps/docs/getting-started/monorepo-setup/choose-package-manager.mdx
+++ b/apps/docs/getting-started/monorepo-setup/choose-package-manager.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Monorepo setup'
 sidebarTitle: 'bun'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 What package manager are you using?

--- a/apps/docs/getting-started/monorepo-setup/npm.mdx
+++ b/apps/docs/getting-started/monorepo-setup/npm.mdx
@@ -2,7 +2,7 @@
 title: 'Setting up for npm workspaces'
 sidebarTitle: 'npm'
 description: 'Configure React Email on a npm monorepo'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 ## 1. Create workspace

--- a/apps/docs/getting-started/monorepo-setup/pnpm.mdx
+++ b/apps/docs/getting-started/monorepo-setup/pnpm.mdx
@@ -2,7 +2,7 @@
 title: 'Setting up for pnpm workspaces'
 sidebarTitle: 'pnpm'
 description: 'Configure React Email on a pnpm monorepo'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 ## 1. Create workspace

--- a/apps/docs/getting-started/monorepo-setup/yarn.mdx
+++ b/apps/docs/getting-started/monorepo-setup/yarn.mdx
@@ -2,7 +2,7 @@
 title: 'Setting up for yarn workspaces'
 sidebarTitle: 'yarn'
 description: 'Configure React Email on a yarn monorepo'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 <Note>

--- a/apps/docs/getting-started/updating-react-email.mdx
+++ b/apps/docs/getting-started/updating-react-email.mdx
@@ -2,7 +2,7 @@
 title: 'Updating React Email'
 sidebarTitle: 'Updating React Email'
 description: 'How to update from React Email 4.0 to 5.0'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 icon: 'arrow-up-wide-short'
 ---
 

--- a/apps/docs/guides/internationalization/next-intl.mdx
+++ b/apps/docs/guides/internationalization/next-intl.mdx
@@ -2,7 +2,7 @@
 title: 'next-intl'
 sidebarTitle: 'next-intl'
 description: 'Integrating React Email with next-intl'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 React Email supports [next-intl](https://next-intl.dev) for internationalization.

--- a/apps/docs/guides/internationalization/react-i18next.mdx
+++ b/apps/docs/guides/internationalization/react-i18next.mdx
@@ -2,7 +2,7 @@
 title: 'react-i18next'
 sidebarTitle: 'react-i18next'
 description: 'Integrating React Email with react-i18next'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 React Email supports [react-i18next](https://react.i18next.com) for internationalization.

--- a/apps/docs/guides/internationalization/react-intl.mdx
+++ b/apps/docs/guides/internationalization/react-intl.mdx
@@ -2,7 +2,7 @@
 title: 'React Intl'
 sidebarTitle: 'React Intl'
 description: 'Integrating React Email with React Intl'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 React Email supports [React Intl](https://formatjs.github.io/react-intl/) for internationalization.

--- a/apps/docs/integrations/aws-ses.mdx
+++ b/apps/docs/integrations/aws-ses.mdx
@@ -2,7 +2,7 @@
 title: 'Send email using AWS SES'
 sidebarTitle: 'AWS SES'
 description: 'Learn how to send an email using React Email and the AWS SES Node.js SDK.'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 ## 1. Install dependencies

--- a/apps/docs/integrations/inbound.mdx
+++ b/apps/docs/integrations/inbound.mdx
@@ -2,7 +2,7 @@
 +title: 'Send (& receive) emails using Inbound'
 sidebarTitle: 'Inbound'
 +description: 'Learn how to send and receive emails using React Email and the Inbound Node.js SDK.'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 ## 1. Install dependencies

--- a/apps/docs/integrations/mailersend.mdx
+++ b/apps/docs/integrations/mailersend.mdx
@@ -2,7 +2,7 @@
 title: 'Send email using MailerSend'
 sidebarTitle: 'MailerSend'
 description: 'Learn how to send an email using React Email and the MailerSend Node.js SDK.'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 ## 1. Install dependencies

--- a/apps/docs/integrations/nodemailer.mdx
+++ b/apps/docs/integrations/nodemailer.mdx
@@ -2,7 +2,7 @@
 title: 'Send email using Nodemailer'
 sidebarTitle: 'Nodemailer'
 description: 'Learn how to send an email using React Email and Nodemailer.'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 ## 1. Install dependencies

--- a/apps/docs/integrations/overview.mdx
+++ b/apps/docs/integrations/overview.mdx
@@ -2,7 +2,7 @@
 title: 'Overview'
 sidebarTitle: 'Overview'
 description: 'Leverage different email service providers to send emails using React.'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 import Integrations from '/snippets/integrations.mdx'

--- a/apps/docs/integrations/plunk.mdx
+++ b/apps/docs/integrations/plunk.mdx
@@ -2,7 +2,7 @@
 title: "Send email using Plunk"
 sidebarTitle: "Plunk"
 description: "Learn how to send an email using React Email and the Plunk Node.js SDK."
-"og:image": "https://react.email/static/covers/react-email.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png"
 ---
 
 ## 1. Install dependencies

--- a/apps/docs/integrations/postmark.mdx
+++ b/apps/docs/integrations/postmark.mdx
@@ -2,7 +2,7 @@
 title: 'Send email using Postmark'
 sidebarTitle: 'Postmark'
 description: 'Learn how to send an email using React Email and the Postmark Node.js SDK.'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 ## 1. Install dependencies

--- a/apps/docs/integrations/resend.mdx
+++ b/apps/docs/integrations/resend.mdx
@@ -2,7 +2,7 @@
 title: 'Send email using Resend'
 sidebarTitle: 'Resend'
 description: 'Learn how to send an email and set up Templates using React Email and the Resend Node.js SDK.'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 ---
 
 ##  Send email with Resend

--- a/apps/docs/integrations/scaleway.mdx
+++ b/apps/docs/integrations/scaleway.mdx
@@ -2,7 +2,7 @@
 title: "Send email using Scaleway Transactional Email"
 sidebarTitle: "Scaleway"
 description: "Learn how to send an email using React Email and the Scaleway Node.js SDK."
-"og:image": "https://react.email/static/covers/react-email.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png"
 ---
 
 ## 1. Install dependencies

--- a/apps/docs/integrations/sendgrid.mdx
+++ b/apps/docs/integrations/sendgrid.mdx
@@ -2,7 +2,7 @@
 title: "Send email using SendGrid"
 sidebarTitle: "SendGrid"
 description: "Learn how to send an email using React Email and the SendGrid Node.js SDK."
-"og:image": "https://react.email/static/covers/react-email.png"
+"og:image": "https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png"
 ---
 
 ## 1. Install dependencies

--- a/apps/docs/introduction.mdx
+++ b/apps/docs/introduction.mdx
@@ -2,7 +2,7 @@
 title: 'React Email'
 sidebarTitle: 'Introduction'
 description: 'Build and send emails using React and TypeScript.'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 icon: 'hand-wave'
 ---
 

--- a/apps/docs/roadmap.mdx
+++ b/apps/docs/roadmap.mdx
@@ -2,7 +2,7 @@
 title: 'Roadmap'
 sidebarTitle: 'Roadmap'
 description: 'Understand what is currently being prioritized and what we are planning to build in the near future.'
-'og:image': 'https://react.email/static/covers/react-email.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/react-email.png'
 icon: 'map'
 ---
 

--- a/apps/docs/utilities/render.mdx
+++ b/apps/docs/utilities/render.mdx
@@ -2,7 +2,7 @@
 title: 'Render'
 sidebarTitle: 'Render'
 description: 'Transform React components into HTML email templates.'
-'og:image': 'https://react.email/static/covers/render.png'
+'og:image': 'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/static/covers/render.png'
 ---
 
 ## 1. Install dependencies

--- a/apps/web/src/app/components/[slug]/page.tsx
+++ b/apps/web/src/app/components/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import { Toaster } from 'sonner';
 import { Heading } from '@/components/heading';
 import { PageWrapper } from '@/components/page-wrapper';
+import { patternsOgImage } from '@/utils/og-images';
 import { componentsStructure } from '../../../../components/structure';
 import { ComponentsView } from '../../../components/components-view';
 import { IconArrowLeft } from '../../../components/icons/icon-arrow-left';
@@ -45,11 +46,11 @@ export const generateMetadata = async ({
     openGraph: {
       title: `${foundCategory.name} Components - React Email`,
       description: foundCategory.description,
-      images: [
-        {
-          url: 'https://react.email/static/covers/patterns.png',
-        },
-      ],
+      images: [patternsOgImage],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      images: [patternsOgImage.url],
     },
     alternates: {
       canonical: `/components/${rawSlug}`,

--- a/apps/web/src/app/components/page.tsx
+++ b/apps/web/src/app/components/page.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { Heading } from '@/components/heading';
 import { PageWrapper } from '@/components/page-wrapper';
+import { patternsOgImage } from '@/utils/og-images';
 import { componentsStructure } from '../../../components/structure';
 import { PageTransition } from '../../components/page-transition';
 import { Spotlight } from '../../components/spotlight';
@@ -14,7 +15,11 @@ export const metadata: Metadata = {
   description:
     'Build beautiful emails with pre-built components that you can copy-and-paste into your app.',
   openGraph: {
-    images: [{ url: 'https://react.email/static/covers/patterns.png' }],
+    images: [patternsOgImage],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [patternsOgImage.url],
   },
   alternates: {
     canonical: '/components',

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import '@/styles/globals.css';
 import localFont from 'next/font/local';
 import { Topbar } from '@/components/topbar';
+import { homepageOgImage } from '@/utils/og-images';
 
 const inter = localFont({
   display: 'swap',
@@ -57,11 +58,7 @@ export const metadata: Metadata = {
   openGraph: {
     description:
       'A collection of high-quality, unstyled components for creating beautiful emails using React and TypeScript.',
-    images: [
-      {
-        url: '/static/covers/react-email.png',
-      },
-    ],
+    images: [homepageOgImage],
     locale: 'en_US',
     siteName: 'React Email',
     title: 'React Email',
@@ -70,7 +67,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    images: 'https://react.email/static/covers/react-email.png',
+    images: [homepageOgImage.url],
   },
   alternates: {
     canonical: '/',

--- a/apps/web/src/utils/og-images.ts
+++ b/apps/web/src/utils/og-images.ts
@@ -1,0 +1,18 @@
+export const publicAssetBaseUrl =
+  'https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public';
+
+const getPublicAssetUrl = (path: `/${string}`) => `${publicAssetBaseUrl}${path}`;
+
+export const homepageOgImage = {
+  alt: 'React Email',
+  height: 630,
+  url: getPublicAssetUrl('/meta/cover.png'),
+  width: 1200,
+} as const;
+
+export const patternsOgImage = {
+  alt: 'React Email components',
+  height: 800,
+  url: getPublicAssetUrl('/static/covers/patterns.png'),
+  width: 1600,
+} as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
fix(web): move OG images to public CDN

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

**Description:**

Moves website and docs `og:image` references off the protected `react.email` origin and onto public jsDelivr URLs backed by this repository's static assets. This avoids Vercel challenge-mode issues for social image-fetching bots, restores the homepage metadata to the canonical 1200x630 OG image, and adds explicit image dimensions in the Next metadata objects.

**Testing:**

- `pnpm turbo run build --filter=web`

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C058BM22A13/p1773845087037249?thread_ts=1773845087.037249&cid=C058BM22A13)

<div><a href="https://cursor.com/agents/bc-cc90e455-40d0-55cf-93dc-85bdf3687fca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc90e455-40d0-55cf-93dc-85bdf3687fca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move all Open Graph images to a public CDN to restore reliable social previews and avoid Vercel challenge-mode blocks. Centralizes OG image config with explicit dimensions and updates Twitter card metadata.

- **Bug Fixes**
  - Serve OG images via `https://cdn.jsdelivr.net/gh/resend/react-email@canary/apps/web/public/...` for both docs and web.
  - Restore homepage OG to the canonical 1200x630 image and add explicit sizes via `homepageOgImage`.
  - Add `apps/web/src/utils/og-images.ts` to centralize URLs/sizes and update Next Open Graph + Twitter metadata (including components pages) to use it.

<sup>Written for commit 7e72ffaaf8d86ea2ddbf4cdbaf54201aff8843d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

