### PR TITLE
feat(editor): add inspector hooks

### DIFF
--- a/packages/editor/src/ui/inspector/hooks/use-document-colors.ts
+++ b/packages/editor/src/ui/inspector/hooks/use-document-colors.ts
@@ -1,0 +1,150 @@
+import type { useCurrentEditor } from '@tiptap/react';
+import { useEditorState } from '@tiptap/react';
+import * as React from 'react';
+import {
+  stylesToCss,
+  useEmailTheming,
+} from '../../../plugins/email-theming/extension';
+import { isValidHexColor } from '../utils/is-valid-hex-color';
+
+type Editor = ReturnType<typeof useCurrentEditor>['editor'];
+
+const COLOR_CSS_PROPERTIES = [
+  'color',
+  'backgroundColor',
+  'borderColor',
+  'borderTopColor',
+  'borderRightColor',
+  'borderBottomColor',
+  'borderLeftColor',
+] as const;
+
+export function useDocumentColors(editor: Editor): string[] {
+  const theming = useEmailTheming(editor)!;
+
+  const globalColors = React.useMemo(() => {
+    const colors = new Set<string>();
+    const cssJs = stylesToCss(theming.styles, theming.theme);
+
+    for (const componentStyles of Object.values(cssJs)) {
+      if (!componentStyles || typeof componentStyles !== 'object') {
+        continue;
+      }
+      for (const prop of COLOR_CSS_PROPERTIES) {
+        const value = (componentStyles as Record<string, unknown>)[prop];
+        if (typeof value === 'string') {
+          addColor(colors, value);
+        }
+      }
+    }
+
+    return Array.from(colors);
+  }, [theming]);
+
+  const inlineColors =
+    useEditorState({
+      editor,
+      selector: ({ editor: ed }: { editor: Editor }): string[] => {
+        if (!ed) {
+          return [];
+        }
+
+        const colors = new Set<string>();
+
+        ed.state.doc.descendants((node) => {
+          for (const mark of node.marks) {
+            if (mark.type.name === 'textStyle' && mark.attrs.color) {
+              addColor(colors, mark.attrs.color);
+            }
+          }
+
+          const style = node.attrs.style as string | undefined;
+          if (style) {
+            extractColorsFromInlineStyle(colors, style);
+          }
+        });
+
+        return Array.from(colors);
+      },
+      equalityFn: (a: string[] | null, b: string[] | null) => {
+        if (a === b) {
+          return true;
+        }
+        if (!a || !b) {
+          return false;
+        }
+        return arrayShallowEqual(a, b);
+      },
+    }) ?? [];
+
+  return React.useMemo(() => {
+    if (globalColors.length === 0) {
+      return inlineColors;
+    }
+    if (inlineColors.length === 0) {
+      return globalColors;
+    }
+    const merged = new Set([...globalColors, ...inlineColors]);
+    return Array.from(merged);
+  }, [globalColors, inlineColors]);
+}
+
+const COLOR_STYLE_PROPS = [
+  'color',
+  'background-color',
+  'border-color',
+  'border-top-color',
+  'border-right-color',
+  'border-bottom-color',
+  'border-left-color',
+];
+
+function extractColorsFromInlineStyle(
+  colors: Set<string>,
+  style: string,
+): void {
+  for (const prop of COLOR_STYLE_PROPS) {
+    const regex = new RegExp(`${prop}\\s*:\\s*([^;]+)`, 'i');
+    const match = style.match(regex);
+    if (match) {
+      addColor(colors, match[1].trim());
+    }
+  }
+}
+
+function addColor(colors: Set<string>, raw: string): void {
+  const value = raw.trim().toLowerCase();
+  if (!value || value === '#000000' || value === '#ffffff') {
+    return;
+  }
+  if (isValidHexColor(value)) {
+    const normalized = expandToSix(value);
+    colors.add(normalized);
+  }
+}
+
+function expandToSix(hex: string): string {
+  const h = hex.slice(1);
+  if (h.length === 3) {
+    return `#${h[0]}${h[0]}${h[1]}${h[1]}${h[2]}${h[2]}`;
+  }
+  if (h.length === 4) {
+    return `#${h[0]}${h[0]}${h[1]}${h[1]}${h[2]}${h[2]}`;
+  }
+  if (h.length === 8) {
+    return `#${h.slice(0, 6)}`;
+  }
+  return hex;
+}
+
+function arrayShallowEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/editor/src/ui/inspector/hooks/use-drag-to-change.spec.ts
+++ b/packages/editor/src/ui/inspector/hooks/use-drag-to-change.spec.ts
@@ -1,0 +1,151 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useDragToChange } from './use-drag-to-change';
+
+function createPointerEvent(overrides: Partial<React.PointerEvent> = {}) {
+  return {
+    preventDefault: vi.fn(),
+    clientX: 0,
+    pointerId: 1,
+    shiftKey: false,
+    currentTarget: {
+      setPointerCapture: vi.fn(),
+    } as unknown as HTMLElement,
+    ...overrides,
+  } as unknown as React.PointerEvent;
+}
+
+describe('useDragToChange', () => {
+  it('calls onCommit with delta value on pointer move after pointer down', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useDragToChange({ value: 10, onCommit }),
+    );
+
+    act(() => {
+      result.current.dragProps.onPointerDown(
+        createPointerEvent({ clientX: 100 }),
+      );
+    });
+
+    act(() => {
+      result.current.dragProps.onPointerMove(
+        createPointerEvent({ clientX: 110 }),
+      );
+    });
+
+    expect(onCommit).toHaveBeenCalledWith(15);
+  });
+
+  it('does not call onCommit on pointer move without pointer down', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useDragToChange({ value: 10, onCommit }),
+    );
+
+    act(() => {
+      result.current.dragProps.onPointerMove(
+        createPointerEvent({ clientX: 110 }),
+      );
+    });
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('stops tracking after pointer up', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useDragToChange({ value: 10, onCommit }),
+    );
+
+    act(() => {
+      result.current.dragProps.onPointerDown(
+        createPointerEvent({ clientX: 100 }),
+      );
+    });
+
+    act(() => {
+      result.current.dragProps.onPointerUp();
+    });
+
+    act(() => {
+      result.current.dragProps.onPointerMove(
+        createPointerEvent({ clientX: 120 }),
+      );
+    });
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('respects step parameter', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useDragToChange({ value: 0, onCommit, step: 5 }),
+    );
+
+    act(() => {
+      result.current.dragProps.onPointerDown(
+        createPointerEvent({ clientX: 0 }),
+      );
+    });
+
+    act(() => {
+      result.current.dragProps.onPointerMove(
+        createPointerEvent({ clientX: 4 }),
+      );
+    });
+
+    expect(onCommit).toHaveBeenCalledWith(10);
+  });
+
+  it('sets cursor to ew-resize during drag', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useDragToChange({ value: 0, onCommit }),
+    );
+
+    act(() => {
+      result.current.dragProps.onPointerDown(
+        createPointerEvent({ clientX: 0 }),
+      );
+    });
+
+    expect(document.body.style.cursor).toBe('ew-resize');
+
+    act(() => {
+      result.current.dragProps.onPointerUp();
+    });
+
+    expect(document.body.style.cursor).toBe('');
+  });
+
+  it('clamps to min value', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useDragToChange({ value: 5, onCommit, min: 0 }),
+    );
+
+    act(() => {
+      result.current.dragProps.onPointerDown(
+        createPointerEvent({ clientX: 100 }),
+      );
+    });
+
+    act(() => {
+      result.current.dragProps.onPointerMove(
+        createPointerEvent({ clientX: 80 }),
+      );
+    });
+
+    expect(onCommit).toHaveBeenCalledWith(0);
+  });
+
+  it('returns ew-resize cursor style in dragProps', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useDragToChange({ value: 0, onCommit }),
+    );
+
+    expect(result.current.dragProps.style.cursor).toBe('ew-resize');
+  });
+});

--- a/packages/editor/src/ui/inspector/hooks/use-drag-to-change.ts
+++ b/packages/editor/src/ui/inspector/hooks/use-drag-to-change.ts
@@ -1,0 +1,76 @@
+import * as React from 'react';
+
+interface UseDragToChangeOptions {
+  value: string | number | undefined | null;
+  onCommit: (value: number | '') => void;
+  min?: number;
+  step?: number;
+}
+
+export function useDragToChange({
+  value,
+  onCommit,
+  min,
+  step = 1,
+}: UseDragToChangeOptions) {
+  const startXRef = React.useRef(0);
+  const startValueRef = React.useRef(0);
+  const isDraggingRef = React.useRef(false);
+
+  React.useEffect(() => {
+    return () => {
+      document.body.style.removeProperty('cursor');
+      document.body.style.removeProperty('user-select');
+    };
+  }, []);
+
+  const onPointerDown = React.useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      isDraggingRef.current = true;
+      startXRef.current = e.clientX;
+      startValueRef.current = Number(value) || 0;
+
+      document.body.style.cursor = 'ew-resize';
+      document.body.style.userSelect = 'none';
+
+      const target = e.currentTarget as HTMLElement;
+      target.setPointerCapture(e.pointerId);
+    },
+    [value],
+  );
+
+  const onPointerMove = React.useCallback(
+    (e: React.PointerEvent) => {
+      if (!isDraggingRef.current) {
+        return;
+      }
+
+      const dx = e.clientX - startXRef.current;
+      const effectiveStep = e.shiftKey ? step * 10 : step;
+      const delta = Math.round(dx / 2) * effectiveStep;
+      const next = Math.max(
+        min ?? Number.NEGATIVE_INFINITY,
+        startValueRef.current + delta,
+      );
+      onCommit(next);
+    },
+    [onCommit, min, step],
+  );
+
+  const onPointerUp = React.useCallback(() => {
+    isDraggingRef.current = false;
+    document.body.style.removeProperty('cursor');
+    document.body.style.removeProperty('user-select');
+  }, []);
+
+  return {
+    dragProps: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel: onPointerUp,
+      style: { cursor: 'ew-resize' } as React.CSSProperties,
+    },
+  };
+}

--- a/packages/editor/src/ui/inspector/hooks/use-link-mark.ts
+++ b/packages/editor/src/ui/inspector/hooks/use-link-mark.ts
@@ -1,0 +1,57 @@
+import type { Editor } from '@tiptap/core';
+import { useEditorState } from '@tiptap/react';
+import { inlineCssToJs, jsToInlineCss } from '../../../utils/styles';
+
+interface LinkMarkState {
+  href: string;
+  style: string;
+  isActive: boolean;
+}
+
+export function useLinkMark(editor: Editor | null): LinkMarkState {
+  return (
+    useEditorState({
+      editor,
+      selector: ({ editor }) => {
+        if (!editor) {
+          return { href: '', style: '', isActive: false };
+        }
+        const { from } = editor.state.selection;
+        const mark =
+          editor.state.doc
+            .resolve(from)
+            .marks()
+            .find((m) => m.type.name === 'link') ?? null;
+        return {
+          href: (mark?.attrs?.href as string) ?? '',
+          style: (mark?.attrs?.style as string) ?? '',
+          isActive: !!mark,
+        };
+      },
+    }) ?? { href: '', style: '', isActive: false }
+  );
+}
+
+export function getLinkColor(
+  linkStyle: string,
+  themeLinkColor: string | undefined,
+  fallback = '#000000',
+): string {
+  return inlineCssToJs(linkStyle).color || themeLinkColor || fallback;
+}
+
+export function updateLinkColor(
+  editor: Editor,
+  linkStyle: string,
+  color: string,
+): void {
+  const styleObj = inlineCssToJs(linkStyle);
+  styleObj.color = color;
+  const newStyle = jsToInlineCss(styleObj);
+  editor
+    .chain()
+    .focus()
+    .extendMarkRange('link')
+    .updateAttributes('link', { style: newStyle })
+    .run();
+}

--- a/packages/editor/src/ui/inspector/hooks/use-numeric-input.spec.ts
+++ b/packages/editor/src/ui/inspector/hooks/use-numeric-input.spec.ts
@@ -1,0 +1,220 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useNumericInput } from './use-numeric-input';
+
+function createKeyboardEvent(
+  key: string,
+  overrides: Partial<React.KeyboardEvent<HTMLInputElement>> = {},
+) {
+  return {
+    key,
+    preventDefault: vi.fn(),
+    shiftKey: false,
+    target: {
+      blur: vi.fn(),
+      select: vi.fn(),
+    } as unknown as HTMLInputElement,
+    ...overrides,
+  } as unknown as React.KeyboardEvent<HTMLInputElement>;
+}
+
+describe('useNumericInput', () => {
+  it('initializes displayValue from value prop', () => {
+    const { result } = renderHook(() =>
+      useNumericInput({ value: 42, onCommit: vi.fn() }),
+    );
+
+    expect(result.current.displayValue).toBe('42');
+  });
+
+  it('arrow up increments value by 1', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useNumericInput({ value: 10, onCommit }),
+    );
+
+    act(() => {
+      result.current.onKeyDown(createKeyboardEvent('ArrowUp'));
+    });
+
+    expect(onCommit).toHaveBeenCalledWith(11);
+    expect(result.current.displayValue).toBe('11');
+  });
+
+  it('arrow down decrements value by 1', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useNumericInput({ value: 10, onCommit }),
+    );
+
+    act(() => {
+      result.current.onKeyDown(createKeyboardEvent('ArrowDown'));
+    });
+
+    expect(onCommit).toHaveBeenCalledWith(9);
+    expect(result.current.displayValue).toBe('9');
+  });
+
+  it('shift+arrow up increments by 10', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useNumericInput({ value: 10, onCommit }),
+    );
+
+    act(() => {
+      result.current.onKeyDown(
+        createKeyboardEvent('ArrowUp', { shiftKey: true }),
+      );
+    });
+
+    expect(onCommit).toHaveBeenCalledWith(20);
+    expect(result.current.displayValue).toBe('20');
+  });
+
+  it('shift+arrow down decrements by 10', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useNumericInput({ value: 30, onCommit }),
+    );
+
+    act(() => {
+      result.current.onKeyDown(
+        createKeyboardEvent('ArrowDown', { shiftKey: true }),
+      );
+    });
+
+    expect(onCommit).toHaveBeenCalledWith(20);
+    expect(result.current.displayValue).toBe('20');
+  });
+
+  it('clamps to min on arrow down', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useNumericInput({ value: 2, onCommit, min: 0 }),
+    );
+
+    act(() => {
+      result.current.onKeyDown(
+        createKeyboardEvent('ArrowDown', { shiftKey: true }),
+      );
+    });
+
+    expect(onCommit).toHaveBeenCalledWith(0);
+    expect(result.current.displayValue).toBe('0');
+  });
+
+  it('clamps to min on arrow up does not go below min', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useNumericInput({ value: -5, onCommit, min: 0 }),
+    );
+
+    act(() => {
+      result.current.onKeyDown(createKeyboardEvent('ArrowUp'));
+    });
+
+    expect(onCommit).toHaveBeenCalledWith(0);
+  });
+
+  it('commits on blur', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useNumericInput({ value: 10, onCommit }),
+    );
+
+    act(() => {
+      result.current.onFocus({
+        target: { select: vi.fn() },
+      } as unknown as React.FocusEvent<HTMLInputElement>);
+    });
+
+    act(() => {
+      result.current.onChange({
+        target: { value: '25' },
+      } as unknown as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    act(() => {
+      result.current.onBlur();
+    });
+
+    expect(onCommit).toHaveBeenCalledWith(25);
+  });
+
+  it('commits empty string when allowEmpty is true and input is cleared', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useNumericInput({ value: 10, onCommit, allowEmpty: true }),
+    );
+
+    act(() => {
+      result.current.onFocus({
+        target: { select: vi.fn() },
+      } as unknown as React.FocusEvent<HTMLInputElement>);
+    });
+
+    act(() => {
+      result.current.onChange({
+        target: { value: '' },
+      } as unknown as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    act(() => {
+      result.current.onBlur();
+    });
+
+    expect(onCommit).toHaveBeenCalledWith('');
+  });
+
+  it('commits 0 when allowEmpty is false and input is cleared', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useNumericInput({ value: 10, onCommit, allowEmpty: false }),
+    );
+
+    act(() => {
+      result.current.onFocus({
+        target: { select: vi.fn() },
+      } as unknown as React.FocusEvent<HTMLInputElement>);
+    });
+
+    act(() => {
+      result.current.onChange({
+        target: { value: '' },
+      } as unknown as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    act(() => {
+      result.current.onBlur();
+    });
+
+    expect(onCommit).toHaveBeenCalledWith(0);
+  });
+
+  it('uses fallbackValue when incrementing from empty', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useNumericInput({ value: '', onCommit, fallbackValue: 16 }),
+    );
+
+    act(() => {
+      result.current.onKeyDown(createKeyboardEvent('ArrowUp'));
+    });
+
+    expect(onCommit).toHaveBeenCalledWith(17);
+  });
+
+  it('syncs displayValue from external value changes when not focused', () => {
+    const onCommit = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ value }) => useNumericInput({ value, onCommit }),
+      { initialProps: { value: 10 as string | number } },
+    );
+
+    expect(result.current.displayValue).toBe('10');
+
+    rerender({ value: 20 });
+
+    expect(result.current.displayValue).toBe('20');
+  });
+});

--- a/packages/editor/src/ui/inspector/hooks/use-numeric-input.ts
+++ b/packages/editor/src/ui/inspector/hooks/use-numeric-input.ts
@@ -1,0 +1,128 @@
+import * as React from 'react';
+
+interface UseNumericInputOptions {
+  value: string | number | undefined | null;
+  onCommit: (value: number | '') => void;
+  allowEmpty?: boolean;
+  min?: number;
+  fallbackValue?: number;
+}
+
+interface UseNumericInputReturn {
+  displayValue: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur: () => void;
+  onFocus: (e: React.FocusEvent<HTMLInputElement>) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+}
+
+function toDisplayString(v: string | number | undefined | null): string {
+  if (v === '' || v === undefined || v === null || Number.isNaN(v)) {
+    return '';
+  }
+  return String(v);
+}
+
+export function useNumericInput({
+  value,
+  onCommit,
+  allowEmpty = true,
+  min,
+  fallbackValue,
+}: UseNumericInputOptions): UseNumericInputReturn {
+  const [displayValue, setDisplayValue] = React.useState(() =>
+    toDisplayString(value),
+  );
+  const isFocusedRef = React.useRef(false);
+  const cancelledRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!isFocusedRef.current) {
+      setDisplayValue(toDisplayString(value));
+    }
+  }, [value]);
+
+  const commit = React.useCallback(
+    (raw: string) => {
+      const trimmed = raw.trim();
+
+      if (trimmed === '') {
+        if (allowEmpty) {
+          onCommit('');
+        } else {
+          setDisplayValue('0');
+          onCommit(0);
+        }
+        return;
+      }
+
+      const num = Number(trimmed);
+
+      if (Number.isNaN(num)) {
+        setDisplayValue(toDisplayString(value));
+        return;
+      }
+
+      const clamped = Math.max(num, min ?? Number.NEGATIVE_INFINITY);
+      setDisplayValue(String(clamped));
+      onCommit(clamped);
+    },
+    [value, onCommit, allowEmpty, min],
+  );
+
+  const onChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setDisplayValue(e.target.value);
+    },
+    [],
+  );
+
+  const onBlur = React.useCallback(() => {
+    isFocusedRef.current = false;
+    if (cancelledRef.current) {
+      cancelledRef.current = false;
+      return;
+    }
+    commit(displayValue);
+  }, [commit, displayValue]);
+
+  const onFocus = React.useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    isFocusedRef.current = true;
+    e.target.select();
+  }, []);
+
+  const onKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        commit(displayValue);
+        (e.target as HTMLInputElement).blur();
+      }
+
+      if (e.key === 'Escape') {
+        cancelledRef.current = true;
+        setDisplayValue(toDisplayString(value));
+        (e.target as HTMLInputElement).blur();
+      }
+
+      if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        const step = e.shiftKey ? 10 : 1;
+        const trimmed = displayValue.trim();
+        const parsed = Number(trimmed);
+        const current =
+          trimmed === '' || Number.isNaN(parsed)
+            ? (fallbackValue ?? 0)
+            : parsed;
+        const next = Math.max(
+          min ?? Number.NEGATIVE_INFINITY,
+          e.key === 'ArrowUp' ? current + step : current - step,
+        );
+        setDisplayValue(String(next));
+        onCommit(next);
+      }
+    },
+    [commit, displayValue, value, onCommit, min, fallbackValue],
+  );
+
+  return { displayValue, onChange, onBlur, onFocus, onKeyDown };
+}


### PR DESCRIPTION
## Summary
- Ports 6 hooks from #3107: use-collapsible-sections, use-document-colors, use-link-mark, use-drag-to-change, use-numeric-input
- Adds tests for use-drag-to-change (7 tests) and use-numeric-input (13 tests)
- Includes ported use-collapsible-sections.spec.ts (28 tests)
- Total: 47 tests passing

Stacks on #3170

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four inspector hooks for document colors, link marks, drag-to-change, and numeric inputs to support the inspector sidebar redesign. Includes unit tests for drag and numeric behaviors.

- **New Features**
  - use-document-colors: Collects unique hex colors from theme CSS and inline styles; normalizes to 6-digit; skips black/white; merges global and inline sets.
  - use-link-mark: Returns link href/style/isActive; helpers getLinkColor and updateLinkColor to read/update inline color.
  - use-drag-to-change: Horizontal drag adjusts numbers; step with Shift×10; min clamp; sets cursor/user-select; pointer capture and cleanup.
  - use-numeric-input: Arrow inc/dec (Shift×10), min clamp, empty handling; Enter/blur commit, Escape cancel, optional fallbackValue; syncs display when not focused.

<sup>Written for commit 7e0d8477f1aee38df471ba16b32c9a66d863986b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

