### PR TITLE
fix(editor): disable link open on click

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/editor",
-  "version": "0.0.0-experimental.28",
+  "version": "0.0.0-experimental.29",
   "description": "",
   "sideEffects": [
     "**/*.css"

--- a/packages/editor/src/extensions/index.ts
+++ b/packages/editor/src/extensions/index.ts
@@ -236,7 +236,7 @@ export const StarterKit = Extension.create<StarterKitOptions>({
       Strike: {},
       Heading: {},
       Divider: {},
-      Link: {},
+      Link: { openOnClick: false },
       Sup: {},
       Underline: {},
       Uppercase: {},


### PR DESCRIPTION
## Summary

Disables the default `openOnClick` behavior in the TipTap `Link` extension. By default, clicking a link in the editor navigates to it, which is disruptive during editing. Setting `openOnClick: false` prevents accidental navigation when users intend to select or edit a link.

## Testing steps

- [ ] Open the editor and insert a hyperlink
- [ ] Click on the link — verify it does NOT navigate/open the URL
- [ ] Verify the link can still be selected and edited normally
- [ ] Verify that link rendering and styling are unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable link navigation on click in the editor by setting the TipTap `Link` extension to `openOnClick: false`, so clicks don’t navigate away while editing. Bumps `@react-email/editor` to `0.0.0-experimental.29`.

<sup>Written for commit fe89e36a733e799bf0084adf6c294f1f369b93b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

