### PR TITLE
chore(editor): export EmailMark

### DIFF
--- a/packages/editor/src/core/index.ts
+++ b/packages/editor/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from './event-bus';
 export * from './is-document-visually-empty';
 export * from './serializer/compose-react-email';
+export * from './serializer/email-mark';
 export * from './serializer/email-node';
 export * from './use-editor';


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Export `EmailMark` from the editor core entry point so consumers can import it directly. No runtime changes; this only exposes the serializer mark for external use.

<sup>Written for commit be81ae35589c1455830028091695ce27f94d0dbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

