### PR TITLE
chore: revert changeset action update, it breaks things

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Create "version packages" pull request
-        uses: changesets/action@2ae596f3dd74aaee4f346b31fda33a58528d3d40
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf
         with:
           version: pnpm run version
           title: "chore(root): version packages"


### PR DESCRIPTION
This reverts commit 5093cd828f8ed020068e74cf8daceb6e2f737aca.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the `changesets/action` update in .github/workflows/bump.yml to restore the bump workflow and unblock automated version PRs. The recent digest bump caused failures, so we’re pinning back to the last known-good version.

<sup>Written for commit 5804b74c03e4b33bbc46975f069de7f63bf7e384. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

