### PR TITLE
fix(preview-server): enrich Zod failure message for email module exports

### DIFF
--- a/packages/preview-server/src/utils/get-email-component.ts
+++ b/packages/preview-server/src/utils/get-email-component.ts
@@ -17,6 +17,24 @@ const EmailComponentModule = z.object({
   reactEmailCreateReactElement: z.function(),
 });
 
+function describeBundledModuleExports(value: unknown): string {
+  if (value === null || value === undefined) {
+    return `module value is ${String(value)}`;
+  }
+  if (typeof value !== 'object') {
+    return `module value has typeof ${typeof value}`;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (keys.length === 0) {
+    return 'module value is an object with no own enumerable keys';
+  }
+  const keyTypes = keys
+    .map((key) => `${JSON.stringify(key)}: ${typeof record[key]}`)
+    .join(', ');
+  return `Object.keys: [${keys.map((k) => JSON.stringify(k)).join(', ')}]; ${keyTypes}`;
+}
+
 export const getEmailComponent = async (
   emailPath: string,
   jsxRuntimePath: string,
@@ -125,10 +143,17 @@ export const getEmailComponent = async (
   const parseResult = EmailComponentModule.safeParse(runningResult.value);
 
   if (parseResult.error) {
+    const zodIssueSummary = parseResult.error.issues
+      .map(
+        (issue) =>
+          `${issue.path.length ? issue.path.join('.') : '(root)'}: ${issue.message} (${issue.code})`,
+      )
+      .join('; ');
+    const actualExports = describeBundledModuleExports(runningResult.value);
     return {
       error: {
         name: 'Error',
-        message: `The email component at ${emailPath} does not contain the expected exports`,
+        message: `The email component at ${emailPath} does not contain the expected exports. Zod: ${zodIssueSummary}. Actual: ${actualExports}`,
         stack: new Error().stack,
         cause: parseResult.error,
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `EmailComponentModule.safeParse` fails in `get-email-component.ts`, the returned error was generic and did not explain which schema fields failed or what the bundled module actually contained.

## Changes

- Add `describeBundledModuleExports()` to summarize `runningResult.value`: handles null/undefined, non-objects, empty keys, and otherwise lists `Object.keys` plus each key's `typeof` value.
- On Zod failure, append a `Zod:` section built from `parseResult.error.issues` (path, message, code per issue) and an `Actual:` section from the helper.
- **`cause` remains `parseResult.error` unchanged.**

## Testing

- `pnpm exec biome check packages/preview-server/src/utils/get-email-component.ts`
- Full `pnpm test` in `packages/preview-server` fails in this environment due to unresolved workspace packages / esbuild resolution (pre-existing); the edited file passes Biome.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-129dabbd-e829-4dbd-ba0d-0f6eb5352e7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-129dabbd-e829-4dbd-ba0d-0f6eb5352e7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve Zod validation errors in the preview server for email modules. The error now shows which fields failed and what the module actually exported to make debugging faster.

- **Bug Fixes**
  - On `EmailComponentModule.safeParse` failure, append issue path/message/code and a summary of actual export keys/types to the error message.
  - Add `describeBundledModuleExports()` to describe null/undefined, non-object values, and list keys with their types.
  - Preserve `cause` as the original Zod error.

<sup>Written for commit d0b15b43d7121891ff365cfc7a925868a5729867. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

