### PR TITLE
feat: skill react email improvements

### DIFF
--- a/skills/react-email/README.md
+++ b/skills/react-email/README.md
@@ -22,7 +22,7 @@ skills/
 Agent Skills are a standardized format for giving AI agents specialized knowledge and workflows. This skill teaches agents how to:
 
 - Build HTML email templates using React Email components
-- Use the visual email editor (`@react-email/editor`)
+- Add a visual drag-and-drop email editor to a React application (using `@react-email/editor`)
 - Send emails through Resend and other providers
 - Implement internationalization for multi-language support
 - Follow email development best practices

--- a/skills/react-email/README.md
+++ b/skills/react-email/README.md
@@ -10,9 +10,11 @@ skills/
     ├── SKILL.md              # Main skill instructions
     └── references/
         ├── COMPONENTS.md     # Complete component reference
+        ├── EDITOR.md         # Visual email editor reference
         ├── I18N.md           # Internationalization guide
         ├── PATTERNS.md       # Common email patterns and examples
-        └── SENDING.md        # Email sending guide
+        ├── SENDING.md        # Email sending guide
+        └── STYLING.md        # Styling and CSS reference
 ```
 
 ## What is an Agent Skill?
@@ -20,6 +22,7 @@ skills/
 Agent Skills are a standardized format for giving AI agents specialized knowledge and workflows. This skill teaches agents how to:
 
 - Build HTML email templates using React Email components
+- Use the visual email editor (`@react-email/editor`)
 - Send emails through Resend and other providers
 - Implement internationalization for multi-language support
 - Follow email development best practices

--- a/skills/react-email/SKILL.md
+++ b/skills/react-email/SKILL.md
@@ -140,8 +140,8 @@ See [references/COMPONENTS.md](references/COMPONENTS.md) for complete component 
 - `Html` - Root wrapper with `lang` attribute
 - `Head` - Meta elements, styles, fonts
 - `Body` - Main content wrapper
-- `Container` - Centers content (max-width layout)
-- `Section` - Layout sections
+- `Container` - Outermost centering wrapper (has built-in `max-width: 37.5em`). Use only once per email.
+- `Section` - Interior content blocks (no built-in max-width). Use for grouping content inside `Container`.
 - `Row` & `Column` - Multi-column layouts
 - `Tailwind` - Enables Tailwind CSS utility classes
 

--- a/skills/react-email/SKILL.md
+++ b/skills/react-email/SKILL.md
@@ -146,7 +146,7 @@ See [references/COMPONENTS.md](references/COMPONENTS.md) for complete component 
 - `Tailwind` - Enables Tailwind CSS utility classes
 
 **Content:**
-- `Preview` - Inbox preview text, must be the first child inside `<Body>`
+- `Preview` - Inbox preview text, placed before `<Body>` inside `<Tailwind>`
 - `Heading` - h1-h6 headings
 - `Text` - Paragraphs
 - `Button` - Styled link buttons (always include `box-border`)
@@ -234,7 +234,7 @@ See [references/STYLING.md](references/STYLING.md) for comprehensive styling doc
 
 ### Structure Notes
 - Always define `<Head />` inside `<Tailwind>` when using Tailwind CSS
-- `<Preview>` must be the first child inside `<Body>`
+- `<Preview>` goes before `<Body>`, inside `<Tailwind>`
 - Only include props in `PreviewProps` that the component actually uses
 - Use fixed width/height for known-size elements (logos, icons); responsive sizing (`w-full`, `h-auto`) for content images
 

--- a/skills/react-email/SKILL.md
+++ b/skills/react-email/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-email
-description: Use when building HTML email templates with React components, using the React Email visual editor, rendering emails to HTML, or sending emails with Resend. Covers welcome emails, password resets, notifications, order confirmations, newsletters, transactional emails, and the embeddable email editor component.
+description: Use when building HTML email templates with React components, adding a visual email editor to an application using the React Email visual editor, rendering emails to HTML, or sending emails with Resend. Covers welcome emails, password resets, notifications, order confirmations, newsletters, transactional emails, and the embeddable email editor component.
 license: MIT
 metadata:
   author: Resend
@@ -112,7 +112,7 @@ export { WelcomeEmail };
 
 ## Behavioral Guidelines
 
-- When re-iterating over the code, only update what the user asked for — keep the rest intact.
+- When iterating over the code, only update what the user asked for. Keep the rest intact.
 - If the user asks to use media queries, inform them that most email clients don't support them and suggest a different approach.
 - Never use template variables (like `{{name}}`) directly in TypeScript code. Instead, reference the underlying properties directly. If the user explicitly asks for `{{variableName}}`, place the mustache string only in PreviewProps, never in the component JSX:
 
@@ -277,7 +277,7 @@ const { data, error } = await resend.emails.send({
 });
 ```
 
-The Node SDK automatically handles both HTML and plain-text rendering.
+The Resend Node SDK automatically handles both HTML and plain-text rendering.
 
 ## CLI Commands
 

--- a/skills/react-email/SKILL.md
+++ b/skills/react-email/SKILL.md
@@ -519,6 +519,38 @@ See [references/PATTERNS.md](references/PATTERNS.md) for complete examples inclu
 - Multi-column layouts
 - Email templates with custom fonts
 
+## Email Editor
+
+React Email includes a visual editor (`@react-email/editor`) that can be embedded in your app. It's built on TipTap/ProseMirror and produces email-ready HTML.
+
+See [references/EDITOR.md](references/EDITOR.md) for complete documentation including:
+- `EmailEditor` — batteries-included component with bubble menus, slash commands, and theming
+- `StarterKit` — 35+ email-aware extensions (headings, lists, tables, columns, buttons, etc.)
+- `Inspector` — contextual sidebar for editing styles
+- `EmailTheming` — built-in themes (`basic`, `minimal`) with customizable CSS properties
+- `composeReactEmail` — export editor content to email-ready HTML and plain text
+- Custom extensions via `EmailNode` and `EmailMark`
+
+Quick example:
+
+```tsx
+import { EmailEditor, type EmailEditorRef } from '@react-email/editor';
+import '@react-email/editor/themes/default.css';
+import { useRef } from 'react';
+
+export function MyEditor() {
+  const ref = useRef<EmailEditorRef>(null);
+
+  return (
+    <EmailEditor
+      ref={ref}
+      content="<p>Start typing...</p>"
+      theme="basic"
+    />
+  );
+}
+```
+
 ## Additional Resources
 
 - [React Email Documentation](https://react.email/docs/llms.txt)
@@ -526,5 +558,6 @@ See [references/PATTERNS.md](references/PATTERNS.md) for complete examples inclu
 - [Resend Documentation](https://resend.com/docs/llms.txt)
 - [Email Client CSS Support](https://www.caniemail.com)
 - Component Reference: [references/COMPONENTS.md](references/COMPONENTS.md)
+- Email Editor: [references/EDITOR.md](references/EDITOR.md)
 - Internationalization Guide: [references/I18N.md](references/I18N.md)
 - Common Patterns: [references/PATTERNS.md](references/PATTERNS.md)

--- a/skills/react-email/SKILL.md
+++ b/skills/react-email/SKILL.md
@@ -79,8 +79,8 @@ export default function WelcomeEmail({ name, verificationUrl }: WelcomeEmailProp
         }}
       >
         <Head />
-        <Preview>Welcome - Verify your email</Preview>
         <Body className="bg-gray-100 font-sans">
+          <Preview>Welcome - Verify your email</Preview>
           <Container className="max-w-xl mx-auto p-5">
             <Heading className="text-2xl text-gray-800">
               Welcome!
@@ -146,7 +146,7 @@ See [references/COMPONENTS.md](references/COMPONENTS.md) for complete component 
 - `Tailwind` - Enables Tailwind CSS utility classes
 
 **Content:**
-- `Preview` - Inbox preview text, placed before `<Body>` inside `<Tailwind>`
+- `Preview` - Inbox preview text, always first inside `<Body>`
 - `Heading` - h1-h6 headings
 - `Text` - Paragraphs
 - `Button` - Styled link buttons (always include `box-border`)
@@ -234,7 +234,7 @@ See [references/STYLING.md](references/STYLING.md) for comprehensive styling doc
 
 ### Structure Notes
 - Always define `<Head />` inside `<Tailwind>` when using Tailwind CSS
-- `<Preview>` goes before `<Body>`, inside `<Tailwind>`
+- `<Preview>` should always be the first element inside `<Body>`
 - Only include props in `PreviewProps` that the component actually uses
 - Use fixed width/height for known-size elements (logos, icons); responsive sizing (`w-full`, `h-auto`) for content images
 

--- a/skills/react-email/SKILL.md
+++ b/skills/react-email/SKILL.md
@@ -199,7 +199,7 @@ See [references/COMPONENTS.md](references/COMPONENTS.md) for complete component 
 - `Tailwind` - Enables Tailwind CSS utility classes
 
 **Content:**
-- `Preview` - Inbox preview text, always first in `Body`
+- `Preview` - Inbox preview text, must be the first child inside `<Body>`
 - `Heading` - h1-h6 headings
 - `Text` - Paragraphs
 - `Button` - Styled link buttons
@@ -313,7 +313,7 @@ Use the Tailwind component for styling if the user is actively using Tailwind CS
 ### Email Client Limitations
 - Never use SVG or WEBP - warn users about rendering issues
 - Never use flexbox - use Row/Column components or tables for layouts
-- Never use CSS/Tailwind media queries (sm:, md:, lg:, xl:) - not supported
+- Avoid CSS/Tailwind media queries (sm:, md:, lg:, xl:) - limited email client support, not reliable across major clients
 - Never use theme selectors (dark:, light:) - not supported
 - Always specify border type (border-solid, border-dashed, etc.)
 - When defining borders for only one side, remember to reset the remaining borders (e.g., border-none border-l)
@@ -359,7 +359,8 @@ Email.PreviewProps = {
 
 ### Images
 - Only include if user requests
-- Never use fixed width/height - use responsive units (w-full, h-auto)
+- Use fixed width/height for known-size elements (logos, icons) to prevent layout shift
+- Use responsive sizing (w-full, h-auto) for content images
 - Never distort user-provided images
 - Never create SVG images - only use provided or web images
 
@@ -466,7 +467,7 @@ export default async function WelcomeEmail({ name, locale }: EmailProps) {
           <Container className="max-w-xl mx-auto p-5">
             <Text className="text-base text-gray-800">{t('greeting')} {name},</Text>
             <Text className="text-base text-gray-800">{t('body')}</Text>
-            <Button href="https://example.com" className="bg-blue-600 text-white px-5 py-3 rounded">
+            <Button href="https://example.com" className="bg-blue-600 text-white px-5 py-3 rounded box-border">
               {t('cta')}
             </Button>
           </Container>

--- a/skills/react-email/SKILL.md
+++ b/skills/react-email/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: react-email
-description: Use when creating HTML email templates with React components - welcome emails, password resets, notifications, order confirmations, newsletters, or transactional emails.
+description: Use when building HTML email templates with React components, using the React Email visual editor, rendering emails to HTML, or sending emails with Resend. Covers welcome emails, password resets, notifications, order confirmations, newsletters, transactional emails, and the embeddable email editor component.
 license: MIT
 metadata:
   author: Resend
-  version: "1.1.0"
+  version: "2.0.0"
 ---
 
 # React Email
@@ -13,90 +13,22 @@ Build and send HTML emails using React components - a modern, component-based ap
 
 ## Installation
 
-You need to scaffold a new React Email project using the create-email CLI. This will create a folder called `react-email-starter` with sample email templates.
+Scaffold a new React Email project, install dependencies, and start the dev server:
 
-Using npm:
 ```sh
 npx create-email@latest
-```
-
-Using yarn:
-```sh
-yarn create email
-```
-
-Using pnpm:
-```sh
-pnpm create email
-```
-
-Using bun:
-```sh
-bun create email
-```
-
-## Navigate to Project Directory
-
-You must change into the newly created project folder:
-
-```sh
 cd react-email-starter
-```
-
-## Install Dependencies
-
-You need to install all project dependencies before running the development server.
-
-Using npm:
-```sh
 npm install
-```
-
-Using yarn:
-```sh
-yarn
-```
-
-Using pnpm:
-```sh
-pnpm install
-```
-
-Using bun:
-```sh
-bun install
-```
-
-## Start the Development Server
-
-Your task is to start the local preview server to view and edit email templates.
-
-Using npm:
-```sh
 npm run dev
 ```
 
-Using yarn:
-```sh
-yarn dev
-```
+This works with any package manager (npm, yarn, pnpm, bun) — substitute accordingly.
 
-Using pnpm:
-```sh
-pnpm dev
-```
+The dev server runs at localhost:3000 with a preview interface for templates in the `emails` folder.
 
-Using bun:
-```sh
-bun dev
-```
+### Adding to an Existing Project
 
-## Verify Installation
-
-Confirm the development server is running by checking that localhost:3000 is accessible. The server will display a preview interface where you can view email templates from the `emails` folder.
-
-### Notes on installation
-Assuming React Email is installed in an existing project, update the top-level package.json file with a script to run the React Email preview server.
+Install the packages and add a script to your `package.json`:
 
 ```json
 {
@@ -106,16 +38,9 @@ Assuming React Email is installed in an existing project, update the top-level p
 }
 ```
 
-Make sure the path to the emails folder is relative to the base project directory.
-
-
-### tsconfig.json updating or creation
-
-Ensure the tsconfig.json includes proper support for jsx.
+Make sure the path to the emails folder is relative to the base project directory. Ensure `tsconfig.json` includes proper support for JSX.
 
 ## Basic Email Template
-
-Replace the sample email templates. Here is how to create a new email template:
 
 Create an email component with proper structure using the Tailwind component for styling:
 
@@ -185,6 +110,28 @@ WelcomeEmail.PreviewProps = {
 export { WelcomeEmail };
 ```
 
+## Behavioral Guidelines
+
+- When re-iterating over the code, only update what the user asked for — keep the rest intact.
+- If the user asks to use media queries, inform them that most email clients don't support them and suggest a different approach.
+- Never use template variables (like `{{name}}`) directly in TypeScript code. Instead, reference the underlying properties directly. If the user explicitly asks for `{{variableName}}`, place the mustache string only in PreviewProps, never in the component JSX:
+
+```typescript
+const EmailTemplate = (props) => {
+  return (
+    <h1>Hello, {props.variableName}!</h1>
+  );
+}
+
+EmailTemplate.PreviewProps = {
+  variableName: "{{variableName}}",
+};
+
+export default EmailTemplate;
+```
+
+- Never write the `{{variableName}}` pattern directly in the component structure. If the user insists, explain that this would make the template invalid.
+
 ## Essential Components
 
 See [references/COMPONENTS.md](references/COMPONENTS.md) for complete component documentation.
@@ -202,7 +149,7 @@ See [references/COMPONENTS.md](references/COMPONENTS.md) for complete component 
 - `Preview` - Inbox preview text, must be the first child inside `<Body>`
 - `Heading` - h1-h6 headings
 - `Text` - Paragraphs
-- `Button` - Styled link buttons
+- `Button` - Styled link buttons (always include `box-border`)
 - `Link` - Hyperlinks
 - `Img` - Images (see Static Files section below)
 - `Hr` - Horizontal dividers
@@ -222,13 +169,6 @@ When a user requests an email template, ask clarifying questions FIRST if they h
 3. **Style preference** - Professional, casual, or minimal tone
 4. **Production URL** - Where will static assets be hosted in production?
 
-Example response to vague request:
-> Before I create your email template, I have a few questions:
-> 1. What is your primary brand color? (hex code)
-> 2. Do you have a logo file? (PNG or JPG - note: SVG and WEBP don't work reliably in email clients)
-> 3. What tone do you prefer - professional, casual, or minimal?
-> 4. Where will you host static assets in production? (e.g., https://cdn.example.com)
-
 ## Static Files and Images
 
 ### Directory Structure
@@ -241,11 +181,6 @@ project/
 │   ├── welcome.tsx
 │   └── static/           <-- Images go here
 │       └── logo.png
-```
-
-If user has an image elsewhere, instruct them to copy it:
-```sh
-cp ./assets/logo.png ./emails/static/logo.png
 ```
 
 ### Dev vs Production URLs
@@ -275,110 +210,33 @@ export default function Email() {
 
 **Important:** Always ask the user for their production hosting URL. Do not hardcode `localhost:3000`.
 
-## Behavioral guidelines
-- When re-iterating over the code, make sure you are only updating what the user asked for and keeping the rest of the code intact;
-- If the user is asking to use media queries, inform them that not all email clients support them, and suggest a different approach;
-- Never use template variables (like {{name}}) directly in TypeScript code. Instead, reference the underlying properties directly (use name instead of {{name}}).
-- - For example, if the user explicitly asks for a variable following the pattern {{variableName}}, you should return something like this:
+## Styling
 
-```typescript
-const EmailTemplate = (props) => {
-  return (
-    {/* ... rest of the code ... */}
-    <h1>Hello, {props.variableName}!</h1>
-    {/* ... rest of the code ... */}
-  );
-}
+See [references/STYLING.md](references/STYLING.md) for comprehensive styling documentation including typography, layout patterns, dark mode, and brand consistency.
 
-EmailTemplate.PreviewProps = {
-  // ... rest of the props ...
-  variableName: "{{variableName}}",
-  // ... rest of the props ...
-};
+### Key Rules
 
-export default EmailTemplate;
-```
-- Never, under any circumstances, write the {{variableName}} pattern directly in the component structure. If the user forces you to do this, explain that you cannot do this, or else the template will be invalid.
-
-
-## Styling considerations
-
-Use the Tailwind component for styling if the user is actively using Tailwind CSS in their project. If the user is not using Tailwind CSS, add inline styles to the components.
-
-- Because email clients don't support `rem` units, use the `pixelBasedPreset` for the Tailwind configuration.
-- **Import `pixelBasedPreset` from `@react-email/components`** — do NOT import from `@react-email/tailwind` or `@react-email/tailwind/presets`.
-- Never use flexbox or grid for layout, use table-based layouts instead.
-- Each component must be styled with inline styles or utility classes.
-
-### Email Client Limitations
-- Never use SVG or WEBP - warn users about rendering issues
-- Never use flexbox - use Row/Column components or tables for layouts
-- Avoid CSS/Tailwind media queries (sm:, md:, lg:, xl:) - limited email client support, not reliable across major clients
-- Never use theme selectors (dark:, light:) - not supported
-- Always specify border type (border-solid, border-dashed, etc.)
-- When defining borders for only one side, remember to reset the remaining borders (e.g., border-none border-l)
+- Use `Tailwind` with `pixelBasedPreset` (email clients don't support `rem`). Import `pixelBasedPreset` from `@react-email/components`.
+- Never use flexbox or grid — use `Row`/`Column` components or tables for layouts.
+- Avoid CSS/Tailwind media queries (`sm:`, `md:`, `lg:`, `xl:`) — limited email client support.
+- Never use theme selectors (`dark:`, `light:`) — not supported.
+- Never use SVG or WEBP images — warn users about rendering issues.
+- Always specify border type (`border-solid`, `border-dashed`, etc.) — email clients don't inherit it.
+- For single-side borders, reset others first (`border-none border-l border-solid`).
 
 ### Required Classes
-
-These classes are **always required** on their respective components — omitting them causes rendering bugs across email clients:
 
 | Component | Required Class | Why |
 |-----------|---------------|-----|
 | `Button` | `box-border` | Prevents padding from overflowing the button width |
-| `Hr` / any border | `border-solid` (or `border-dashed`, etc.) | Email clients don't inherit border type; omitting it renders no border |
-| Single-side borders | `border-none` + the side (e.g., `border-none border-t border-solid`) | Resets default borders on other sides |
+| `Hr` / any border | `border-solid` (or `border-dashed`, etc.) | Email clients don't inherit border type |
+| Single-side borders | `border-none` + the side | Resets default borders on other sides |
 
-### Component Structure
+### Structure Notes
 - Always define `<Head />` inside `<Tailwind>` when using Tailwind CSS
-- Only use PreviewProps when passing props to a component
-- Only include props in PreviewProps that the component actually uses
-
-```tsx
-const Email = (props) => {
-  return (
-    <div>
-      <a href={props.source}>click here if you want candy 👀</a>
-    </div>
-  );
-}
-
-Email.PreviewProps = {
-  source: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-};
-```
-
-### Default Structure
-- Body: `font-sans py-10 bg-gray-100`
-- Container: white, centered, content left-aligned
-- Footer: physical address, unsubscribe link, current year with `m-0` on address/copyright
-
-### Typography
-- Titles: bold, larger font, larger margins
-- Paragraphs: regular weight, smaller font, smaller margins
-- Use consistent spacing respecting content hierarchy
-
-### Images
-- Only include if user requests
-- Use fixed width/height for known-size elements (logos, icons) to prevent layout shift
-- Use responsive sizing (w-full, h-auto) for content images
-- Never distort user-provided images
-- Never create SVG images - only use provided or web images
-
-### Buttons
-- Always use `box-border` to prevent padding overflow
-
-### Layout
-- Always mobile-friendly by default
-- Use stacked layouts that work on all screen sizes
-- Remove default spacing/margins/padding between list items
-
-### Dark Mode
-When requested: container black (#000), background dark gray (#151516)
-
-### Best Practices
-- Choose colors, layout, and copy based on user's request
-- Make templates unique, not generic
-- Use keywords in email body to increase conversion
+- `<Preview>` must be the first child inside `<Body>`
+- Only include props in `PreviewProps` that the component actually uses
+- Use fixed width/height for known-size elements (logos, icons); responsive sizing (`w-full`, `h-auto`) for content images
 
 ## Rendering
 
@@ -396,17 +254,14 @@ const html = await render(
 ### Convert to Plain Text
 
 ```tsx
-import { render } from '@react-email/components';
-import { WelcomeEmail } from './emails/welcome';
-
 const text = await render(<WelcomeEmail name="John" verificationUrl="https://example.com/verify" />, { plainText: true });
 ```
 
 ## Sending
 
-React Email supports sending with any email service provider. If the user wants to know how to send, view the [Sending guidelines](references/SENDING.md).
+React Email supports sending with any email service provider. See [references/SENDING.md](references/SENDING.md) for complete sending documentation including Resend, Nodemailer, and SendGrid examples.
 
-Quick example using the Resend SDK for Node.js:
+Quick example using the Resend SDK:
 
 ```tsx
 import { Resend } from 'resend';
@@ -420,104 +275,26 @@ const { data, error } = await resend.emails.send({
   subject: 'Welcome to Acme',
   react: <WelcomeEmail name="John" verificationUrl="https://example.com/verify" />
 });
-
-if (error) {
-  console.error('Failed to send:', error);
-}
 ```
 
-The Node SDK automatically handles the plain-text rendering and HTML rendering for you.
+The Node SDK automatically handles both HTML and plain-text rendering.
+
+## CLI Commands
+
+The `react-email` package provides a CLI accessible via the `email` command:
+
+| Command | Description |
+|---------|-------------|
+| `email dev --dir <path> --port <port>` | Start the preview development server (default: `./emails`, port 3000) |
+| `email build --dir <path>` | Build the preview app for production deployment |
+| `email start` | Run the built preview app |
+| `email export --outDir <path> --pretty --plainText --dir <path>` | Export templates to static HTML files |
+| `email resend setup` | Connect the CLI to your Resend account via API key |
+| `email resend reset` | Remove the stored Resend API key |
 
 ## Internationalization
 
-See [references/I18N.md](references/I18N.md) for complete i18n documentation.
-
-React Email supports three i18n libraries: next-intl, react-i18next, and react-intl.
-
-### Quick Example (next-intl)
-
-```tsx
-import { createTranslator } from 'next-intl';
-import {
-  Html,
-  Body,
-  Container,
-  Text,
-  Button,
-  Tailwind,
-  pixelBasedPreset
-} from '@react-email/components';
-
-interface EmailProps {
-  name: string;
-  locale: string;
-}
-
-export default async function WelcomeEmail({ name, locale }: EmailProps) {
-  const t = createTranslator({
-    messages: await import(\`../messages/\${locale}.json\`),
-    namespace: 'welcome-email',
-    locale
-  });
-
-  return (
-    <Html lang={locale}>
-      <Tailwind config={{ presets: [pixelBasedPreset] }}>
-        <Body className="bg-gray-100 font-sans">
-          <Container className="max-w-xl mx-auto p-5">
-            <Text className="text-base text-gray-800">{t('greeting')} {name},</Text>
-            <Text className="text-base text-gray-800">{t('body')}</Text>
-            <Button href="https://example.com" className="bg-blue-600 text-white px-5 py-3 rounded box-border">
-              {t('cta')}
-            </Button>
-          </Container>
-        </Body>
-      </Tailwind>
-    </Html>
-  );
-}
-```
-
-Message files (\`messages/en.json\`, \`messages/es.json\`, etc.):
-
-```json
-{
-  "welcome-email": {
-    "greeting": "Hi",
-    "body": "Thanks for signing up!",
-    "cta": "Get Started"
-  }
-}
-```
-
-## Email Best Practices
-
-1. **Test across email clients** - Test in Gmail, Outlook, Apple Mail, Yahoo Mail. Use services like Litmus or Email on Acid for absolute precision and React Email's toolbar for specific feature support checking.
-
-2. **Keep it responsive** - Max-width around 600px, test on mobile devices.
-
-3. **Use absolute image URLs** - Host on reliable CDN, always include \`alt\` text.
-
-4. **Provide plain text version** - Required for accessibility and some email clients.
-
-5. **Keep file size under 102KB** - Gmail clips larger emails.
-
-6. **Add proper TypeScript types** - Define interfaces for all email props.
-
-7. **Include preview props** - Add \`.PreviewProps\` to components for development testing.
-
-8. **Handle errors** - Always check for errors when sending emails.
-
-9.  **Use verified domains** - For production, use verified domains in \`from\` addresses.
-
-## Common Patterns
-
-See [references/PATTERNS.md](references/PATTERNS.md) for complete examples including:
-- Password reset emails
-- Order confirmations with product lists
-- Notification emails with code blocks
-- Multi-column layouts
-- Email templates with custom fonts
+See [references/I18N.md](references/I18N.md) for complete i18n documentation. React Email supports three libraries: next-intl, react-i18next, and react-intl.
 
 ## Email Editor
 
@@ -551,6 +328,26 @@ export function MyEditor() {
 }
 ```
 
+## Common Patterns
+
+See [references/PATTERNS.md](references/PATTERNS.md) for complete examples including:
+- Password reset emails
+- Order confirmations with product lists
+- Notification emails with code blocks
+- Multi-column layouts
+- Team invitation emails
+
+## Email Best Practices
+
+1. **Test across email clients** - Gmail, Outlook, Apple Mail, Yahoo Mail
+2. **Keep it responsive** - Max-width around 600px, test on mobile
+3. **Use absolute image URLs** - Host on reliable CDN, always include `alt` text
+4. **Provide plain text version** - Required for accessibility
+5. **Keep file size under 102KB** - Gmail clips larger emails
+6. **Add proper TypeScript types** - Define interfaces for all email props
+7. **Include preview props** - Add `.PreviewProps` for development testing
+8. **Use verified domains** - For production `from` addresses
+
 ## Additional Resources
 
 - [React Email Documentation](https://react.email/docs/llms.txt)
@@ -558,6 +355,8 @@ export function MyEditor() {
 - [Resend Documentation](https://resend.com/docs/llms.txt)
 - [Email Client CSS Support](https://www.caniemail.com)
 - Component Reference: [references/COMPONENTS.md](references/COMPONENTS.md)
+- Styling Guide: [references/STYLING.md](references/STYLING.md)
 - Email Editor: [references/EDITOR.md](references/EDITOR.md)
+- Sending Guide: [references/SENDING.md](references/SENDING.md)
 - Internationalization Guide: [references/I18N.md](references/I18N.md)
 - Common Patterns: [references/PATTERNS.md](references/PATTERNS.md)

--- a/skills/react-email/references/COMPONENTS.md
+++ b/skills/react-email/references/COMPONENTS.md
@@ -61,7 +61,7 @@ export default function Email() {
             </Text>
             <Button
               href="https://example.com"
-              className="bg-brand text-white px-6 py-3 rounded-lg block text-center"
+              className="bg-brand text-white px-6 py-3 rounded-lg block text-center box-border"
             >
               Get Started
             </Button>
@@ -85,7 +85,7 @@ export default function Email() {
 **Important:**
 - Always use `pixelBasedPreset` - email clients don't support `rem` units
 - Custom config is optional - defaults work well
-- Responsive classes (sm:, md:, lg:) work via media queries, but should be used with caution due to limited email client support
+- Avoid responsive classes (sm:, md:, lg:) — limited email client support, not reliable across major clients
 
 ## Structural Components
 
@@ -237,7 +237,7 @@ import { Button } from '@react-email/components';
 <Button
   href="https://example.com/verify"
   target="_blank"
-  className="bg-blue-600 text-white px-5 py-3 rounded block text-center no-underline font-medium"
+  className="bg-blue-600 text-white px-5 py-3 rounded block text-center no-underline font-medium box-border"
 >
   Verify Email Address
 </Button>
@@ -318,8 +318,8 @@ import { CodeBlock, dracula } from '@react-email/components';
 const Email = () => {
   const code = `export default async (req, res) => {
   try {
-    const html = await renderAsync(
-      EmailTemplate({ firstName: 'John' })
+    const html = await render(
+      <EmailTemplate firstName="John" />
     );
     return NextResponse.json({ html });
   } catch (error) {

--- a/skills/react-email/references/COMPONENTS.md
+++ b/skills/react-email/references/COMPONENTS.md
@@ -85,7 +85,7 @@ export default function Email() {
 **Important:**
 - Always use `pixelBasedPreset` - email clients don't support `rem` units
 - Custom config is optional - defaults work well
-- Avoid responsive classes (sm:, md:, lg:) — limited email client support, not reliable across major clients
+- Avoid responsive classes (sm:, md:, lg:). These have limited email client support, and are not reliable across major clients
 
 ## Structural Components
 

--- a/skills/react-email/references/COMPONENTS.md
+++ b/skills/react-email/references/COMPONENTS.md
@@ -194,7 +194,7 @@ import { Preview } from '@react-email/components';
 **Best practices:**
 - Keep under 140 characters
 - Make it compelling and action-oriented
-- Place before `<Body>`, inside `<Tailwind>`
+- Should always be the first element inside `<Body>`
 
 ### Heading
 

--- a/skills/react-email/references/COMPONENTS.md
+++ b/skills/react-email/references/COMPONENTS.md
@@ -303,7 +303,7 @@ Display a divider that separates content areas in your email.
 ```tsx
 import { Hr } from '@react-email/components';
 
-<Hr className="border-gray-200 my-5" />
+<Hr className="border-solid border-gray-200 my-5" />
 ```
 
 ## Specialized Components

--- a/skills/react-email/references/COMPONENTS.md
+++ b/skills/react-email/references/COMPONENTS.md
@@ -194,7 +194,7 @@ import { Preview } from '@react-email/components';
 **Best practices:**
 - Keep under 140 characters
 - Make it compelling and action-oriented
-- Should always be the first element inside `<Body>`
+- Place before `<Body>`, inside `<Tailwind>`
 
 ### Heading
 

--- a/skills/react-email/references/EDITOR.md
+++ b/skills/react-email/references/EDITOR.md
@@ -21,7 +21,7 @@ A visual rich-text editor for building email templates, built on [TipTap](https:
 Install the editor and its peer dependencies:
 
 ```sh
-npm install @react-email/editor @tiptap/react @tiptap/core @tiptap/pm
+npm install @react-email/editor
 ```
 
 Requires **React 18+** and a bundler that supports [package exports](https://nodejs.org/api/packages.html#exports) (Vite, Next.js, Webpack 5, etc.).
@@ -155,7 +155,7 @@ const extensions = [StarterKit];
 export function MyEditor() {
   return (
     <EditorProvider extensions={extensions} content={content}>
-      <BubbleMenu.Default />
+      <BubbleMenu />
     </EditorProvider>
   );
 }
@@ -165,7 +165,7 @@ export function MyEditor() {
 
 | Component | Appears when... | Controls |
 |-----------|----------------|----------|
-| `BubbleMenu.Default` | Text is selected | Bold, italic, underline, strike, code, uppercase, alignment, node type, link |
+| `BubbleMenu` | Text is selected | Bold, italic, underline, strike, code, uppercase, alignment, node type, link |
 | `BubbleMenu.LinkDefault` | Cursor is on a link | Edit URL, open link, unlink |
 | `BubbleMenu.ButtonDefault` | Cursor is on a button | Edit button URL, unlink |
 | `BubbleMenu.ImageDefault` | Cursor is on an image | Edit image URL |
@@ -173,7 +173,7 @@ export function MyEditor() {
 Exclude specific items from the default menu:
 
 ```tsx
-<BubbleMenu.Default excludeItems={['strike', 'code', 'uppercase']} />
+<BubbleMenu excludeItems={['strike', 'code', 'uppercase']} />
 ```
 
 ## Slash Commands

--- a/skills/react-email/references/EDITOR.md
+++ b/skills/react-email/references/EDITOR.md
@@ -36,7 +36,7 @@ import '@react-email/editor/themes/default.css';
 
 This includes the default color theme and built-in UI styles for bubble menus, slash commands, and the inspector.
 
-To import only what you use:
+To import only what you need:
 
 ```tsx
 import '@react-email/editor/styles/bubble-menu.css';
@@ -50,7 +50,7 @@ The editor is organized into six entry points:
 
 | Import | Purpose |
 |--------|---------|
-| `@react-email/editor` | `EmailEditor` — the all-in-one component |
+| `@react-email/editor` | `EmailEditor`: the all-in-one component |
 | `@react-email/editor/core` | `composeReactEmail` serialization, `EmailNode`, `EmailMark`, event bus, types |
 | `@react-email/editor/extensions` | `StarterKit` and 35+ email-aware extensions |
 | `@react-email/editor/ui` | `BubbleMenu`, `SlashCommand`, `Inspector` |
@@ -175,6 +175,8 @@ Exclude specific items from the default menu:
 ```tsx
 <BubbleMenu excludeItems={['strike', 'code', 'uppercase']} />
 ```
+
+When combining the text bubble menu with contextual menus for links, images, or buttons, use `hideWhenActiveMarks` on `BubbleMenu` to prevent it from appearing when a link is focused.
 
 ## Slash Commands
 

--- a/skills/react-email/references/EDITOR.md
+++ b/skills/react-email/references/EDITOR.md
@@ -46,7 +46,7 @@ import '@react-email/editor/styles/inspector.css';
 
 ## Architecture
 
-The editor is organized into five entry points:
+The editor is organized into six entry points:
 
 | Import | Purpose |
 |--------|---------|
@@ -63,6 +63,7 @@ The `EmailEditor` component from `@react-email/editor` is a batteries-included c
 
 ```tsx
 import { EmailEditor, type EmailEditorRef } from '@react-email/editor';
+import '@react-email/editor/themes/default.css';
 import { useRef } from 'react';
 
 export function MyEditor() {
@@ -165,9 +166,9 @@ export function MyEditor() {
 | Component | Appears when... | Controls |
 |-----------|----------------|----------|
 | `BubbleMenu.Default` | Text is selected | Bold, italic, underline, strike, code, uppercase, alignment, node type, link |
-| `BubbleMenu.Link` | Cursor is on a link | Edit URL, open link, unlink |
-| `BubbleMenu.Button` | Cursor is on a button | Edit button URL, unlink |
-| `BubbleMenu.Image` | Cursor is on an image | Edit image URL |
+| `BubbleMenu.LinkDefault` | Cursor is on a link | Edit URL, open link, unlink |
+| `BubbleMenu.ButtonDefault` | Cursor is on a button | Edit button URL, unlink |
+| `BubbleMenu.ImageDefault` | Cursor is on an image | Edit image URL |
 
 Exclude specific items from the default menu:
 
@@ -299,13 +300,18 @@ function ExportPanel() {
 
   const handleExport = async () => {
     if (!editor) return;
-    const { html, text } = await composeReactEmail({ editor });
+    const { html, text } = await composeReactEmail({
+      editor,
+      preview: 'Inbox preview text', // optional
+    });
     console.log(html, text);
   };
 
   return <button onClick={handleExport}>Export HTML</button>;
 }
 ```
+
+The `preview` parameter is optional — when provided, it sets the inbox preview text in the exported HTML.
 
 The export pipeline:
 1. Reads the editor's JSON document

--- a/skills/react-email/references/EDITOR.md
+++ b/skills/react-email/references/EDITOR.md
@@ -1,0 +1,358 @@
+# React Email Editor Reference
+
+A visual rich-text editor for building email templates, built on [TipTap](https://tiptap.dev/) and [ProseMirror](https://prosemirror.net/). Embed it in your app to let users compose email-ready HTML without writing code.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [CSS Setup](#css-setup)
+- [Architecture](#architecture)
+- [EmailEditor Component](#emaileditor-component)
+- [Minimal Setup (Extensions Only)](#minimal-setup-extensions-only)
+- [Bubble Menus](#bubble-menus)
+- [Slash Commands](#slash-commands)
+- [Inspector](#inspector)
+- [Email Theming](#email-theming)
+- [Email Export](#email-export)
+- [Custom Extensions](#custom-extensions)
+
+## Installation
+
+Install the editor and its peer dependencies:
+
+```sh
+npm install @react-email/editor @tiptap/react @tiptap/core @tiptap/pm
+```
+
+Requires **React 18+** and a bundler that supports [package exports](https://nodejs.org/api/packages.html#exports) (Vite, Next.js, Webpack 5, etc.).
+
+## CSS Setup
+
+Import the bundled default theme for the quickest start:
+
+```tsx
+import '@react-email/editor/themes/default.css';
+```
+
+This includes the default color theme and built-in UI styles for bubble menus, slash commands, and the inspector.
+
+To import only what you use:
+
+```tsx
+import '@react-email/editor/styles/bubble-menu.css';
+import '@react-email/editor/styles/slash-command.css';
+import '@react-email/editor/styles/inspector.css';
+```
+
+## Architecture
+
+The editor is organized into five entry points:
+
+| Import | Purpose |
+|--------|---------|
+| `@react-email/editor` | `EmailEditor` — the all-in-one component |
+| `@react-email/editor/core` | `composeReactEmail` serialization, `EmailNode`, `EmailMark`, event bus, types |
+| `@react-email/editor/extensions` | `StarterKit` and 35+ email-aware extensions |
+| `@react-email/editor/ui` | `BubbleMenu`, `SlashCommand`, `Inspector` |
+| `@react-email/editor/plugins` | `EmailTheming` plugin |
+| `@react-email/editor/utils` | Attribute helpers, style utilities |
+
+## EmailEditor Component
+
+The `EmailEditor` component from `@react-email/editor` is a batteries-included component that bundles StarterKit, EmailTheming, BubbleMenus, and SlashCommands. Use it when you want the full experience with minimal setup.
+
+```tsx
+import { EmailEditor, type EmailEditorRef } from '@react-email/editor';
+import { useRef } from 'react';
+
+export function MyEditor() {
+  const editorRef = useRef<EmailEditorRef>(null);
+
+  const handleExport = async () => {
+    const { html, text } = await editorRef.current!.export();
+    console.log(html, text);
+  };
+
+  return (
+    <div>
+      <EmailEditor
+        ref={editorRef}
+        content="<p>Start typing...</p>"
+        theme="basic"
+        onReady={(editor) => console.log('Editor ready', editor)}
+        onChange={(editor) => console.log('Content changed')}
+      />
+      <button onClick={handleExport}>Export HTML</button>
+    </div>
+  );
+}
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `content` | `Content` | — | Initial editor content (HTML string or TipTap JSON) |
+| `onChange` | `(editor: Editor) => void` | — | Called on every content change |
+| `onUploadImage` | `UploadImageHandler` | — | Handler for pasted/dropped images |
+| `onReady` | `(editor: Editor) => void` | — | Called when editor is initialized |
+| `theme` | `'basic' \| 'minimal'` | `'basic'` | Built-in email theme |
+| `editable` | `boolean` | `true` | Whether content is editable |
+| `placeholder` | `string` | — | Placeholder text for empty editor |
+| `bubbleMenu` | `{ hideWhenActiveNodes?: string[], hideWhenActiveMarks?: string[] }` | — | Configure bubble menu visibility |
+| `extensions` | `Extensions` | — | Override the default extensions entirely |
+| `className` | `string` | — | CSS class for the editor container |
+
+### Ref Methods (`EmailEditorRef`)
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `export()` | `Promise<{ html: string; text: string }>` | Export email-ready HTML and plain text |
+| `getJSON()` | `JSONContent` | Get editor content as TipTap JSON |
+| `getHTML()` | `string` | Get editor content as HTML |
+| `editor` | `Editor \| null` | Access the underlying TipTap editor instance |
+
+## Minimal Setup (Extensions Only)
+
+For more control, use `EditorProvider` from `@tiptap/react` directly with `StarterKit`:
+
+```tsx
+import { StarterKit } from '@react-email/editor/extensions';
+import { EditorProvider } from '@tiptap/react';
+
+const extensions = [StarterKit];
+
+const content = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'Start typing or edit this text.' }],
+    },
+  ],
+};
+
+export function MyEditor() {
+  return <EditorProvider extensions={extensions} content={content} />;
+}
+```
+
+This gives you a content-editable area with all core extensions (paragraphs, headings, lists, tables, code blocks, columns, buttons, etc.) but no UI overlays.
+
+## Bubble Menus
+
+Floating formatting toolbars that appear on text selection. Add as children of `EditorProvider`.
+
+```tsx
+import { StarterKit } from '@react-email/editor/extensions';
+import { BubbleMenu } from '@react-email/editor/ui';
+import { EditorProvider } from '@tiptap/react';
+import '@react-email/editor/themes/default.css';
+
+const extensions = [StarterKit];
+
+export function MyEditor() {
+  return (
+    <EditorProvider extensions={extensions} content={content}>
+      <BubbleMenu.Default />
+    </EditorProvider>
+  );
+}
+```
+
+### Available Bubble Menus
+
+| Component | Appears when... | Controls |
+|-----------|----------------|----------|
+| `BubbleMenu.Default` | Text is selected | Bold, italic, underline, strike, code, uppercase, alignment, node type, link |
+| `BubbleMenu.Link` | Cursor is on a link | Edit URL, open link, unlink |
+| `BubbleMenu.Button` | Cursor is on a button | Edit button URL, unlink |
+| `BubbleMenu.Image` | Cursor is on an image | Edit image URL |
+
+Exclude specific items from the default menu:
+
+```tsx
+<BubbleMenu.Default excludeItems={['strike', 'code', 'uppercase']} />
+```
+
+## Slash Commands
+
+Insert content blocks by typing `/` in the editor.
+
+```tsx
+import { defaultSlashCommands, SlashCommand } from '@react-email/editor/ui';
+
+<EditorProvider extensions={extensions} content={content}>
+  <SlashCommand.Root items={defaultSlashCommands} />
+</EditorProvider>
+```
+
+### Default Commands
+
+| Command | Category | Description |
+|---------|----------|-------------|
+| `TEXT` | Text | Plain text block |
+| `H1`, `H2`, `H3` | Text | Headings |
+| `BULLET_LIST` | Text | Unordered list |
+| `NUMBERED_LIST` | Text | Ordered list |
+| `QUOTE` | Text | Block quote |
+| `CODE` | Text | Code snippet |
+| `BUTTON` | Layout | Clickable button |
+| `DIVIDER` | Layout | Horizontal separator |
+| `SECTION` | Layout | Content section |
+| `TWO_COLUMNS` | Layout | Two column layout |
+| `THREE_COLUMNS` | Layout | Three column layout |
+| `FOUR_COLUMNS` | Layout | Four column layout |
+
+Cherry-pick individual commands:
+
+```tsx
+import { BUTTON, H1, H2, TEXT } from '@react-email/editor/ui';
+
+<SlashCommand.Root items={[TEXT, H1, H2, BUTTON]} />
+```
+
+## Inspector
+
+A contextual sidebar for editing document-level styles, node properties, and text formatting. Requires the `EmailTheming` plugin.
+
+```tsx
+import { StarterKit } from '@react-email/editor/extensions';
+import { EmailTheming } from '@react-email/editor/plugins';
+import { Inspector } from '@react-email/editor/ui';
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react';
+import '@react-email/editor/themes/default.css';
+
+const extensions = [StarterKit, EmailTheming];
+
+export function MyEditor() {
+  const editor = useEditor({ extensions, content });
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <div style={{ display: 'flex' }}>
+        <div style={{ flex: 1 }}>
+          <EditorContent editor={editor} />
+        </div>
+        <Inspector.Root style={{ width: 240, borderLeft: '1px solid #e5e7eb', padding: 16 }}>
+          <Inspector.Breadcrumb />
+          <Inspector.Document />
+          <Inspector.Node />
+          <Inspector.Text />
+        </Inspector.Root>
+      </div>
+    </EditorContext.Provider>
+  );
+}
+```
+
+The inspector automatically switches between document, node, and text controls based on the current selection.
+
+## Email Theming
+
+Apply visual styles (typography, spacing, colors) to email output. Themes are resolved during `composeReactEmail` and inlined as `style` attributes.
+
+```tsx
+import { StarterKit } from '@react-email/editor/extensions';
+import { EmailTheming } from '@react-email/editor/plugins';
+
+const extensions = [StarterKit, EmailTheming.configure({ theme: 'basic' })];
+```
+
+### Built-in Themes
+
+| Theme | Description |
+|-------|-------------|
+| `'basic'` | Full styling: typography, spacing, borders, visual hierarchy. **Default.** |
+| `'minimal'` | Essentially no styles — blank slate for custom themes. |
+
+### Switching Themes Dynamically
+
+```tsx
+const [theme, setTheme] = useState<'basic' | 'minimal'>('basic');
+const extensions = [StarterKit, EmailTheming.configure({ theme })];
+
+// Re-key EditorProvider when theme changes
+<EditorProvider key={theme} extensions={extensions} content={content}>
+```
+
+## Email Export
+
+Convert editor content to email-ready HTML and plain text.
+
+### Via EmailEditor ref
+
+```tsx
+const editorRef = useRef<EmailEditorRef>(null);
+
+const { html, text } = await editorRef.current!.export();
+```
+
+### Via composeReactEmail (lower-level)
+
+```tsx
+import { composeReactEmail } from '@react-email/editor/core';
+import { useCurrentEditor } from '@tiptap/react';
+
+function ExportPanel() {
+  const { editor } = useCurrentEditor();
+
+  const handleExport = async () => {
+    if (!editor) return;
+    const { html, text } = await composeReactEmail({ editor });
+    console.log(html, text);
+  };
+
+  return <button onClick={handleExport}>Export HTML</button>;
+}
+```
+
+The export pipeline:
+1. Reads the editor's JSON document
+2. Traverses each node and mark
+3. Calls `renderToReactEmail()` on each `EmailNode` and `EmailMark`
+4. Applies theme styles via `EmailTheming` plugin (if configured)
+5. Wraps in a base template and renders to HTML string + plain text
+
+## Custom Extensions
+
+Create custom email-compatible nodes using `EmailNode` (extends TipTap's `Node` with `renderToReactEmail()`):
+
+```tsx
+import { EmailNode } from '@react-email/editor/core';
+import { mergeAttributes } from '@tiptap/core';
+
+const Callout = EmailNode.create({
+  name: 'callout',
+  group: 'block',
+  content: 'inline*',
+
+  parseHTML() {
+    return [{ tag: 'div[data-callout]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        'data-callout': '',
+        style: 'padding: 12px 16px; background: #f4f4f5; border-left: 3px solid #1c1c1c;',
+      }),
+      0,
+    ];
+  },
+
+  renderToReactEmail({ children, style }) {
+    return (
+      <div style={{ ...style, padding: '12px 16px', backgroundColor: '#f4f4f5', borderLeft: '3px solid #1c1c1c' }}>
+        {children}
+      </div>
+    );
+  },
+});
+
+// Register it
+const extensions = [StarterKit, Callout];
+```
+
+For custom marks (inline formatting), use `EmailMark` from `@react-email/editor/core` — same pattern but for inline elements.

--- a/skills/react-email/references/I18N.md
+++ b/skills/react-email/references/I18N.md
@@ -123,7 +123,7 @@ export default async function WelcomeEmail({
             >
               {t('cta')}
             </Button>
-            <Hr className="border-gray-200 my-5" />
+            <Hr className="border-solid border-gray-200 my-5" />
             <Text className="text-sm text-gray-500">
               {t('footer')}
             </Text>
@@ -621,7 +621,7 @@ export default async function OrderConfirmation({
             >
               {t('view-order')}
             </Button>
-            <Hr className="border-gray-200 my-5" />
+            <Hr className="border-solid border-gray-200 my-5" />
             <Text className="text-sm text-gray-500">
               {t('footer')}
             </Text>

--- a/skills/react-email/references/I18N.md
+++ b/skills/react-email/references/I18N.md
@@ -105,8 +105,8 @@ export default async function WelcomeEmail({
     <Html lang={locale}>
       <Tailwind config={{ presets: [pixelBasedPreset] }}>
         <Head />
-        <Preview>{t('subject')}</Preview>
         <Body className="bg-gray-100 font-sans">
+          <Preview>{t('subject')}</Preview>
           <Container className="mx-auto py-10 px-5 max-w-xl">
             <Heading className="text-2xl font-bold text-gray-800">
               {t('subject')}
@@ -598,8 +598,8 @@ export default async function OrderConfirmation({
     <Html lang={locale} dir={isRTL ? 'rtl' : 'ltr'}>
       <Tailwind config={{ presets: [pixelBasedPreset] }}>
         <Head />
-        <Preview>{t('preview')}</Preview>
         <Body className="bg-gray-100 font-sans">
+          <Preview>{t('preview')}</Preview>
           <Container className="mx-auto py-10 px-5 max-w-xl">
             <Heading className="text-2xl font-bold text-gray-800">
               {t('title')}

--- a/skills/react-email/references/I18N.md
+++ b/skills/react-email/references/I18N.md
@@ -110,7 +110,7 @@ export default async function WelcomeEmail({
             </Text>
             <Button
               href={verificationUrl}
-              className="bg-blue-600 text-white px-5 py-3 rounded block text-center no-underline"
+              className="bg-blue-600 text-white px-5 py-3 rounded block text-center no-underline box-border"
             >
               {t('cta')}
             </Button>
@@ -215,7 +215,7 @@ export default async function WelcomeEmail({
             </Text>
             <Button
               href="https://example.com"
-              className="bg-blue-600 text-white px-5 py-3 rounded"
+              className="bg-blue-600 text-white px-5 py-3 rounded box-border"
             >
               {formatMessage({ id: 'cta' })}
             </Button>
@@ -346,7 +346,7 @@ export default async function WelcomeEmail({ name, locale }: WelcomeEmailProps) 
             </Text>
             <Button
               href="https://example.com"
-              className="bg-blue-600 text-white px-5 py-3 rounded"
+              className="bg-blue-600 text-white px-5 py-3 rounded box-border"
             >
               {t('cta')}
             </Button>
@@ -608,7 +608,7 @@ export default async function OrderConfirmation({
             </Section>
             <Button
               href={`https://example.com/orders/${orderNumber}`}
-              className="bg-blue-600 text-white px-5 py-3 rounded block text-center no-underline my-5"
+              className="bg-blue-600 text-white px-5 py-3 rounded block text-center no-underline my-5 box-border"
             >
               {t('view-order')}
             </Button>

--- a/skills/react-email/references/I18N.md
+++ b/skills/react-email/references/I18N.md
@@ -2,6 +2,15 @@
 
 Complete guide for implementing multi-language email support with React Email using Tailwind CSS styling.
 
+## Table of Contents
+
+- [next-intl](#next-intl)
+- [react-intl (FormatJS)](#react-intl-formatjs)
+- [react-i18next](#react-i18next)
+- [Message File Organization](#message-file-organization)
+- [Best Practices](#best-practices)
+- [Example: Complete Multi-locale Email](#example-complete-multi-locale-email)
+
 React Email officially supports three popular i18n libraries: next-intl, react-i18next, and react-intl.
 
 ## next-intl

--- a/skills/react-email/references/PATTERNS.md
+++ b/skills/react-email/references/PATTERNS.md
@@ -2,6 +2,14 @@
 
 Real-world examples of common email templates using React Email with Tailwind CSS styling.
 
+## Table of Contents
+
+- [Password Reset Email](#password-reset-email)
+- [Order Confirmation with Product List](#order-confirmation-with-product-list)
+- [Notification Email with Code Block](#notification-email-with-code-block)
+- [Multi-Column Newsletter](#multi-column-newsletter)
+- [Team Invitation Email](#team-invitation-email)
+
 ## Password Reset Email
 
 ```tsx

--- a/skills/react-email/references/PATTERNS.md
+++ b/skills/react-email/references/PATTERNS.md
@@ -38,8 +38,8 @@ export default function PasswordReset({ resetUrl, email, expiryHours = 1 }: Pass
     <Html lang="en">
       <Tailwind config={{ presets: [pixelBasedPreset] }}>
         <Head />
-        <Preview>Reset your password - Action required</Preview>
         <Body className="bg-gray-100 font-sans">
+          <Preview>Reset your password - Action required</Preview>
           <Container className="mx-auto py-10 px-5 max-w-xl bg-white">
             <Heading className="text-2xl font-bold text-gray-800 mb-5">
               Reset Your Password
@@ -137,8 +137,8 @@ export default function OrderConfirmation({
     <Html lang="en">
       <Tailwind config={{ presets: [pixelBasedPreset] }}>
         <Head />
-        <Preview>Order #{orderNumber} confirmed - Thank you for your purchase!</Preview>
         <Body className="bg-gray-100 font-sans">
+          <Preview>Order #{orderNumber} confirmed - Thank you for your purchase!</Preview>
           <Container className="mx-auto py-10 px-5 max-w-xl">
             <Heading className="text-3xl font-bold text-gray-800 mb-2">
               Order Confirmed
@@ -337,8 +337,8 @@ export default function Notification({
     <Html lang="en">
       <Tailwind config={{ presets: [pixelBasedPreset] }}>
         <Head />
-        <Preview>{title} - {severity}</Preview>
         <Body className="bg-gray-100 font-mono">
+          <Preview>{title} - {severity}</Preview>
           <Container className="mx-auto max-w-xl bg-white border border-solid border-gray-200 rounded overflow-hidden">
             <Section className={`h-1 w-full ${severityColors[severity]}`} />
 
@@ -457,8 +457,8 @@ export default function Newsletter({ articles, unsubscribeUrl }: NewsletterProps
     <Html lang="en">
       <Tailwind config={{ presets: [pixelBasedPreset] }}>
         <Head />
-        <Preview>Your weekly roundup of the latest articles</Preview>
         <Body className="bg-white font-sans">
+          <Preview>Your weekly roundup of the latest articles</Preview>
           <Container className="mx-auto max-w-xl">
             {/* Header */}
             <Section className="pt-10 px-5 pb-5 text-center">
@@ -658,8 +658,8 @@ export default function TeamInvitation({
     <Html lang="en">
       <Tailwind config={{ presets: [pixelBasedPreset] }}>
         <Head />
-        <Preview>You've been invited to join {teamName}</Preview>
         <Body className="bg-gray-100 font-sans">
+          <Preview>You've been invited to join {teamName}</Preview>
           <Container className="mx-auto py-10 px-5 max-w-xl bg-white">
             <Heading className="text-3xl font-bold text-gray-800 text-center mb-6">
               You're Invited!

--- a/skills/react-email/references/PATTERNS.md
+++ b/skills/react-email/references/PATTERNS.md
@@ -56,7 +56,7 @@ export default function PasswordReset({ resetUrl, email, expiryHours = 1 }: Pass
             >
               Reset Password
             </Button>
-            <Hr className="border-gray-200 my-6" />
+            <Hr className="border-solid border-gray-200 my-6" />
             <Text className="text-sm text-gray-500 leading-5 my-2">
               If you didn't request this, please ignore this email. Your password will remain unchanged.
             </Text>
@@ -158,7 +158,7 @@ export default function OrderConfirmation({
               </Row>
             </Section>
 
-            <Hr className="border-gray-200 my-6" />
+            <Hr className="border-solid border-gray-200 my-6" />
 
             <Heading as="h2" className="text-xl font-bold text-gray-800 my-4">
               Order Items
@@ -173,7 +173,7 @@ export default function OrderConfirmation({
                       alt={item.name}
                       width="80"
                       height="80"
-                      className="rounded border border-gray-200"
+                      className="rounded border border-solid border-gray-200"
                     />
                   </Column>
                   <Column className="align-top pl-4">
@@ -192,7 +192,7 @@ export default function OrderConfirmation({
               </Section>
             ))}
 
-            <Hr className="border-gray-200 my-6" />
+            <Hr className="border-solid border-gray-200 my-6" />
 
             <Section className="mt-6">
               <Row>
@@ -213,7 +213,7 @@ export default function OrderConfirmation({
                   <Text className="text-sm text-gray-800 my-2">${tax.toFixed(2)}</Text>
                 </Column>
               </Row>
-              <Hr className="border-gray-200 my-3" />
+              <Hr className="border-solid border-gray-200 my-3" />
               <Row>
                 <Column><Text className="text-lg font-bold text-gray-800 my-2">Total</Text></Column>
                 <Column className="text-right">
@@ -222,7 +222,7 @@ export default function OrderConfirmation({
               </Row>
             </Section>
 
-            <Hr className="border-gray-200 my-6" />
+            <Hr className="border-solid border-gray-200 my-6" />
 
             <Heading as="h2" className="text-xl font-bold text-gray-800 my-4">
               Shipping Address
@@ -339,7 +339,7 @@ export default function Notification({
         <Head />
         <Preview>{title} - {severity}</Preview>
         <Body className="bg-gray-100 font-mono">
-          <Container className="mx-auto max-w-xl bg-white border border-gray-200 rounded overflow-hidden">
+          <Container className="mx-auto max-w-xl bg-white border border-solid border-gray-200 rounded overflow-hidden">
             <Section className={`h-1 w-full ${severityColors[severity]}`} />
 
             <Heading className="text-2xl font-bold text-gray-800 mx-6 mt-6 mb-4">
@@ -363,24 +363,23 @@ export default function Notification({
 
             {logData && (
               <>
-                <Hr className="border-gray-200 my-6" />
+                <Hr className="border-solid border-gray-200 my-6" />
                 <Heading as="h2" className="text-lg font-bold text-gray-800 mx-6 my-4">
                   Log Details
                 </Heading>
-                <Section className="mx-6">
+                <div className="overflow-auto mx-6">
                   <CodeBlock
                     code={logData}
                     language="json"
                     theme={dracula}
-                    lineNumbers
                   />
-                </Section>
+                </div>
               </>
             )}
 
             {actionUrl && (
               <>
-                <Hr className="border-gray-200 my-6" />
+                <Hr className="border-solid border-gray-200 my-6" />
                 <Link
                   href={actionUrl}
                   className={`inline-block px-6 py-3 text-base font-bold text-white rounded no-underline mx-6 mb-6 ${severityBtnColors[severity]}`}
@@ -390,7 +389,7 @@ export default function Notification({
               </>
             )}
 
-            <Hr className="border-gray-200 my-6" />
+            <Hr className="border-solid border-gray-200 my-6" />
             <Text className="text-xs text-gray-500 mx-6 mb-6">
               This is an automated notification. Please do not reply to this email.
             </Text>
@@ -478,7 +477,7 @@ export default function Newsletter({ articles, unsubscribeUrl }: NewsletterProps
               Here are the top articles from this week. Enjoy your reading!
             </Text>
 
-            <Hr className="border-gray-200 mx-5 my-8" />
+            <Hr className="border-solid border-gray-200 mx-5 my-8" />
 
             {/* Featured Article */}
             {articles[0] && (
@@ -507,7 +506,7 @@ export default function Newsletter({ articles, unsubscribeUrl }: NewsletterProps
               </Section>
             )}
 
-            <Hr className="border-gray-200 mx-5 my-8" />
+            <Hr className="border-solid border-gray-200 mx-5 my-8" />
 
             {/* Two-Column Articles */}
             {articles.slice(1, 5).length > 0 && (
@@ -568,7 +567,7 @@ export default function Newsletter({ articles, unsubscribeUrl }: NewsletterProps
               </>
             )}
 
-            <Hr className="border-gray-200 mx-5 my-8" />
+            <Hr className="border-solid border-gray-200 mx-5 my-8" />
 
             {/* Footer */}
             <Section className="bg-gray-50 p-8 mt-8 text-center">
@@ -671,7 +670,7 @@ export default function TeamInvitation({
               <strong>{teamName}</strong> team.
             </Text>
 
-            <Section className="bg-gray-50 p-5 rounded border border-gray-200 my-6">
+            <Section className="bg-gray-50 p-5 rounded border border-solid border-gray-200 my-6">
               <Text className="text-xs text-gray-500 uppercase font-bold mb-2">Role</Text>
               <Text className="text-lg font-bold text-gray-800 m-0">{role}</Text>
             </Section>
@@ -687,7 +686,7 @@ export default function TeamInvitation({
               Accept Invitation
             </Button>
 
-            <Hr className="border-gray-200 my-6" />
+            <Hr className="border-solid border-gray-200 my-6" />
 
             <Text className="text-sm text-gray-500 leading-5 my-2">
               This invitation will expire in {expiryDays} day{expiryDays > 1 ? 's' : ''}.

--- a/skills/react-email/references/PATTERNS.md
+++ b/skills/react-email/references/PATTERNS.md
@@ -44,7 +44,7 @@ export default function PasswordReset({ resetUrl, email, expiryHours = 1 }: Pass
             </Text>
             <Button
               href={resetUrl}
-              className="bg-red-600 text-white px-7 py-3.5 rounded block text-center font-bold my-6 no-underline"
+              className="bg-red-600 text-white px-7 py-3.5 rounded block text-center font-bold my-6 no-underline box-border"
             >
               Reset Password
             </Button>
@@ -492,7 +492,7 @@ export default function Newsletter({ articles, unsubscribeUrl }: NewsletterProps
                 </Text>
                 <Button
                   href={articles[0].url}
-                  className="bg-blue-600 text-white px-6 py-3 rounded font-bold inline-block no-underline"
+                  className="bg-blue-600 text-white px-6 py-3 rounded font-bold inline-block no-underline box-border"
                 >
                   Read More
                 </Button>
@@ -674,7 +674,7 @@ export default function TeamInvitation({
 
             <Button
               href={inviteUrl}
-              className="bg-green-600 text-white px-7 py-3.5 rounded block text-center font-bold text-base my-6 no-underline"
+              className="bg-green-600 text-white px-7 py-3.5 rounded block text-center font-bold text-base my-6 no-underline box-border"
             >
               Accept Invitation
             </Button>

--- a/skills/react-email/references/PATTERNS.md
+++ b/skills/react-email/references/PATTERNS.md
@@ -367,13 +367,13 @@ export default function Notification({
                 <Heading as="h2" className="text-lg font-bold text-gray-800 mx-6 my-4">
                   Log Details
                 </Heading>
-                <div className="overflow-auto mx-6">
+                <Section className="overflow-auto mx-6">
                   <CodeBlock
                     code={logData}
                     language="json"
                     theme={dracula}
                   />
-                </div>
+                </Section>
               </>
             )}
 

--- a/skills/react-email/references/SENDING.md
+++ b/skills/react-email/references/SENDING.md
@@ -1,8 +1,10 @@
-Below are general guidelines for sending emails with React Email.
+# Sending Guide
+
+General guidelines for sending emails with React Email.
 
 Important: Use verified domains in `from` addresses. Ask the user for the verified domain and use it in the `from` address. If the user does not have a verified domain, ask them to verify one with their email service provider.
 
-### Send with Resend (Recommended)
+## Send with Resend (Recommended)
 
 When you have access to the Resend MCP tool:
 
@@ -47,7 +49,7 @@ if (error) {
 
 The Node SDK automatically handles the plain-text rendering and HTML rendering for you.
 
-### Send as a Template to Resend
+## Send as a Template to Resend
 
 If preferred, you can upload the email as a template to Resend, which can be used to send emails with the Resend SDK for Node.js:
 
@@ -72,7 +74,7 @@ await resend.emails.send({
 });
 ```
 
-### Send with Other Providers
+## Send with Other Providers
 
 **Nodemailer:**
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrades the React Email skill to v2.0 with a complete `@react-email/editor` reference, a slimmer SKILL.md, and consistent, email‑client‑safe docs and examples. Improves guidance (layout, styling, export) and aligns patterns across references.

- **New Features**
  - Added `references/EDITOR.md` covering `EmailEditor`, `StarterKit`, bubble menus, slash commands, inspector, theming, export, and custom extensions; added an editor section with a quick example in SKILL.md.
  - Added CLI commands to SKILL.md (`email dev/build/start/export`, `email resend setup/reset`) and linked `EDITOR.md`/`STYLING.md` in README; added tables of contents to `I18N.md` and `PATTERNS.md`.

- **Refactors**
  - Restructured SKILL.md (condensed install; focused on editor/rendering/sending) and clarified layout roles: use `Container` once (max‑width 37.5em) and `Section` for inner blocks.
  - Standardized rules and examples across docs: `<Preview>` first inside `<Body>`; avoid responsive classes; fixed dimensions for logos/icons and responsive for content images; `box-border` on `Button`; `border-solid` on borders; replaced `renderAsync`→`render`; wrapped `CodeBlock` in an overflow container.
  - Corrected editor docs: six entry points, BubbleMenu names (`.LinkDefault`, `.ButtonDefault`, `.ImageDefault`), optional `preview` in `composeReactEmail`, and CSS import in the `EmailEditor` example; improved SENDING.md heading structure and polished grammar.

<sup>Written for commit bead85d62e2b091756513c085abac515b8487ed9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

