### PR TITLE
fix(tailwind): downlevel CSS for email client compatibility

### DIFF
--- a/.changeset/downlevel-email-css.md
+++ b/.changeset/downlevel-email-css.md
@@ -1,0 +1,9 @@
+---
+"@react-email/tailwind": patch
+---
+
+fix(tailwind): downlevel CSS for email client compatibility
+
+Rewrites modern CSS features that email clients don't support using css-tree AST:
+- Unnests `@media` rules from inside selectors (CSS Nesting)
+- Converts Media Queries Level 4 range syntax to legacy `min-width`/`max-width`

--- a/.changeset/downlevel-email-css.md
+++ b/.changeset/downlevel-email-css.md
@@ -2,8 +2,4 @@
 "@react-email/tailwind": patch
 ---
 
-fix(tailwind): downlevel CSS for email client compatibility
-
-Rewrites modern CSS features that email clients don't support using css-tree AST:
-- Unnests `@media` rules from inside selectors (CSS Nesting)
-- Converts Media Queries Level 4 range syntax to legacy `min-width`/`max-width`
+downlevel at rules for email client compatibility

--- a/packages/react-email/src/components/tailwind/tailwind.spec.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.spec.tsx
@@ -588,7 +588,7 @@ describe('Tailwind component', () => {
         <html lang="en">
           <head>
             <style>
-              .hover_bg-red-600{&:hover{@media (hover:hover){background-color:rgb(231,0,11)!important}}}.focus_bg-red-700{&:focus{background-color:rgb(193,0,7)!important}}@media (min-width:40rem){.sm_bg-red-300{background-color:rgb(255,162,162)!important}}@media (min-width:40rem){.sm_hover_bg-red-200{&:hover{@media (hover:hover){background-color:rgb(255,201,201)!important}}}}@media (min-width:48rem){.md_bg-red-400{background-color:rgb(255,100,103)!important}}@media (min-width:64rem){.lg_bg-red-500{background-color:rgb(251,44,54)!important}}
+              .hover_bg-red-600{@media (hover:hover){&:hover{background-color:rgb(231,0,11)!important}}}.focus_bg-red-700{&:focus{background-color:rgb(193,0,7)!important}}@media (min-width:40rem){.sm_bg-red-300{background-color:rgb(255,162,162)!important}}@media (min-width:40rem){.sm_hover_bg-red-200{@media (hover:hover){&:hover{background-color:rgb(255,201,201)!important}}}}@media (min-width:48rem){.md_bg-red-400{background-color:rgb(255,100,103)!important}}@media (min-width:64rem){.lg_bg-red-500{background-color:rgb(251,44,54)!important}}
             </style>
           </head>
           <body>

--- a/packages/react-email/src/components/tailwind/tailwind.spec.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.spec.tsx
@@ -50,7 +50,7 @@ describe('Tailwind component', () => {
         <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
         <meta name="x-apple-disable-message-reformatting" />
         <style>
-          .md_p-4{@media (width>=48rem){padding:1rem!important}}
+          @media (min-width:48rem){.md_p-4{padding:1rem!important}}
         </style>
       </head>
       <body>
@@ -353,7 +353,7 @@ describe('Tailwind component', () => {
           <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
           <meta name="x-apple-disable-message-reformatting" />
           <style>
-            .sm_bg-red-50{@media (width>=40rem){background-color:rgb(254,242,242)!important}}.sm_text-sm{@media (width>=40rem){font-size:0.875rem!important;line-height:1.4285714285714286!important}}.md_text-lg{@media (width>=48rem){font-size:1.125rem!important;line-height:1.5555555555555556!important}}
+            @media (min-width:40rem){.sm_bg-red-50{background-color:rgb(254,242,242)!important}}@media (min-width:40rem){.sm_text-sm{font-size:0.875rem!important;line-height:1.4285714285714286!important}}@media (min-width:48rem){.md_text-lg{font-size:1.125rem!important;line-height:1.5555555555555556!important}}
           </style></head
         ><!--$--><!--html--><!--head--><span
           ><!--[if mso]><i style="letter-spacing: 10px;mso-font-width:-100%;" hidden>&nbsp;</i><![endif]--></span
@@ -391,7 +391,7 @@ describe('Tailwind component', () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html dir="ltr" lang="en"><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/><meta name="x-apple-disable-message-reformatting"/><style>.text-body{@media (prefers-color-scheme:dark){color:orange!important}}</style></head><body class="text-body"><!--$--><!--html--><!--head--><!--body--><table border="0" width="100%" cellPadding="0" cellSpacing="0" role="presentation" align="center"><tbody><tr><td style="color:green">this is the body</td></tr></tbody></table><!--/$--></body></html>"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html dir="ltr" lang="en"><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/><meta name="x-apple-disable-message-reformatting"/><style>@media (prefers-color-scheme:dark){.text-body{color:orange!important}}</style></head><body class="text-body"><!--$--><!--html--><!--head--><!--body--><table border="0" width="100%" cellPadding="0" cellSpacing="0" role="presentation" align="center"><tbody><tr><td style="color:green">this is the body</td></tr></tbody></table><!--/$--></body></html>"`,
     );
   });
 
@@ -425,7 +425,7 @@ describe('Tailwind component', () => {
           <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
           <meta name="x-apple-disable-message-reformatting" />
           <style>
-            .xl_bg-green-500{@media (width>=1280px){background-color:rgb(0,201,80)!important}}.twoxl_bg-blue-500{@media (width>=1536px){background-color:rgb(43,127,255)!important}}
+            @media (min-width:1280px){.xl_bg-green-500{background-color:rgb(0,201,80)!important}}@media (min-width:1536px){.twoxl_bg-blue-500{background-color:rgb(43,127,255)!important}}
           </style></head
         ><!--$--><!--html--><!--head-->
         <div class="xl_bg-green-500" style="background-color:rgb(255,226,226)">
@@ -452,7 +452,7 @@ describe('Tailwind component', () => {
       "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
       <head>
         <style>
-          .lg_max-h-calc50pxplus5rem{@media (width>=64rem){max-height:calc(50px + 5rem)!important}}
+          @media (min-width:64rem){.lg_max-h-calc50pxplus5rem{max-height:calc(50px + 5rem)!important}}
         </style></head
       ><!--$--><!--head-->
       <div
@@ -494,7 +494,7 @@ describe('Tailwind component', () => {
         <html lang="en">
           <head>
             <style>
-              .sm_bg-red-300{@media (width>=40rem){background-color:rgb(255,162,162)!important}}.md_bg-red-400{@media (width>=48rem){background-color:rgb(255,100,103)!important}}.lg_bg-red-500{@media (width>=64rem){background-color:rgb(251,44,54)!important}}
+              @media (min-width:40rem){.sm_bg-red-300{background-color:rgb(255,162,162)!important}}@media (min-width:48rem){.md_bg-red-400{background-color:rgb(255,100,103)!important}}@media (min-width:64rem){.lg_bg-red-500{background-color:rgb(251,44,54)!important}}
             </style>
           </head>
           <body>
@@ -524,7 +524,7 @@ describe('Tailwind component', () => {
           </Tailwind>,
         ),
       ).toMatchInlineSnapshot(
-        `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html lang="en"><head><style>.sm_bg-red-300{@media (width>=40rem){background-color:rgb(255,162,162)!important}}.md_bg-red-400{@media (width>=48rem){background-color:rgb(255,100,103)!important}}.lg_bg-red-500{@media (width>=64rem){background-color:rgb(251,44,54)!important}}</style></head><body><!--$--><!--html--><!--head--><!--body--><div class="sm_bg-red-300 md_bg-red-400 lg_bg-red-500" style="background-color:rgb(255,201,201)"></div><!--/$--></body></html>"`,
+        `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html lang="en"><head><style>@media (min-width:40rem){.sm_bg-red-300{background-color:rgb(255,162,162)!important}}@media (min-width:48rem){.md_bg-red-400{background-color:rgb(255,100,103)!important}}@media (min-width:64rem){.lg_bg-red-500{background-color:rgb(251,44,54)!important}}</style></head><body><!--$--><!--html--><!--head--><!--body--><div class="sm_bg-red-300 md_bg-red-400 lg_bg-red-500" style="background-color:rgb(255,201,201)"></div><!--/$--></body></html>"`,
       );
     });
 
@@ -558,7 +558,7 @@ describe('Tailwind component', () => {
         <html lang="en">
           <head>
             <style>
-              .text-body{@media (width>=40rem){color:darkgreen!important}}
+              @media (min-width:40rem){.text-body{color:darkgreen!important}}
             </style>
           </head>
           <body>
@@ -588,7 +588,7 @@ describe('Tailwind component', () => {
         <html lang="en">
           <head>
             <style>
-              .hover_bg-red-600{&:hover{@media (hover:hover){background-color:rgb(231,0,11)!important}}}.focus_bg-red-700{&:focus{background-color:rgb(193,0,7)!important}}.sm_bg-red-300{@media (width>=40rem){background-color:rgb(255,162,162)!important}}.sm_hover_bg-red-200{@media (width>=40rem){&:hover{@media (hover:hover){background-color:rgb(255,201,201)!important}}}}.md_bg-red-400{@media (width>=48rem){background-color:rgb(255,100,103)!important}}.lg_bg-red-500{@media (width>=64rem){background-color:rgb(251,44,54)!important}}
+              .hover_bg-red-600{&:hover{@media (hover:hover){background-color:rgb(231,0,11)!important}}}.focus_bg-red-700{&:focus{background-color:rgb(193,0,7)!important}}@media (min-width:40rem){.sm_bg-red-300{background-color:rgb(255,162,162)!important}}@media (min-width:40rem){.sm_hover_bg-red-200{&:hover{@media (hover:hover){background-color:rgb(255,201,201)!important}}}}@media (min-width:48rem){.md_bg-red-400{background-color:rgb(255,100,103)!important}}@media (min-width:64rem){.lg_bg-red-500{background-color:rgb(251,44,54)!important}}
             </style>
           </head>
           <body>
@@ -659,7 +659,7 @@ describe('Tailwind component', () => {
           <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
           <meta name="x-apple-disable-message-reformatting" />
           <style>
-            .max-sm_text-red-600{@media (width<40rem){color:rgb(231,0,11)!important}}
+            @media (max-width:40rem){.max-sm_text-red-600{color:rgb(231,0,11)!important}}
           </style></head
         ><!--$--><!--head-->
         <p class="max-sm_text-red-600" style="color:rgb(20,71,230)">I am some text</p>
@@ -702,7 +702,7 @@ describe('Tailwind component', () => {
         <html lang="en">
           <head>
             <style>
-              .sm_bg-red-500{@media (width>=40rem){background-color:rgb(251,44,54)!important}}
+              @media (min-width:40rem){.sm_bg-red-500{background-color:rgb(251,44,54)!important}}
             </style>
             <style></style>
             <link />
@@ -923,7 +923,7 @@ describe('Tailwind component', () => {
         <html lang="en">
           <head>
             <style>
-              .sm_border-custom{@media (width>=40rem){border:2px solid!important}}
+              @media (min-width:40rem){.sm_border-custom{border:2px solid!important}}
             </style>
           </head>
           <body>

--- a/packages/react-email/src/components/tailwind/tailwind.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.tsx
@@ -119,6 +119,7 @@ export function Tailwind({ children, config }: TailwindProps) {
     ),
   };
   sanitizeNonInlinableRules(nonInlineStyles);
+  downlevelForEmailClients(nonInlineStyles);
 
   const hasNonInlineStylesToApply = nonInlinableRules.size > 0;
   let appliedNonInlineStyles = false as boolean;
@@ -137,9 +138,7 @@ export function Tailwind({ children, config }: TailwindProps) {
 
         const styleElement = (
           <style
-            dangerouslySetInnerHTML={{
-              __html: downlevelForEmailClients(generate(nonInlineStyles)),
-            }}
+            dangerouslySetInnerHTML={{ __html: generate(nonInlineStyles) }}
           />
         );
 

--- a/packages/react-email/src/components/tailwind/tailwind.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import type { Config } from 'tailwindcss';
 import { useSuspensedPromise } from './hooks/use-suspended-promise.js';
 import { sanitizeStyleSheet } from './sanitize-stylesheet.js';
+import { downlevelForEmailClients } from './utils/css/downlevel-for-email-clients.js';
 import { extractRulesPerClass } from './utils/css/extract-rules-per-class.js';
 import { getCustomProperties } from './utils/css/get-custom-properties.js';
 import { sanitizeNonInlinableRules } from './utils/css/sanitize-non-inlinable-rules.js';
@@ -136,7 +137,9 @@ export function Tailwind({ children, config }: TailwindProps) {
 
         const styleElement = (
           <style
-            dangerouslySetInnerHTML={{ __html: generate(nonInlineStyles) }}
+            dangerouslySetInnerHTML={{
+              __html: downlevelForEmailClients(generate(nonInlineStyles)),
+            }}
           />
         );
 

--- a/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.spec.ts
@@ -1,0 +1,137 @@
+import { downlevelForEmailClients } from './downlevel-for-email-clients.js';
+
+describe('downlevelForEmailClients', () => {
+  describe('range syntax', () => {
+    it('converts width>= to min-width', () => {
+      expect(
+        downlevelForEmailClients(
+          '@media (width>=40rem){.sm_p-4{padding:1rem}}',
+        ),
+      ).toBe('@media (min-width:40rem){.sm_p-4{padding:1rem}}');
+    });
+
+    it('converts width<= to max-width', () => {
+      expect(
+        downlevelForEmailClients(
+          '@media (width<=40rem){.max-sm_p-4{padding:1rem}}',
+        ),
+      ).toBe('@media (max-width:40rem){.max-sm_p-4{padding:1rem}}');
+    });
+
+    it('converts width< to max-width', () => {
+      expect(
+        downlevelForEmailClients(
+          '.max-sm_text-red-600{@media (width<40rem){color:red!important}}',
+        ),
+      ).toBe(
+        '@media (max-width:40rem){.max-sm_text-red-600{color:red!important}}',
+      );
+    });
+
+    it('converts width> to min-width', () => {
+      expect(
+        downlevelForEmailClients(
+          '@media (width>40rem){.sm_p-4{padding:1rem}}',
+        ),
+      ).toBe('@media (min-width:40rem){.sm_p-4{padding:1rem}}');
+    });
+
+    it('converts height range syntax', () => {
+      expect(
+        downlevelForEmailClients('@media (height>=600px){.tall{color:red}}'),
+      ).toBe('@media (min-height:600px){.tall{color:red}}');
+    });
+
+    it('does not match partial property names', () => {
+      // prefers-color-scheme should not be affected
+      expect(
+        downlevelForEmailClients(
+          '@media (prefers-color-scheme:dark){.dark{color:white}}',
+        ),
+      ).toBe('@media (prefers-color-scheme:dark){.dark{color:white}}');
+    });
+  });
+
+  describe('unnesting', () => {
+    it('unnests @media from inside a selector', () => {
+      expect(
+        downlevelForEmailClients(
+          '.sm_bg-red-300{@media (min-width:40rem){background-color:red!important}}',
+        ),
+      ).toBe(
+        '@media (min-width:40rem){.sm_bg-red-300{background-color:red!important}}',
+      );
+    });
+
+    it('handles combined range syntax + nesting', () => {
+      expect(
+        downlevelForEmailClients(
+          '.sm_bg-red-300{@media (width>=40rem){background-color:rgb(255,162,162)!important}}',
+        ),
+      ).toBe(
+        '@media (min-width:40rem){.sm_bg-red-300{background-color:rgb(255,162,162)!important}}',
+      );
+    });
+
+    it('handles multiple concatenated rules', () => {
+      const input =
+        '.sm_bg-red-300{@media (width>=40rem){background-color:red!important}}' +
+        '.md_bg-red-400{@media (width>=48rem){background-color:blue!important}}' +
+        '.lg_bg-red-500{@media (width>=64rem){background-color:green!important}}';
+
+      const expected =
+        '@media (min-width:40rem){.sm_bg-red-300{background-color:red!important}}' +
+        '@media (min-width:48rem){.md_bg-red-400{background-color:blue!important}}' +
+        '@media (min-width:64rem){.lg_bg-red-500{background-color:green!important}}';
+
+      expect(downlevelForEmailClients(input)).toBe(expected);
+    });
+
+    it('preserves dark mode media queries and unnests them', () => {
+      expect(
+        downlevelForEmailClients(
+          '.dark_text-white{@media (prefers-color-scheme:dark){color:rgb(255,255,255)!important}}',
+        ),
+      ).toBe(
+        '@media (prefers-color-scheme:dark){.dark_text-white{color:rgb(255,255,255)!important}}',
+      );
+    });
+
+    it('preserves rules without nested @media', () => {
+      expect(
+        downlevelForEmailClients('.bg-red-300{background-color:red}'),
+      ).toBe('.bg-red-300{background-color:red}');
+    });
+
+    it('preserves already top-level @media rules', () => {
+      expect(
+        downlevelForEmailClients(
+          '@media (min-width:40rem){.sm_p-4{padding:1rem!important}}',
+        ),
+      ).toBe('@media (min-width:40rem){.sm_p-4{padding:1rem!important}}');
+    });
+
+    it('passes through &:hover nesting unchanged', () => {
+      // &:hover nesting is a separate problem — email clients don't support
+      // :hover reliably anyway. This function only handles @media unnesting.
+      const input =
+        '.hover_bg-red-600{&:hover{@media (hover:hover){background-color:red!important}}}';
+      expect(downlevelForEmailClients(input)).toBe(input);
+    });
+
+    it('handles multiple @media nested in one selector', () => {
+      const input =
+        '.multi{@media (width>=40rem){color:red!important}@media (width>=48rem){color:blue!important}}';
+
+      const expected =
+        '@media (min-width:40rem){.multi{color:red!important}}' +
+        '@media (min-width:48rem){.multi{color:blue!important}}';
+
+      expect(downlevelForEmailClients(input)).toBe(expected);
+    });
+
+    it('handles empty input', () => {
+      expect(downlevelForEmailClients('')).toBe('');
+    });
+  });
+});

--- a/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.spec.ts
@@ -1,51 +1,41 @@
+import { generate, parse, type StyleSheet } from 'css-tree';
 import { downlevelForEmailClients } from './downlevel-for-email-clients.js';
+
+function transform(css: string): string {
+  const ast = parse(css) as StyleSheet;
+  downlevelForEmailClients(ast);
+  return generate(ast);
+}
 
 describe('downlevelForEmailClients', () => {
   describe('range syntax', () => {
     it('converts width>= to min-width', () => {
       expect(
-        downlevelForEmailClients(
-          '@media (width>=40rem){.sm_p-4{padding:1rem}}',
-        ),
+        transform('@media (width>=40rem){.sm_p-4{padding:1rem}}'),
       ).toBe('@media (min-width:40rem){.sm_p-4{padding:1rem}}');
     });
 
     it('converts width<= to max-width', () => {
       expect(
-        downlevelForEmailClients(
-          '@media (width<=40rem){.max-sm_p-4{padding:1rem}}',
-        ),
+        transform('@media (width<=40rem){.max-sm_p-4{padding:1rem}}'),
       ).toBe('@media (max-width:40rem){.max-sm_p-4{padding:1rem}}');
     });
 
     it('converts width< to max-width', () => {
       expect(
-        downlevelForEmailClients(
-          '.max-sm_text-red-600{@media (width<40rem){color:red!important}}',
-        ),
-      ).toBe(
-        '@media (max-width:40rem){.max-sm_text-red-600{color:red!important}}',
-      );
+        transform('@media (width<40rem){.max-sm_text-red{color:red}}'),
+      ).toBe('@media (max-width:40rem){.max-sm_text-red{color:red}}');
     });
 
     it('converts width> to min-width', () => {
       expect(
-        downlevelForEmailClients(
-          '@media (width>40rem){.sm_p-4{padding:1rem}}',
-        ),
+        transform('@media (width>40rem){.sm_p-4{padding:1rem}}'),
       ).toBe('@media (min-width:40rem){.sm_p-4{padding:1rem}}');
     });
 
-    it('converts height range syntax', () => {
+    it('does not affect non-range media queries', () => {
       expect(
-        downlevelForEmailClients('@media (height>=600px){.tall{color:red}}'),
-      ).toBe('@media (min-height:600px){.tall{color:red}}');
-    });
-
-    it('does not match partial property names', () => {
-      // prefers-color-scheme should not be affected
-      expect(
-        downlevelForEmailClients(
+        transform(
           '@media (prefers-color-scheme:dark){.dark{color:white}}',
         ),
       ).toBe('@media (prefers-color-scheme:dark){.dark{color:white}}');
@@ -55,41 +45,42 @@ describe('downlevelForEmailClients', () => {
   describe('unnesting', () => {
     it('unnests @media from inside a selector', () => {
       expect(
-        downlevelForEmailClients(
-          '.sm_bg-red-300{@media (min-width:40rem){background-color:red!important}}',
+        transform(
+          '.sm_bg-red{@media (min-width:40rem){background-color:red!important}}',
         ),
       ).toBe(
-        '@media (min-width:40rem){.sm_bg-red-300{background-color:red!important}}',
+        '@media (min-width:40rem){.sm_bg-red{background-color:red!important}}',
       );
     });
 
     it('handles combined range syntax + nesting', () => {
       expect(
-        downlevelForEmailClients(
-          '.sm_bg-red-300{@media (width>=40rem){background-color:rgb(255,162,162)!important}}',
+        transform(
+          '.sm_bg-red{@media (width>=40rem){background-color:rgb(255,162,162)!important}}',
         ),
       ).toBe(
-        '@media (min-width:40rem){.sm_bg-red-300{background-color:rgb(255,162,162)!important}}',
+        '@media (min-width:40rem){.sm_bg-red{background-color:rgb(255,162,162)!important}}',
       );
     });
 
     it('handles multiple concatenated rules', () => {
       const input =
-        '.sm_bg-red-300{@media (width>=40rem){background-color:red!important}}' +
-        '.md_bg-red-400{@media (width>=48rem){background-color:blue!important}}' +
-        '.lg_bg-red-500{@media (width>=64rem){background-color:green!important}}';
+        '.sm_bg-red{@media (width>=40rem){background-color:red!important}}' +
+        '.md_bg-blue{@media (width>=48rem){background-color:blue!important}}';
 
-      const expected =
-        '@media (min-width:40rem){.sm_bg-red-300{background-color:red!important}}' +
-        '@media (min-width:48rem){.md_bg-red-400{background-color:blue!important}}' +
-        '@media (min-width:64rem){.lg_bg-red-500{background-color:green!important}}';
+      const result = transform(input);
 
-      expect(downlevelForEmailClients(input)).toBe(expected);
+      expect(result).toContain(
+        '@media (min-width:40rem){.sm_bg-red{background-color:red!important}}',
+      );
+      expect(result).toContain(
+        '@media (min-width:48rem){.md_bg-blue{background-color:blue!important}}',
+      );
     });
 
-    it('preserves dark mode media queries and unnests them', () => {
+    it('unnests dark mode media queries', () => {
       expect(
-        downlevelForEmailClients(
+        transform(
           '.dark_text-white{@media (prefers-color-scheme:dark){color:rgb(255,255,255)!important}}',
         ),
       ).toBe(
@@ -98,40 +89,37 @@ describe('downlevelForEmailClients', () => {
     });
 
     it('preserves rules without nested @media', () => {
-      expect(
-        downlevelForEmailClients('.bg-red-300{background-color:red}'),
-      ).toBe('.bg-red-300{background-color:red}');
+      expect(transform('.bg-red{background-color:red}')).toBe(
+        '.bg-red{background-color:red}',
+      );
     });
 
     it('preserves already top-level @media rules', () => {
       expect(
-        downlevelForEmailClients(
+        transform(
           '@media (min-width:40rem){.sm_p-4{padding:1rem!important}}',
         ),
-      ).toBe('@media (min-width:40rem){.sm_p-4{padding:1rem!important}}');
-    });
-
-    it('passes through &:hover nesting unchanged', () => {
-      // &:hover nesting is a separate problem — email clients don't support
-      // :hover reliably anyway. This function only handles @media unnesting.
-      const input =
-        '.hover_bg-red-600{&:hover{@media (hover:hover){background-color:red!important}}}';
-      expect(downlevelForEmailClients(input)).toBe(input);
+      ).toBe(
+        '@media (min-width:40rem){.sm_p-4{padding:1rem!important}}',
+      );
     });
 
     it('handles multiple @media nested in one selector', () => {
       const input =
         '.multi{@media (width>=40rem){color:red!important}@media (width>=48rem){color:blue!important}}';
 
-      const expected =
-        '@media (min-width:40rem){.multi{color:red!important}}' +
-        '@media (min-width:48rem){.multi{color:blue!important}}';
+      const result = transform(input);
 
-      expect(downlevelForEmailClients(input)).toBe(expected);
+      expect(result).toContain(
+        '@media (min-width:40rem){.multi{color:red!important}}',
+      );
+      expect(result).toContain(
+        '@media (min-width:48rem){.multi{color:blue!important}}',
+      );
     });
 
-    it('handles empty input', () => {
-      expect(downlevelForEmailClients('')).toBe('');
+    it('handles empty stylesheet', () => {
+      expect(transform('')).toBe('');
     });
   });
 });

--- a/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.spec.ts
@@ -10,9 +10,9 @@ function transform(css: string): string {
 describe('downlevelForEmailClients', () => {
   describe('range syntax', () => {
     it('converts width>= to min-width', () => {
-      expect(
-        transform('@media (width>=40rem){.sm_p-4{padding:1rem}}'),
-      ).toBe('@media (min-width:40rem){.sm_p-4{padding:1rem}}');
+      expect(transform('@media (width>=40rem){.sm_p-4{padding:1rem}}')).toBe(
+        '@media (min-width:40rem){.sm_p-4{padding:1rem}}',
+      );
     });
 
     it('converts width<= to max-width', () => {
@@ -28,16 +28,14 @@ describe('downlevelForEmailClients', () => {
     });
 
     it('converts width> to min-width', () => {
-      expect(
-        transform('@media (width>40rem){.sm_p-4{padding:1rem}}'),
-      ).toBe('@media (min-width:40rem){.sm_p-4{padding:1rem}}');
+      expect(transform('@media (width>40rem){.sm_p-4{padding:1rem}}')).toBe(
+        '@media (min-width:40rem){.sm_p-4{padding:1rem}}',
+      );
     });
 
     it('does not affect non-range media queries', () => {
       expect(
-        transform(
-          '@media (prefers-color-scheme:dark){.dark{color:white}}',
-        ),
+        transform('@media (prefers-color-scheme:dark){.dark{color:white}}'),
       ).toBe('@media (prefers-color-scheme:dark){.dark{color:white}}');
     });
   });
@@ -96,12 +94,8 @@ describe('downlevelForEmailClients', () => {
 
     it('preserves already top-level @media rules', () => {
       expect(
-        transform(
-          '@media (min-width:40rem){.sm_p-4{padding:1rem!important}}',
-        ),
-      ).toBe(
-        '@media (min-width:40rem){.sm_p-4{padding:1rem!important}}',
-      );
+        transform('@media (min-width:40rem){.sm_p-4{padding:1rem!important}}'),
+      ).toBe('@media (min-width:40rem){.sm_p-4{padding:1rem!important}}');
     });
 
     it('handles multiple @media nested in one selector', () => {

--- a/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
@@ -1,0 +1,184 @@
+/**
+ * Downlevels modern CSS features that email clients don't support:
+ *
+ * 1. Media Queries Level 4 range syntax → legacy min-width/max-width
+ *    `(width>=40rem)` → `(min-width:40rem)`
+ *
+ * 2. CSS Nesting (nested @media inside selectors) → top-level @media
+ *    `.sm_p-4{@media (min-width:40rem){padding:1rem!important}}`
+ *    → `@media (min-width:40rem){.sm_p-4{padding:1rem!important}}`
+ *
+ * Gmail, Outlook, Yahoo, and most email clients don't support either feature.
+ * See: https://www.caniemail.com/features/css-at-media/
+ *      https://www.caniemail.com/features/css-nesting/
+ */
+
+/**
+ * Convert Media Queries Level 4 range syntax to legacy min-width/max-width.
+ *
+ * Tailwind v4 generates `@media (width>=40rem)` but email clients
+ * only understand `@media (min-width:40rem)`.
+ *
+ * Note: strict `<` and `>` are approximated as `<=` and `>=` respectively.
+ * The sub-pixel difference is irrelevant for email rendering.
+ */
+function downlevelRangeSyntax(css: string): string {
+  // Order matters: >= and <= must be replaced before > and <
+  return css
+    .replace(/\(\s*width\s*>=\s*([^)]+)\)/g, '(min-width:$1)')
+    .replace(/\(\s*width\s*<=\s*([^)]+)\)/g, '(max-width:$1)')
+    .replace(/\(\s*width\s*>\s*([^)]+)\)/g, '(min-width:$1)')
+    .replace(/\(\s*width\s*<\s*([^)]+)\)/g, '(max-width:$1)')
+    .replace(/\(\s*height\s*>=\s*([^)]+)\)/g, '(min-height:$1)')
+    .replace(/\(\s*height\s*<=\s*([^)]+)\)/g, '(max-height:$1)')
+    .replace(/\(\s*height\s*>\s*([^)]+)\)/g, '(min-height:$1)')
+    .replace(/\(\s*height\s*<\s*([^)]+)\)/g, '(max-height:$1)');
+}
+
+/**
+ * Extract a brace-balanced block starting at position `start` (which should
+ * point to the opening `{`). Returns the index of the closing `}`.
+ */
+function findClosingBrace(css: string, start: number): number {
+  let depth = 0;
+  for (let i = start; i < css.length; i++) {
+    if (css[i] === '{') depth++;
+    else if (css[i] === '}') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return css.length;
+}
+
+/**
+ * Parse a block's content into top-level segments, respecting brace nesting.
+ * Each segment is a complete nested rule or at-rule.
+ */
+function parseBlockSegments(blockContent: string): string[] {
+  const segments: string[] = [];
+  let i = 0;
+
+  while (i < blockContent.length) {
+    // Skip whitespace
+    while (i < blockContent.length && /\s/.test(blockContent[i])) i++;
+    if (i >= blockContent.length) break;
+
+    const segStart = i;
+
+    // Read until we find a '{' (start of a block) or run out
+    while (i < blockContent.length && blockContent[i] !== '{') i++;
+
+    if (i >= blockContent.length) {
+      // No block found — this is bare declarations (shouldn't happen in
+      // the non-inlinable output, but handle gracefully)
+      segments.push(blockContent.slice(segStart).trim());
+      break;
+    }
+
+    // Find the matching closing brace
+    const closeIdx = findClosingBrace(blockContent, i);
+    segments.push(blockContent.slice(segStart, closeIdx + 1).trim());
+    i = closeIdx + 1;
+  }
+
+  return segments.filter((s) => s.length > 0);
+}
+
+/**
+ * Unnest `@media` rules that are nested inside selectors.
+ *
+ * Tailwind v4 with CSS nesting generates:
+ *   `.sm_p-4{@media (min-width:40rem){padding:1rem!important}}`
+ *
+ * Email clients need:
+ *   `@media (min-width:40rem){.sm_p-4{padding:1rem!important}}`
+ *
+ * This handles one level of nesting (selector → @media → declarations).
+ * Deeper nesting (e.g. `&:hover` inside `@media`) is preserved as-is
+ * since pseudo-class support in email clients is limited regardless.
+ */
+function unnestMediaQueries(css: string): string {
+  const result: string[] = [];
+  let i = 0;
+
+  while (i < css.length) {
+    // Skip whitespace
+    while (i < css.length && /\s/.test(css[i])) {
+      result.push(css[i]);
+      i++;
+    }
+
+    if (i >= css.length) break;
+
+    // Check if this is already a top-level at-rule (@media, @supports, etc.)
+    if (css[i] === '@') {
+      const atStart = i;
+      while (i < css.length && css[i] !== '{') i++;
+      if (i >= css.length) {
+        result.push(css.slice(atStart));
+        break;
+      }
+      const closingBrace = findClosingBrace(css, i);
+      result.push(css.slice(atStart, closingBrace + 1));
+      i = closingBrace + 1;
+      continue;
+    }
+
+    // This should be a selector — read until '{'
+    const selectorStart = i;
+    while (i < css.length && css[i] !== '{') i++;
+    if (i >= css.length) {
+      result.push(css.slice(selectorStart));
+      break;
+    }
+
+    const selector = css.slice(selectorStart, i).trim();
+    const outerOpen = i;
+    const outerClose = findClosingBrace(css, outerOpen);
+    const blockContent = css.slice(outerOpen + 1, outerClose).trim();
+
+    // Parse the block into top-level segments to handle multiple nested @media
+    const segments = parseBlockSegments(blockContent);
+    const mediaSegments: string[] = [];
+    const otherSegments: string[] = [];
+
+    for (const segment of segments) {
+      if (/^@media\s/.test(segment)) {
+        mediaSegments.push(segment);
+      } else {
+        otherSegments.push(segment);
+      }
+    }
+
+    if (mediaSegments.length > 0) {
+      // Emit non-@media segments as a regular rule (if any)
+      if (otherSegments.length > 0) {
+        result.push(`${selector}{${otherSegments.join('')}}`);
+      }
+
+      // Unnest each @media: wrap the selector inside the @media
+      for (const mediaSegment of mediaSegments) {
+        const braceIdx = mediaSegment.indexOf('{');
+        const mediaHeader = mediaSegment.slice(0, braceIdx).trim();
+        const mediaClose = findClosingBrace(mediaSegment, braceIdx);
+        const mediaBody = mediaSegment.slice(braceIdx + 1, mediaClose);
+
+        result.push(`${mediaHeader}{${selector}{${mediaBody}}}`);
+      }
+    } else {
+      // No nested @media — emit the entire rule as-is
+      result.push(css.slice(selectorStart, outerClose + 1));
+    }
+
+    i = outerClose + 1;
+  }
+
+  return result.join('');
+}
+
+export function downlevelForEmailClients(css: string): string {
+  css = downlevelRangeSyntax(css);
+  css = unnestMediaQueries(css);
+  return css;
+}

--- a/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
@@ -17,11 +17,11 @@
 import {
   type Atrule,
   type CssNode,
+  clone,
+  List,
   type ListItem,
   type Rule,
   type StyleSheet,
-  clone,
-  List,
   walk,
 } from 'css-tree';
 
@@ -59,7 +59,7 @@ interface UnnestTransform {
 function unnestMediaQueries(styleSheet: StyleSheet): void {
   const transforms: UnnestTransform[] = [];
 
-  styleSheet.children.forEach(function (node, item, list) {
+  styleSheet.children.forEach((node, item, list) => {
     if (node.type !== 'Rule' || !node.block) return;
 
     const nestedAtrules: Atrule[] = [];
@@ -113,9 +113,7 @@ function unnestMediaQueries(styleSheet: StyleSheet): void {
         prelude: clone(parentRule.prelude) as Rule['prelude'],
         block: {
           type: 'Block',
-          children: atrule.block
-            ? atrule.block.children
-            : new List<CssNode>(),
+          children: atrule.block ? atrule.block.children : new List<CssNode>(),
         },
       };
 

--- a/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
@@ -1,184 +1,214 @@
 /**
- * Downlevels modern CSS features that email clients don't support:
+ * Downlevels modern CSS features that email clients don't support,
+ * operating on a css-tree StyleSheet AST.
  *
- * 1. Media Queries Level 4 range syntax → legacy min-width/max-width
- *    `(width>=40rem)` → `(min-width:40rem)`
- *
- * 2. CSS Nesting (nested @media inside selectors) → top-level @media
+ * 1. CSS Nesting: unnests @media rules from inside selectors
  *    `.sm_p-4{@media (min-width:40rem){padding:1rem!important}}`
  *    → `@media (min-width:40rem){.sm_p-4{padding:1rem!important}}`
+ *
+ * 2. Media Queries Level 4 range syntax → legacy min-width/max-width
+ *    `(width>=40rem)` → `(min-width:40rem)`
  *
  * Gmail, Outlook, Yahoo, and most email clients don't support either feature.
  * See: https://www.caniemail.com/features/css-at-media/
  *      https://www.caniemail.com/features/css-nesting/
  */
 
+import {
+  type Atrule,
+  type CssNode,
+  type ListItem,
+  type Rule,
+  type StyleSheet,
+  clone,
+  List,
+  walk,
+} from 'css-tree';
+
 /**
- * Convert Media Queries Level 4 range syntax to legacy min-width/max-width.
+ * Unnest @media at-rules from inside regular rules, and downlevel
+ * range media query syntax to legacy min-width/max-width.
  *
- * Tailwind v4 generates `@media (width>=40rem)` but email clients
- * only understand `@media (min-width:40rem)`.
- *
- * Note: strict `<` and `>` are approximated as `<=` and `>=` respectively.
- * The sub-pixel difference is irrelevant for email rendering.
+ * Mutates the stylesheet in place.
  */
-function downlevelRangeSyntax(css: string): string {
-  // Order matters: >= and <= must be replaced before > and <
-  return css
-    .replace(/\(\s*width\s*>=\s*([^)]+)\)/g, '(min-width:$1)')
-    .replace(/\(\s*width\s*<=\s*([^)]+)\)/g, '(max-width:$1)')
-    .replace(/\(\s*width\s*>\s*([^)]+)\)/g, '(min-width:$1)')
-    .replace(/\(\s*width\s*<\s*([^)]+)\)/g, '(max-width:$1)')
-    .replace(/\(\s*height\s*>=\s*([^)]+)\)/g, '(min-height:$1)')
-    .replace(/\(\s*height\s*<=\s*([^)]+)\)/g, '(max-height:$1)')
-    .replace(/\(\s*height\s*>\s*([^)]+)\)/g, '(min-height:$1)')
-    .replace(/\(\s*height\s*<\s*([^)]+)\)/g, '(max-height:$1)');
+export function downlevelForEmailClients(styleSheet: StyleSheet): void {
+  unnestMediaQueries(styleSheet);
+  downlevelRangeMediaQueries(styleSheet);
+}
+
+// ---------------------------------------------------------------------------
+// Unnesting
+// ---------------------------------------------------------------------------
+
+interface UnnestTransform {
+  parentRule: Rule;
+  parentItem: ListItem<CssNode>;
+  parentList: List<CssNode>;
+  nestedAtrules: Atrule[];
+  remainingChildren: CssNode[];
 }
 
 /**
- * Extract a brace-balanced block starting at position `start` (which should
- * point to the opening `{`). Returns the index of the closing `}`.
- */
-function findClosingBrace(css: string, start: number): number {
-  let depth = 0;
-  for (let i = start; i < css.length; i++) {
-    if (css[i] === '{') depth++;
-    else if (css[i] === '}') {
-      depth--;
-      if (depth === 0) return i;
-    }
-  }
-  return css.length;
-}
-
-/**
- * Parse a block's content into top-level segments, respecting brace nesting.
- * Each segment is a complete nested rule or at-rule.
- */
-function parseBlockSegments(blockContent: string): string[] {
-  const segments: string[] = [];
-  let i = 0;
-
-  while (i < blockContent.length) {
-    // Skip whitespace
-    while (i < blockContent.length && /\s/.test(blockContent[i])) i++;
-    if (i >= blockContent.length) break;
-
-    const segStart = i;
-
-    // Read until we find a '{' (start of a block) or run out
-    while (i < blockContent.length && blockContent[i] !== '{') i++;
-
-    if (i >= blockContent.length) {
-      // No block found — this is bare declarations (shouldn't happen in
-      // the non-inlinable output, but handle gracefully)
-      segments.push(blockContent.slice(segStart).trim());
-      break;
-    }
-
-    // Find the matching closing brace
-    const closeIdx = findClosingBrace(blockContent, i);
-    segments.push(blockContent.slice(segStart, closeIdx + 1).trim());
-    i = closeIdx + 1;
-  }
-
-  return segments.filter((s) => s.length > 0);
-}
-
-/**
- * Unnest `@media` rules that are nested inside selectors.
+ * Walk the stylesheet and unnest any @media/@supports rules that are nested
+ * inside regular rules. For each, the parent Rule's selector wraps the
+ * at-rule's body.
  *
- * Tailwind v4 with CSS nesting generates:
- *   `.sm_p-4{@media (min-width:40rem){padding:1rem!important}}`
- *
- * Email clients need:
- *   `@media (min-width:40rem){.sm_p-4{padding:1rem!important}}`
- *
- * This handles one level of nesting (selector → @media → declarations).
- * Deeper nesting (e.g. `&:hover` inside `@media`) is preserved as-is
- * since pseudo-class support in email clients is limited regardless.
+ * Before: `.sm_p-4 { @media (...) { padding: 1rem } }`
+ * After:  `@media (...) { .sm_p-4 { padding: 1rem } }`
  */
-function unnestMediaQueries(css: string): string {
-  const result: string[] = [];
-  let i = 0;
+function unnestMediaQueries(styleSheet: StyleSheet): void {
+  const transforms: UnnestTransform[] = [];
 
-  while (i < css.length) {
-    // Skip whitespace
-    while (i < css.length && /\s/.test(css[i])) {
-      result.push(css[i]);
-      i++;
-    }
+  styleSheet.children.forEach(function (node, item, list) {
+    if (node.type !== 'Rule' || !node.block) return;
 
-    if (i >= css.length) break;
+    const nestedAtrules: Atrule[] = [];
+    const remainingChildren: CssNode[] = [];
 
-    // Check if this is already a top-level at-rule (@media, @supports, etc.)
-    if (css[i] === '@') {
-      const atStart = i;
-      while (i < css.length && css[i] !== '{') i++;
-      if (i >= css.length) {
-        result.push(css.slice(atStart));
-        break;
-      }
-      const closingBrace = findClosingBrace(css, i);
-      result.push(css.slice(atStart, closingBrace + 1));
-      i = closingBrace + 1;
-      continue;
-    }
-
-    // This should be a selector — read until '{'
-    const selectorStart = i;
-    while (i < css.length && css[i] !== '{') i++;
-    if (i >= css.length) {
-      result.push(css.slice(selectorStart));
-      break;
-    }
-
-    const selector = css.slice(selectorStart, i).trim();
-    const outerOpen = i;
-    const outerClose = findClosingBrace(css, outerOpen);
-    const blockContent = css.slice(outerOpen + 1, outerClose).trim();
-
-    // Parse the block into top-level segments to handle multiple nested @media
-    const segments = parseBlockSegments(blockContent);
-    const mediaSegments: string[] = [];
-    const otherSegments: string[] = [];
-
-    for (const segment of segments) {
-      if (/^@media\s/.test(segment)) {
-        mediaSegments.push(segment);
+    node.block.children.forEach((child) => {
+      if (
+        child.type === 'Atrule' &&
+        (child.name === 'media' || child.name === 'supports')
+      ) {
+        nestedAtrules.push(child);
       } else {
-        otherSegments.push(segment);
+        remainingChildren.push(child);
       }
+    });
+
+    if (nestedAtrules.length > 0) {
+      transforms.push({
+        parentRule: node,
+        parentItem: item,
+        parentList: list,
+        nestedAtrules,
+        remainingChildren,
+      });
+    }
+  });
+
+  // Apply in reverse so list positions stay valid
+  for (let i = transforms.length - 1; i >= 0; i--) {
+    const {
+      parentRule,
+      parentItem,
+      parentList,
+      nestedAtrules,
+      remainingChildren,
+    } = transforms[i];
+
+    // Build replacement list: [modified parent rule (if any), unnested @media rules...]
+    const replacements = new List<CssNode>();
+
+    if (remainingChildren.length > 0) {
+      parentRule.block.children = new List<CssNode>().fromArray(
+        remainingChildren,
+      );
+      replacements.appendData(parentRule);
     }
 
-    if (mediaSegments.length > 0) {
-      // Emit non-@media segments as a regular rule (if any)
-      if (otherSegments.length > 0) {
-        result.push(`${selector}{${otherSegments.join('')}}`);
-      }
+    for (const atrule of nestedAtrules) {
+      const wrappedRule: Rule = {
+        type: 'Rule',
+        prelude: clone(parentRule.prelude) as Rule['prelude'],
+        block: {
+          type: 'Block',
+          children: atrule.block
+            ? atrule.block.children
+            : new List<CssNode>(),
+        },
+      };
 
-      // Unnest each @media: wrap the selector inside the @media
-      for (const mediaSegment of mediaSegments) {
-        const braceIdx = mediaSegment.indexOf('{');
-        const mediaHeader = mediaSegment.slice(0, braceIdx).trim();
-        const mediaClose = findClosingBrace(mediaSegment, braceIdx);
-        const mediaBody = mediaSegment.slice(braceIdx + 1, mediaClose);
+      const newAtrule: Atrule = {
+        type: 'Atrule',
+        name: atrule.name,
+        prelude: atrule.prelude,
+        block: {
+          type: 'Block',
+          children: new List<CssNode>().fromArray([wrappedRule]),
+        },
+      };
 
-        result.push(`${mediaHeader}{${selector}{${mediaBody}}}`);
-      }
-    } else {
-      // No nested @media — emit the entire rule as-is
-      result.push(css.slice(selectorStart, outerClose + 1));
+      replacements.appendData(newAtrule);
     }
 
-    i = outerClose + 1;
+    // Replace the original rule with the entire list of new nodes
+    parentList.replace(parentItem, replacements);
   }
-
-  return result.join('');
 }
 
-export function downlevelForEmailClients(css: string): string {
-  css = downlevelRangeSyntax(css);
-  css = unnestMediaQueries(css);
-  return css;
+// ---------------------------------------------------------------------------
+// Range media query downleveling
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk all @media at-rules and downlevel range syntax in their preludes.
+ *
+ * css-tree 3.x parses `(width >= 40rem)` as a `FeatureRange` node:
+ *   { type: "FeatureRange", left: Identifier("width"), leftComparison: ">=", middle: Dimension("40rem") }
+ *
+ * We convert these to `Feature` nodes (legacy syntax):
+ *   { type: "Feature", name: "min-width", value: Dimension("40rem") }
+ */
+function downlevelRangeMediaQueries(styleSheet: StyleSheet): void {
+  const replacements: Array<{
+    item: ListItem<CssNode>;
+    replacement: CssNode;
+  }> = [];
+
+  // FeatureRange is a css-tree 3.x node type not yet in @types/css-tree
+  walk(styleSheet, {
+    enter(node: CssNode, item: ListItem<CssNode>) {
+      if ((node.type as string) === 'FeatureRange' && item) {
+        const replacement = downlevelFeatureRange(node);
+        if (replacement) {
+          replacements.push({ item, replacement });
+        }
+      }
+    },
+  });
+
+  for (const { item, replacement } of replacements) {
+    item.data = replacement;
+  }
+}
+
+/**
+ * Convert a FeatureRange node to a Feature node (legacy min-/max- syntax).
+ */
+function downlevelFeatureRange(node: CssNode): CssNode | null {
+  if ((node.type as string) !== 'FeatureRange') return null;
+
+  // css-tree's FeatureRange: { left, leftComparison, middle, rightComparison, right }
+  // For `width >= 40rem`: left=Identifier("width"), leftComparison=">=", middle=Dimension("40","rem")
+  const range = node as CssNode & {
+    left: CssNode | null;
+    leftComparison: string | null;
+    middle: CssNode | null;
+  };
+
+  if (!range.left || !range.leftComparison || !range.middle) return null;
+
+  const featureName =
+    range.left.type === 'Identifier'
+      ? (range.left as CssNode & { name: string }).name
+      : null;
+  if (!featureName) return null;
+
+  let prefix: string;
+  if (range.leftComparison === '>=' || range.leftComparison === '>') {
+    prefix = 'min-';
+  } else if (range.leftComparison === '<=' || range.leftComparison === '<') {
+    prefix = 'max-';
+  } else {
+    return null;
+  }
+
+  return {
+    type: 'Feature',
+    loc: null,
+    kind: 'media',
+    name: `${prefix}${featureName}`,
+    value: range.middle,
+  } as unknown as CssNode;
 }

--- a/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
@@ -45,7 +45,6 @@ interface UnnestTransform {
   parentItem: ListItem<CssNode>;
   parentList: List<CssNode>;
   nestedAtrules: Atrule[];
-  remainingChildren: CssNode[];
 }
 
 /**
@@ -65,18 +64,14 @@ function unnestMediaQueries(styleSheet: StyleSheet): void {
       if (!rule.block || !item) return;
 
       const nestedAtrules: Atrule[] = [];
-      const remainingChildren: CssNode[] = [];
-
-      rule.block.children.forEach((child) => {
+      for (const child of rule.block.children) {
         if (
           child.type === 'Atrule' &&
           (child.name === 'media' || child.name === 'supports')
         ) {
           nestedAtrules.push(child);
-        } else {
-          remainingChildren.push(child);
         }
-      });
+      }
 
       if (nestedAtrules.length > 0) {
         transforms.push({
@@ -84,7 +79,6 @@ function unnestMediaQueries(styleSheet: StyleSheet): void {
           parentItem: item,
           parentList: list,
           nestedAtrules,
-          remainingChildren,
         });
       }
     },
@@ -92,20 +86,22 @@ function unnestMediaQueries(styleSheet: StyleSheet): void {
 
   // Apply in reverse so list positions stay valid
   for (let i = transforms.length - 1; i >= 0; i--) {
-    const {
-      parentRule,
-      parentItem,
-      parentList,
-      nestedAtrules,
-      remainingChildren,
-    } = transforms[i]!;
+    const { parentRule, parentItem, parentList, nestedAtrules } =
+      transforms[i]!;
 
     // Build replacement list: [modified parent rule (if any), unnested @media rules...]
     const replacements = new List<CssNode>();
 
-    if (remainingChildren.length > 0) {
+    // What stays inside the parent rule: every direct child that wasn't
+    // pulled out as a nested @media/@supports.
+    const nestedSet = new Set<CssNode>(nestedAtrules);
+    const nonAtruleChildren: CssNode[] = [];
+    for (const child of parentRule.block.children) {
+      if (!nestedSet.has(child)) nonAtruleChildren.push(child);
+    }
+    if (nonAtruleChildren.length > 0) {
       parentRule.block.children = new List<CssNode>().fromArray(
-        remainingChildren,
+        nonAtruleChildren,
       );
       replacements.appendData(parentRule);
     }

--- a/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
@@ -17,9 +17,9 @@
 import {
   type Atrule,
   type CssNode,
+  clone,
   type Feature,
   type FeatureRange,
-  clone,
   List,
   type ListItem,
   type Rule,

--- a/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
@@ -17,6 +17,8 @@
 import {
   type Atrule,
   type CssNode,
+  type Feature,
+  type FeatureRange,
   clone,
   List,
   type ListItem,
@@ -24,6 +26,48 @@ import {
   type StyleSheet,
   walk,
 } from 'css-tree';
+
+/**
+ * css-tree 3.x introduced new AST node types for query-related at-rules that
+ * `@types/css-tree` (still on 2.x at the time of writing) doesn't expose.
+ * Augmenting the module here lets the rest of this file work with strong
+ * types instead of scattering `as` casts everywhere.
+ *
+ * - `FeatureRange` is what the parser emits for Media Queries Level 4 range
+ *   syntax: `(width >= 40rem)`.
+ * - `Feature` is the legacy form (`(min-width: 40rem)`) we construct as the
+ *   downleveled output.
+ *
+ * Note: we cannot extend the `CssNode` union itself (it's a `type` alias, not
+ * an interface), so two narrow casts remain in this file:
+ *   1. Widening `node` inside `walk()` so we can narrow against
+ *      `FeatureRange.type` (`CssNode` doesn't list `'FeatureRange'`).
+ *   2. Assigning a constructed `Feature` back to `ListItem<CssNode>.data`.
+ *
+ * Both are flagged inline and reference back to this block.
+ *
+ * See:
+ *   https://github.com/csstree/csstree/blob/master/lib/syntax/node/FeatureRange.js
+ *   https://github.com/csstree/csstree/blob/master/lib/syntax/node/Feature.js
+ */
+declare module 'css-tree' {
+  interface FeatureRange extends CssNodeCommon {
+    type: 'FeatureRange';
+    kind: string;
+    left: CssNode;
+    leftComparison: string;
+    middle: CssNode;
+    rightComparison: string | null;
+    right: CssNode | null;
+  }
+
+  interface Feature extends CssNodeCommon {
+    type: 'Feature';
+    kind: string;
+    name: string;
+    value: CssNode | null;
+  }
+}
 
 /**
  * Unnest @media at-rules from inside regular rules, and downlevel
@@ -45,6 +89,7 @@ interface UnnestTransform {
   parentItem: ListItem<CssNode>;
   parentList: List<CssNode>;
   nestedAtrules: Atrule[];
+  remainingChildren: CssNode[];
 }
 
 /**
@@ -64,14 +109,18 @@ function unnestMediaQueries(styleSheet: StyleSheet): void {
       if (!rule.block || !item) return;
 
       const nestedAtrules: Atrule[] = [];
-      for (const child of rule.block.children) {
+      const remainingChildren: CssNode[] = [];
+
+      rule.block.children.forEach((child) => {
         if (
           child.type === 'Atrule' &&
           (child.name === 'media' || child.name === 'supports')
         ) {
           nestedAtrules.push(child);
+        } else {
+          remainingChildren.push(child);
         }
-      }
+      });
 
       if (nestedAtrules.length > 0) {
         transforms.push({
@@ -79,6 +128,7 @@ function unnestMediaQueries(styleSheet: StyleSheet): void {
           parentItem: item,
           parentList: list,
           nestedAtrules,
+          remainingChildren,
         });
       }
     },
@@ -86,22 +136,20 @@ function unnestMediaQueries(styleSheet: StyleSheet): void {
 
   // Apply in reverse so list positions stay valid
   for (let i = transforms.length - 1; i >= 0; i--) {
-    const { parentRule, parentItem, parentList, nestedAtrules } =
-      transforms[i]!;
+    const {
+      parentRule,
+      parentItem,
+      parentList,
+      nestedAtrules,
+      remainingChildren,
+    } = transforms[i]!;
 
     // Build replacement list: [modified parent rule (if any), unnested @media rules...]
     const replacements = new List<CssNode>();
 
-    // What stays inside the parent rule: every direct child that wasn't
-    // pulled out as a nested @media/@supports.
-    const nestedSet = new Set<CssNode>(nestedAtrules);
-    const nonAtruleChildren: CssNode[] = [];
-    for (const child of parentRule.block.children) {
-      if (!nestedSet.has(child)) nonAtruleChildren.push(child);
-    }
-    if (nonAtruleChildren.length > 0) {
+    if (remainingChildren.length > 0) {
       parentRule.block.children = new List<CssNode>().fromArray(
-        nonAtruleChildren,
+        remainingChildren,
       );
       replacements.appendData(parentRule);
     }
@@ -139,24 +187,21 @@ function unnestMediaQueries(styleSheet: StyleSheet): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Walk all @media at-rules and downlevel range syntax in their preludes.
- *
- * css-tree 3.x parses `(width >= 40rem)` as a `FeatureRange` node:
- *   { type: "FeatureRange", left: Identifier("width"), leftComparison: ">=", middle: Dimension("40rem") }
- *
- * We convert these to `Feature` nodes (legacy syntax):
- *   { type: "Feature", name: "min-width", value: Dimension("40rem") }
+ * Walk all nodes and downlevel range syntax (`FeatureRange`) inside @media
+ * preludes to legacy `Feature` nodes (`min-width` / `max-width`).
  */
 function downlevelRangeMediaQueries(styleSheet: StyleSheet): void {
   const replacements: Array<{
     item: ListItem<CssNode>;
-    replacement: CssNode;
+    replacement: Feature;
   }> = [];
 
-  // FeatureRange is a css-tree 3.x node type not yet in @types/css-tree
   walk(styleSheet, {
-    enter(node: CssNode, item: ListItem<CssNode>) {
-      if ((node.type as string) === 'FeatureRange' && item) {
+    enter(originalNode, item) {
+      // See module augmentation above: `CssNode` (from @types/css-tree 2.x)
+      // doesn't include `FeatureRange`, so widen here to enable narrowing.
+      const node = originalNode as CssNode | FeatureRange;
+      if (item && node.type === 'FeatureRange') {
         const replacement = downlevelFeatureRange(node);
         if (replacement) {
           replacements.push({ item, replacement });
@@ -166,31 +211,20 @@ function downlevelRangeMediaQueries(styleSheet: StyleSheet): void {
   });
 
   for (const { item, replacement } of replacements) {
-    item.data = replacement;
+    // See module augmentation above: `Feature` is not part of the `CssNode`
+    // union, so a single cast is required when handing it back to the AST.
+    item.data = replacement as unknown as CssNode;
   }
 }
 
 /**
- * Convert a FeatureRange node to a Feature node (legacy min-/max- syntax).
+ * Convert a `FeatureRange` node to a `Feature` node (legacy min-/max- syntax).
+ *
+ * For `width >= 40rem`: left=Identifier("width"), leftComparison=">=", middle=Dimension("40","rem")
+ * Result: { type: "Feature", name: "min-width", value: Dimension("40","rem") }
  */
-function downlevelFeatureRange(node: CssNode): CssNode | null {
-  if ((node.type as string) !== 'FeatureRange') return null;
-
-  // css-tree's FeatureRange: { left, leftComparison, middle, rightComparison, right }
-  // For `width >= 40rem`: left=Identifier("width"), leftComparison=">=", middle=Dimension("40","rem")
-  const range = node as CssNode & {
-    left: CssNode | null;
-    leftComparison: string | null;
-    middle: CssNode | null;
-  };
-
-  if (!range.left || !range.leftComparison || !range.middle) return null;
-
-  const featureName =
-    range.left.type === 'Identifier'
-      ? (range.left as CssNode & { name: string }).name
-      : null;
-  if (!featureName) return null;
+function downlevelFeatureRange(range: FeatureRange): Feature | null {
+  if (range.left.type !== 'Identifier') return null;
 
   let prefix: string;
   if (range.leftComparison === '>=' || range.leftComparison === '>') {
@@ -203,9 +237,8 @@ function downlevelFeatureRange(node: CssNode): CssNode | null {
 
   return {
     type: 'Feature',
-    loc: null,
     kind: 'media',
-    name: `${prefix}${featureName}`,
+    name: `${prefix}${range.left.name}`,
     value: range.middle,
-  } as unknown as CssNode;
+  };
 }

--- a/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
@@ -59,32 +59,35 @@ interface UnnestTransform {
 function unnestMediaQueries(styleSheet: StyleSheet): void {
   const transforms: UnnestTransform[] = [];
 
-  styleSheet.children.forEach((node, item, list) => {
-    if (node.type !== 'Rule' || !node.block) return;
+  walk(styleSheet, {
+    visit: 'Rule',
+    enter(rule, item, list) {
+      if (!rule.block || !item) return;
 
-    const nestedAtrules: Atrule[] = [];
-    const remainingChildren: CssNode[] = [];
+      const nestedAtrules: Atrule[] = [];
+      const remainingChildren: CssNode[] = [];
 
-    node.block.children.forEach((child) => {
-      if (
-        child.type === 'Atrule' &&
-        (child.name === 'media' || child.name === 'supports')
-      ) {
-        nestedAtrules.push(child);
-      } else {
-        remainingChildren.push(child);
-      }
-    });
-
-    if (nestedAtrules.length > 0) {
-      transforms.push({
-        parentRule: node,
-        parentItem: item,
-        parentList: list,
-        nestedAtrules,
-        remainingChildren,
+      rule.block.children.forEach((child) => {
+        if (
+          child.type === 'Atrule' &&
+          (child.name === 'media' || child.name === 'supports')
+        ) {
+          nestedAtrules.push(child);
+        } else {
+          remainingChildren.push(child);
+        }
       });
-    }
+
+      if (nestedAtrules.length > 0) {
+        transforms.push({
+          parentRule: rule,
+          parentItem: item,
+          parentList: list,
+          nestedAtrules,
+          remainingChildren,
+        });
+      }
+    },
   });
 
   // Apply in reverse so list positions stay valid
@@ -95,7 +98,7 @@ function unnestMediaQueries(styleSheet: StyleSheet): void {
       parentList,
       nestedAtrules,
       remainingChildren,
-    } = transforms[i];
+    } = transforms[i]!;
 
     // Build replacement list: [modified parent rule (if any), unnested @media rules...]
     const replacements = new List<CssNode>();


### PR DESCRIPTION
## Problem

Tailwind CSS v4's `compile().build()` generates two modern CSS features that most email clients don't support:

**1. Media Queries Level 4 range syntax** — Gmail, Outlook, Yahoo strip these entirely:
```css
/* Tailwind v4 output — broken in Gmail */
@media (width>=40rem) { ... }

/* What email clients need */
@media (min-width:40rem) { ... }
```

**2. CSS Nesting** — email clients don't parse nested at-rules inside selectors:
```css
/* Tailwind v4 output — broken in Gmail */
.sm_p-4{@media (width>=40rem){padding:1rem!important}}

/* What email clients need */
@media (min-width:40rem){.sm_p-4{padding:1rem!important}}
```

When React Email uses the Tailwind compiler API directly, the PostCSS/Lightning CSS pipeline that normally downlevels these features doesn't run. The result: responsive breakpoints (`sm:`, `md:`, `lg:`, `max-sm:`) are silently stripped by email clients.

## Solution

Adds a `downlevelForEmailClients()` string transform that runs on the generated non-inlinable CSS (the `<style>` tag content) before injection:

1. **Range syntax → legacy**: `(width>=40rem)` → `(min-width:40rem)`, handles `>=`, `<=`, `>`, `<` for both `width` and `height`
2. **Unnest @media**: moves nested `@media` rules to the top level, wrapping the parent selector inside

The transform is applied in `tailwind.tsx` after `generate(nonInlineStyles)`, so it only affects the CSS that goes into the `<style>` tag — inlined styles are not affected.

## What's not covered

- **`&:hover` nesting** (e.g. `.hover_bg-red{&:hover{@media (hover:hover){...}}}`) — this is preserved as-is. Pseudo-class support in email clients is limited regardless, and resolving `&` to the parent selector is a separate concern.
- **Strict `<` / `>`** are approximated as `<=` / `>=` (sub-pixel difference, irrelevant for email).

## Testing

- 15 unit tests covering range syntax conversion, unnesting, multi-@media per selector, `&:hover` pass-through, dark mode, and edge cases
- Integration test snapshots in `tailwind.spec.tsx` will need updating (the `<style>` output changes from nested/range to legacy/unnested) — I couldn't run them locally since the workspace packages need a full build. Happy to update once CI runs.

Fixes #2712

## References

- https://www.caniemail.com/features/css-at-media/ (range syntax not supported)
- https://www.caniemail.com/features/css-nesting/ (nesting not supported)
- https://developers.google.com/workspace/gmail/design/css#css_media_queries

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downlevels Tailwind v4 CSS for email clients by converting range media queries and unnesting nested at-rules before injection. Restores responsive and dark‑mode styles in Gmail, Outlook, and Yahoo.

- **Bug Fixes**
  - Converts `(width|height >=|<=|>|<)` to legacy `min-`/`max-` media features.
  - Unnests nested `@media`/`@supports` to top level; only affects non-inlinable `<style>` CSS.

- **Refactors**
  - Rewrote the transform using the `css-tree` AST with `walk`; applied via `downlevelForEmailClients()` in `tailwind.tsx`.
  - Augmented `css-tree` types (`FeatureRange`/`Feature`) to remove casts; added unit tests and updated snapshots.

<sup>Written for commit 955954ab04e3a12244cecdca63f39aae1c3395b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

