### PR TITLE
fix(editor): render Table as native `<table>` instead of Section to fix invalid nesting

### DIFF
--- a/.changeset/fix-table-nesting.md
+++ b/.changeset/fix-table-nesting.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Render Table as a native `<table>` instead of `Section` to fix invalid `<tr>` inside `<td>` nesting in email output

--- a/packages/editor/src/extensions/__snapshots__/table.spec.tsx.snap
+++ b/packages/editor/src/extensions/__snapshots__/table.spec.tsx.snap
@@ -12,9 +12,7 @@ exports[`Table Nodes > renders Table React Email properly 1`] = `
   role="presentation"
   style="margin-top:0;margin-right:auto;margin-bottom:0;margin-left:auto;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
   <tbody>
-    <tr>
-      <td>Table content</td>
-    </tr>
+    Table content
   </tbody>
 </table>
 <!--/$-->
@@ -37,6 +35,38 @@ exports[`Table Nodes > renders TableRow React Email properly 1`] = `
 <tr style="margin:0;padding:0">
   Row content
 </tr>
+<!--/$-->
+"
+`;
+
+exports[`Table Nodes > renders nested table structure without invalid tr-inside-td nesting 1`] = `
+"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--$-->
+<table
+  align="center"
+  width="600"
+  border="0"
+  cellpadding="0"
+  cellspacing="0"
+  role="presentation"
+  style="margin-top:0;margin-right:auto;margin-bottom:0;margin-left:auto;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+  <tbody>
+    <tr style="margin:0;padding:0">
+      <td
+        align="left"
+        data-id="__react-email-column"
+        style="margin:0;padding:0">
+        Cell 1
+      </td>
+      <td
+        align="left"
+        data-id="__react-email-column"
+        style="margin:0;padding:0">
+        Cell 2
+      </td>
+    </tr>
+  </tbody>
+</table>
 <!--/$-->
 "
 `;

--- a/packages/editor/src/extensions/table.spec.tsx
+++ b/packages/editor/src/extensions/table.spec.tsx
@@ -71,4 +71,50 @@ describe('Table Nodes', () => {
       ),
     ).toMatchSnapshot();
   });
+
+  it('renders nested table structure without invalid tr-inside-td nesting', async () => {
+    const TableComponent = Table.config.renderToReactEmail;
+    const RowComponent = TableRow.config.renderToReactEmail;
+    const CellComponent = TableCell.config.renderToReactEmail;
+
+    const html = await render(
+      <TableComponent
+        node={{
+          type: 'table',
+          attrs: {
+            alignment: 'center',
+            width: '600',
+          },
+        }}
+        style={tableStyle}
+        extension={Table}
+      >
+        <RowComponent
+          node={{ type: 'tableRow', attrs: {} }}
+          style={tableRowStyle}
+          extension={TableRow}
+        >
+          <CellComponent
+            node={{ type: 'tableCell', attrs: { alignment: 'left' } }}
+            style={tableCellStyle}
+            extension={TableCell}
+          >
+            Cell 1
+          </CellComponent>
+          <CellComponent
+            node={{ type: 'tableCell', attrs: { alignment: 'left' } }}
+            style={tableCellStyle}
+            extension={TableCell}
+          >
+            Cell 2
+          </CellComponent>
+        </RowComponent>
+      </TableComponent>,
+      { pretty: true },
+    );
+
+    expect(html).not.toMatch(/<td[^>]*>\s*<tr/);
+    expect(html).toMatch(/<table[^>]*>\s*<tbody>\s*<tr/);
+    expect(html).toMatchSnapshot();
+  });
 });

--- a/packages/editor/src/extensions/table.tsx
+++ b/packages/editor/src/extensions/table.tsx
@@ -1,6 +1,6 @@
 import type { ParentConfig } from '@tiptap/core';
 import { mergeAttributes, Node } from '@tiptap/core';
-import { Column, Section } from 'react-email';
+import { Column } from 'react-email';
 import { EmailNode } from '../core/serializer/email-node';
 import {
   COMMON_HTML_ATTRIBUTES,
@@ -91,17 +91,21 @@ export const Table = EmailNode.create<TableOptions>({
       alignment === 'center' ? { marginLeft: 'auto', marginRight: 'auto' } : {};
 
     return (
-      <Section
-        className={node.attrs?.class || undefined}
+      <table
         align={alignment}
+        width={width}
+        border={0}
+        cellPadding="0"
+        cellSpacing="0"
+        role="presentation"
+        className={node.attrs?.class || undefined}
         style={resolveConflictingStyles(style, {
           ...inlineStyles,
           ...centeringStyles,
         })}
-        {...(width !== undefined ? { width } : {})}
       >
-        {children}
-      </Section>
+        <tbody>{children}</tbody>
+      </table>
     );
   },
 });


### PR DESCRIPTION

## Summary by cubic
Render the editor’s Table as a native `<table>` instead of `Section` to eliminate invalid `<tr>` inside `<td>` nesting. This fixes broken layouts in email clients and fulfills Linear BU-670.

- **Bug Fixes**
  - Replaced `Section` from `@react-email/components` with a native `<table>` that wraps children in `<tbody>`.
  - Preserved `align`, `width`, `border=0`, `cellPadding=0`, `cellSpacing=0`, `role="presentation"`, and centering styles.
  - Added an integration test to prevent `<tr>` inside `<td>` and updated snapshots.

<sup>Written for commit 8e1b4c3d22a229f2392f7893269a2ecaca70ef51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

