### PR TITLE
chore(editor): fix wording and use real TipTap extensions in examples

### DIFF
--- a/apps/docs/editor/api-reference/compose-react-email.mdx
+++ b/apps/docs/editor/api-reference/compose-react-email.mdx
@@ -76,8 +76,8 @@ It recursively walks the ProseMirror document. For each node it:
 
 1. **Resolves styles** — calls `serializerPlugin.getNodeStyles(node, depth, editor)` to get
    theme styles, then merges any inline styles from the node's attributes
-2. **Skips unknown nodes** — if the node type isn't registered or isn't an
-   [`EmailNode`](/editor/api-reference/email-node), it's rendered as `null`
+2. **Renders unknown nodes as `null`** — if the node type isn't registered or isn't an
+   [`EmailNode`](/editor/api-reference/email-node), it returns `null`
 3. **Renders the node** — calls the extension's `renderToReactEmail()` component, passing
    `children` (from recursing into child nodes), `style`, `node`, and `extension`
 4. **Wraps with marks** — iterates through the node's marks (bold, italic, link, etc.) and
@@ -150,7 +150,7 @@ default — it adds theme-specific body/container styles and can inject global C
 
 The React tree is rendered to an HTML string using `@react-email/components`' `render()`
 function. Both the formatted HTML and a plain text version (tags stripped, text preserved)
-are rendered in parallel from the final React.
+are produced in parallel from the final React tree.
 
 ---
 

--- a/apps/docs/editor/api-reference/email-mark.mdx
+++ b/apps/docs/editor/api-reference/email-mark.mdx
@@ -61,24 +61,10 @@ reuse a community TipTap extension and add email export support without rewritin
 
 ```tsx
 import { EmailMark } from '@react-email/editor/core';
-import { Mark } from '@tiptap/core';
+import Strike from '@tiptap/extension-strike';
 
-const MyTipTapMark = Mark.create({
-  name: 'customHighlight',
-
-  parseHTML() {
-    return [{ tag: 'mark' }];
-  },
-
-  renderHTML({ HTMLAttributes }) {
-    return ['mark', HTMLAttributes, 0];
-  },
-});
-
-const MyEmailMark = EmailMark.from(MyTipTapMark, ({ children, style }) => {
-  return (
-    <mark style={{ ...style, backgroundColor: '#fef08a' }}>{children}</mark>
-  );
+const EmailStrike = EmailMark.from(Strike, ({ children, style }) => {
+  return <s style={style}>{children}</s>;
 });
 ```
 

--- a/apps/docs/editor/api-reference/email-node.mdx
+++ b/apps/docs/editor/api-reference/email-node.mdx
@@ -58,24 +58,14 @@ reuse a community TipTap extension and add email export support without rewritin
 
 ```tsx
 import { EmailNode } from '@react-email/editor/core';
-import { Node } from '@tiptap/core';
+import Blockquote from '@tiptap/extension-blockquote';
 
-const MyTipTapNode = Node.create({
-  name: 'customBlock',
-  group: 'block',
-  content: 'inline*',
-
-  parseHTML() {
-    return [{ tag: 'div[data-custom]' }];
-  },
-
-  renderHTML({ HTMLAttributes }) {
-    return ['div', HTMLAttributes, 0];
-  },
-});
-
-const MyEmailNode = EmailNode.from(MyTipTapNode, ({ children, style }) => {
-  return <div style={style}>{children}</div>;
+const EmailBlockquote = EmailNode.from(Blockquote, ({ children, style }) => {
+  return (
+    <blockquote style={{ ...style, borderLeft: '4px solid #e0e0e0', paddingLeft: '16px' }}>
+      {children}
+    </blockquote>
+  );
 });
 ```
 


### PR DESCRIPTION
## Summary
- Fix "skips unknown nodes" → "renders unknown nodes as `null`" in `compose-react-email.mdx`
- Fix incomplete sentence in serialization pipeline step 7
- `EmailMark.from()` example now uses `Strike` from `@tiptap/extension-strike` instead of a made-up mark
- `EmailNode.from()` example now uses `Blockquote` from `@tiptap/extension-blockquote` instead of a made-up node

Closes PRODUCT-1689 (docs wording + examples sections only)

## Test plan
- [ ] Verify MDX renders correctly on Mintlify

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `compose-react-email.mdx` to say unknown nodes are rendered as `null` and fix the incomplete sentence in the serialization step. Replace example marks/nodes with real TipTap extensions: `@tiptap/extension-strike` for `EmailMark.from()` and `@tiptap/extension-blockquote` for `EmailNode.from()` to address PRODUCT-1689.

<sup>Written for commit e181ef2c6d8b9a9078242c20cfb22b43e86928b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

