### PR TITLE
feat(editor): ensure EmailTheming presence in Inspector.Provider

### DIFF
--- a/packages/editor/src/ui/inspector/provider.tsx
+++ b/packages/editor/src/ui/inspector/provider.tsx
@@ -131,19 +131,17 @@ export function useInspector() {
 export function InspectorProvider({ children }: RootProps) {
   const { editor } = useCurrentEditor();
 
-  React.useEffect(() => {
-    if (editor) {
-      const hasEmailTheming = editor.extensionManager.extensions.some(
-        (extension) => extension.name === 'theming',
+  if (editor) {
+    const hasEmailTheming = editor.extensionManager.extensions.some(
+      (extension) => extension.name === 'theming',
+    );
+    if (!hasEmailTheming) {
+      throw new Error(
+        'Inspector.Provider requires the EmailTheming extension to be added to your editor. ' +
+          'Please add EmailTheming (or EmailTheming.configure({ ... })) to your editor extensions.',
       );
-      if (!hasEmailTheming) {
-        throw new Error(
-          'Inspector.Provider requires the EmailTheming extension to be added to your editor. ' +
-            'Please add EmailTheming (or EmailTheming.configure({ ... })) to your editor extensions.',
-        );
-      }
     }
-  }, [editor]);
+  }
 
   const target = useEditorState({
     editor,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a runtime validation check in `Inspector.Provider` that throws an error if the `EmailTheming` extension is not registered on the editor. Previously, if a developer forgot to add `EmailTheming` to their editor extensions, the `Inspector.Document` component would silently return `null`, making it difficult to debug. Now, a clear error message is thrown instructing the user to add the extension.

## Changes

- **`packages/editor/src/ui/inspector/provider.tsx`**: Added a check at the top of `InspectorProvider` that verifies the `'theming'` extension (i.e. `EmailTheming`) is present in the editor's extension manager. If missing, throws an `Error` with an actionable message.

This follows the existing validation pattern used in `useInspector`, `useBubbleMenuContext`, and `useNodeSelectorContext` which throw errors for missing providers/contexts.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0A9HFCVA13/p1775159916347659?thread_ts=1775159916.347659&cid=C0A9HFCVA13)

<div><a href="https://cursor.com/agents/bc-20805fa4-2a7b-507a-91a1-1122ab8ae9b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20805fa4-2a7b-507a-91a1-1122ab8ae9b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a runtime validation in `Inspector.Provider` to ensure the editor registers `EmailTheming`. If missing, we throw a clear error instead of `Inspector.Document` returning `null`.

- **Refactors**
  - Validate the `'theming'` extension during render using `editor.extensionManager.extensions`, and throw an actionable error if missing.

<sup>Written for commit b43b4d0b187e53023bcfd57c8b09f5e054a7922d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

