### PR TITLE
fix(editor): preserve button href through HTML round-trip

### DIFF
--- a/packages/editor/src/extensions/button.spec.tsx
+++ b/packages/editor/src/extensions/button.spec.tsx
@@ -1,5 +1,5 @@
-import { render } from 'react-email';
 import { Editor } from '@tiptap/core';
+import { render } from 'react-email';
 import { afterEach, describe, expect, it } from 'vitest';
 import { DEFAULT_STYLES } from '../utils/default-styles';
 import { Button } from './button';

--- a/packages/editor/src/extensions/button.spec.tsx
+++ b/packages/editor/src/extensions/button.spec.tsx
@@ -1,10 +1,20 @@
 import { render } from 'react-email';
+import { Editor } from '@tiptap/core';
+import { afterEach, describe, expect, it } from 'vitest';
 import { DEFAULT_STYLES } from '../utils/default-styles';
 import { Button } from './button';
+import { StarterKit } from './index';
 
 const buttonStyle = { ...DEFAULT_STYLES.reset, ...DEFAULT_STYLES.button };
 
 describe('EditorButton Node', () => {
+  let editor: Editor | null = null;
+
+  afterEach(() => {
+    editor?.destroy();
+    editor = null;
+  });
+
   it('renders React Email properly', async () => {
     const Component = Button.config.renderToReactEmail;
     expect(Component).toBeDefined();
@@ -27,5 +37,61 @@ describe('EditorButton Node', () => {
         { pretty: true },
       ),
     ).toMatchSnapshot();
+  });
+
+  it('preserves href through HTML round-trip', () => {
+    editor = new Editor({
+      extensions: [StarterKit],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'container',
+            content: [
+              {
+                type: 'button',
+                attrs: { href: 'https://example.com' },
+                content: [{ type: 'text', text: 'Click me' }],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const html = editor.getHTML();
+    expect(html).toContain('data-href="https://example.com"');
+    expect(html).toContain('href="https://example.com"');
+
+    editor.commands.setContent(html);
+
+    const json = editor.getJSON();
+    const findButton = (nodes: typeof json.content): typeof json | undefined =>
+      nodes?.reduce<typeof json | undefined>(
+        (found, n) =>
+          found ?? (n.type === 'button' ? n : findButton(n.content ?? [])),
+        undefined,
+      );
+    const buttonNode = findButton(json.content ?? []);
+    expect(buttonNode?.attrs?.href).toBe('https://example.com');
+  });
+
+  it('parses data-href back to href when href attribute is missing', () => {
+    editor = new Editor({ extensions: [StarterKit] });
+
+    const htmlWithOnlyDataHref =
+      '<div class="align-left"><a class="node-button button" data-id="react-email-button" data-href="https://restored.example.com">Restore me</a></div>';
+
+    editor.commands.setContent(htmlWithOnlyDataHref);
+
+    const json = editor.getJSON();
+    const findButton = (nodes: typeof json.content): typeof json | undefined =>
+      nodes?.reduce<typeof json | undefined>(
+        (found, n) =>
+          found ?? (n.type === 'button' ? n : findButton(n.content ?? [])),
+        undefined,
+      );
+    const buttonNode = findButton(json.content ?? []);
+    expect(buttonNode?.attrs?.href).toBe('https://restored.example.com');
   });
 });

--- a/packages/editor/src/extensions/button.tsx
+++ b/packages/editor/src/extensions/button.tsx
@@ -49,13 +49,14 @@ export const Button = EmailNode.create<EditorButtonOptions>({
           }
           const element = node as HTMLElement;
           const attrs: Record<string, string> = {};
-
-          // Preserve all attributes
           Array.from(element.attributes).forEach((attr) => {
             attrs[attr.name] = attr.value;
           });
 
-          return attrs;
+          return {
+            ...attrs,
+            href: attrs['data-href'] ?? attrs.href,
+          };
         },
       },
     ];
@@ -73,6 +74,7 @@ export const Button = EmailNode.create<EditorButtonOptions>({
           class: `node-button ${HTMLAttributes?.class}`,
           style: HTMLAttributes?.style,
           'data-id': 'react-email-button',
+          href: HTMLAttributes?.href,
           'data-href': HTMLAttributes?.href,
         }),
         0,


### PR DESCRIPTION

## Summary 
The button extension serializes href into a data-href attribute in renderHTML but never maps it back during parseHTML. This means any HTML round-trip (e.g. getHTML() → setContent(), copy/paste, or persist/reload) causes the button's link to be lost, falling back to the default #.
