### PR TITLE
feat(editor): make preview optional not nullable

### DIFF
--- a/packages/editor/examples/src/examples/email-export.tsx
+++ b/packages/editor/examples/src/examples/email-export.tsx
@@ -44,7 +44,7 @@ function ExportPanel() {
   const handleExport = async () => {
     if (!editor) return;
     setExporting(true);
-    const result = await composeReactEmail({ editor, preview: null });
+    const result = await composeReactEmail({ editor });
     setHtml(result.html);
     setExporting(false);
   };

--- a/packages/editor/examples/src/examples/full-email-builder.tsx
+++ b/packages/editor/examples/src/examples/full-email-builder.tsx
@@ -30,7 +30,7 @@ function ControlPanel() {
   const handleExport = async () => {
     if (!editor) return;
     setExporting(true);
-    const result = await composeReactEmail({ editor, preview: null });
+    const result = await composeReactEmail({ editor });
     setHtml(result.html);
     setExporting(false);
   };

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/editor",
-  "version": "0.0.0-experimental.30",
+  "version": "0.0.0-experimental.31",
   "description": "",
   "sideEffects": [
     "**/*.css"

--- a/packages/editor/src/core/serializer/compose-react-email.tsx
+++ b/packages/editor/src/core/serializer/compose-react-email.tsx
@@ -21,7 +21,7 @@ export const composeReactEmail = async ({
   preview,
 }: {
   editor: Editor;
-  preview: string | null;
+  preview?: string;
 }): Promise<ComposeReactEmailResult> => {
   const data = editor.getJSON();
   const extensions = editor.extensionManager.extensions;

--- a/packages/editor/src/core/serializer/default-base-template.tsx
+++ b/packages/editor/src/core/serializer/default-base-template.tsx
@@ -3,7 +3,7 @@ import type * as React from 'react';
 
 type BaseTemplateProps = {
   children: React.ReactNode;
-  previewText: string | null;
+  previewText?: string;
 };
 
 export function DefaultBaseTemplate({

--- a/packages/editor/src/core/serializer/serializer-plugin.ts
+++ b/packages/editor/src/core/serializer/serializer-plugin.ts
@@ -7,7 +7,7 @@ export interface SerializerPlugin {
     editor: Editor,
   ): React.CSSProperties;
   BaseTemplate(props: {
-    previewText: string | null;
+    previewText?: string;
     children: React.ReactNode;
     editor: Editor;
   }): React.ReactNode;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the `preview` field optional in `composeReactEmail` and removes `| null` typing to avoid ambiguity. Also bumps the experimental version to `0.0.0-experimental.31`.

## Changes

- **`compose-react-email.tsx`**: Changed `preview` parameter from `string | null` (required) to `string?` (optional)
- **`default-base-template.tsx`**: Changed `previewText` prop from `string | null` to `string?`
- **`serializer-plugin.ts`**: Changed `previewText` in `SerializerPlugin.BaseTemplate` props from `string | null` to `string?`
- **Examples**: Removed explicit `preview: null` from `email-export.tsx` and `full-email-builder.tsx` since the field is now optional
- **`package.json`**: Bumped version from `0.0.0-experimental.30` to `0.0.0-experimental.31`

## Motivation

Using `string | null` for the `preview` field forced consumers to always explicitly pass `null` even when they didn't need a preview. Making the field optional with `string?` (i.e. `string | undefined`) is cleaner and avoids the `null` vs `undefined` ambiguity.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0A9HFCVA13/p1774447106104319?thread_ts=1774447106.104319&cid=C0A9HFCVA13)

<div><a href="https://cursor.com/agents/bc-9e915fa2-5813-5977-886b-75f67192abc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e915fa2-5813-5977-886b-75f67192abc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the preview field optional so callers don’t need to pass null, simplifying the editor serializer API. Also bump `@react-email/editor` to 0.0.0-experimental.31.

- **Refactors**
  - `composeReactEmail`: `preview` now optional (`string?` instead of `string | null`)
  - `DefaultBaseTemplate`: `previewText` now optional
  - `SerializerPlugin.BaseTemplate`: `previewText` now optional
  - Examples updated to remove `preview: null`

- **Migration**
  - Remove `preview: null` when calling `composeReactEmail` (no other changes needed)

<sup>Written for commit 0f04398111dcf2dfb8c5e922354e131821db2265. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

