### PR TITLE
feat: delete empty section on backspace

### DIFF
--- a/packages/editor/src/extensions/section.tsx
+++ b/packages/editor/src/extensions/section.tsx
@@ -58,7 +58,15 @@ export const Section = EmailNode.create<SectionOptions>({
         for (let depth = $from.depth; depth >= 1; depth--) {
           if ($from.node(depth).type.name !== 'section') continue;
 
-          if ($from.pos !== $from.start(depth)) return false;
+          if ($from.parentOffset !== 0) return false;
+          let atStart = true;
+          for (let d = depth; d < $from.depth; d++) {
+            if ($from.index(d) !== 0) {
+              atStart = false;
+              break;
+            }
+          }
+          if (!atStart) return false;
 
           const sectionNode = $from.node(depth);
           if (!isSectionEmpty(sectionNode)) return false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `Backspace` keyboard shortcut handler to the Section editor node so that pressing backspace deletes an empty section.

### Behavior

- **Cursor inside an empty section** (at the start position): The entire section is removed. If the section is the only child of its parent, it's replaced with a plain paragraph to maintain valid document structure.
- **Cursor right after an empty section** (previous sibling is an empty section): That empty section is deleted, removing the unwanted whitespace.

### How it works

A section is considered "empty" when it has no text content and its content size is only the structural overhead of its child nodes (e.g., a single empty paragraph).

This follows the same pattern established by `ColumnsColumn` in `columns.tsx` for handling backspace deletion of structural nodes.

### Changes

- `packages/editor/src/extensions/section.tsx` — Added `addKeyboardShortcuts()` with `Backspace` handler and `isSectionEmpty()` helper function
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0A9HFCVA13/p1775232720683519?thread_ts=1775232720.683519&cid=C0A9HFCVA13)

<div><a href="https://cursor.com/agents/bc-a2f76f56-15ff-5d79-a604-9be46567a98c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2f76f56-15ff-5d79-a604-9be46567a98c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Backspace shortcut to delete empty section nodes for cleaner documents. Also fixes the start-position check so deletion works inside nested blocks; if the section is the only child, it’s replaced with a plain paragraph.

- **New Features**
  - Backspace at the start of an empty section deletes it; if it’s the only child, insert a paragraph.
  - Backspace when the cursor is right after an empty section deletes the previous empty section.

<sup>Written for commit 2a6a6b3cb18a0280689645591ee3dbe927171807. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

