### PR TITLE
fix(editor): zero body padding removing default padding from email clients

### DIFF
--- a/packages/editor/src/extensions/container.spec.tsx
+++ b/packages/editor/src/extensions/container.spec.tsx
@@ -277,8 +277,7 @@ describe('Container Node', () => {
             name="format-detection" />
           <!--$-->
         </head>
-        <body
-          style="background-color:#ffffff;padding-top:0;padding-bottom:0;padding-right:0;padding-left:0">
+        <body style="background-color:#ffffff">
           <table
             border="0"
             width="100%"
@@ -289,7 +288,7 @@ describe('Container Node', () => {
             <tbody>
               <tr>
                 <td
-                  style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px">
+                  style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff">
                   <table
                     align="left"
                     width="100%"
@@ -1579,8 +1578,7 @@ describe('Container Node', () => {
             name="format-detection" />
           <!--$-->
         </head>
-        <body
-          style="background-color:#ffffff;padding-top:0;padding-bottom:0;padding-right:0;padding-left:0">
+        <body style="background-color:#ffffff">
           <table
             border="0"
             width="100%"
@@ -1591,7 +1589,7 @@ describe('Container Node', () => {
             <tbody>
               <tr>
                 <td
-                  style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px">
+                  style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff">
                   <table
                     align="left"
                     width="100%"

--- a/packages/editor/src/plugins/email-theming/themes.ts
+++ b/packages/editor/src/plugins/email-theming/themes.ts
@@ -53,7 +53,7 @@ const THEME_BASIC: PanelGroup[] = [
       {
         label: 'Padding Top',
         type: 'number',
-        value: 0,
+        value: undefined,
         unit: 'px',
         prop: 'paddingTop',
         classReference: 'body',
@@ -61,7 +61,7 @@ const THEME_BASIC: PanelGroup[] = [
       {
         label: 'Padding Right',
         type: 'number',
-        value: 0,
+        value: undefined,
         unit: 'px',
         prop: 'paddingRight',
         classReference: 'body',
@@ -69,7 +69,7 @@ const THEME_BASIC: PanelGroup[] = [
       {
         label: 'Padding Bottom',
         type: 'number',
-        value: 0,
+        value: undefined,
         unit: 'px',
         prop: 'paddingBottom',
         classReference: 'body',
@@ -77,7 +77,7 @@ const THEME_BASIC: PanelGroup[] = [
       {
         label: 'Padding Left',
         type: 'number',
-        value: 0,
+        value: undefined,
         unit: 'px',
         prop: 'paddingLeft',
         classReference: 'body',
@@ -418,7 +418,7 @@ const THEME_MINIMAL: PanelGroup[] = [
       {
         label: 'Padding Top',
         type: 'number',
-        value: 0,
+        value: undefined,
         unit: 'px',
         prop: 'paddingTop',
         classReference: 'body',
@@ -426,7 +426,7 @@ const THEME_MINIMAL: PanelGroup[] = [
       {
         label: 'Padding Right',
         type: 'number',
-        value: 0,
+        value: undefined,
         unit: 'px',
         prop: 'paddingRight',
         classReference: 'body',
@@ -434,7 +434,7 @@ const THEME_MINIMAL: PanelGroup[] = [
       {
         label: 'Padding Bottom',
         type: 'number',
-        value: 0,
+        value: undefined,
         unit: 'px',
         prop: 'paddingBottom',
         classReference: 'body',
@@ -442,7 +442,7 @@ const THEME_MINIMAL: PanelGroup[] = [
       {
         label: 'Padding Left',
         type: 'number',
-        value: 0,
+        value: undefined,
         unit: 'px',
         prop: 'paddingLeft',
         classReference: 'body',


### PR DESCRIPTION
## Summary
- Changes the default body padding values in both `basic` and `minimal` editor themes from `0` to `undefined`, so the theming system no longer explicitly sets `padding: 0px` on the `<body>` element.
- This prevents overriding the `Body` component's natural defaults when no padding has been configured by the user.
- Container padding defaults remain at `0` (intentional).

## Test plan
- [x] Updated inline snapshots in `container.spec.tsx` to match the new output
- [ ] Verify the editor preview renders body padding correctly when no custom padding is set
- [ ] Verify that setting body padding via the theme panel still works as expected

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop forcing body padding to 0 in editor themes. Body padding now defaults to undefined so the Body component keeps its natural defaults.

- **Bug Fixes**
  - Set body padding defaults in basic and minimal themes to undefined (was 0).
  - Updated snapshots to reflect removal of explicit body padding; container padding remains 0.

<sup>Written for commit f0dedc148792ba23422dbffa3738726977338ee5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

