### PR TITLE
fix(editor): preserve list styles in minimal theme

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/editor",
-  "version": "0.0.0-experimental.47",
+  "version": "0.0.0-experimental.48",
   "description": "A rich text editor for editing and building email templates",
   "sideEffects": [
     "**/*.css"

--- a/packages/editor/src/plugins/email-theming/themes.ts
+++ b/packages/editor/src/plugins/email-theming/themes.ts
@@ -710,6 +710,10 @@ const RESET_MINIMAL: ResetTheme = {
   reset: RESET_BASIC.reset,
   button: RESET_BASIC.button,
   image: RESET_BASIC.image,
+  list: RESET_BASIC.list,
+  nestedList: RESET_BASIC.nestedList,
+  listItem: RESET_BASIC.listItem,
+  listParagraph: RESET_BASIC.listParagraph,
 };
 
 export const RESET_THEMES: Record<EditorTheme, ResetTheme> = {


### PR DESCRIPTION
## Summary

- `RESET_MINIMAL` zeroes out all `RESET_BASIC` keys then only restores `reset`, `button`, and `image` — this strips `paddingLeft`/`marginLeft` from list elements, making bullet points and numbered list markers invisible
- Preserves `list`, `nestedList`, `listItem`, and `listParagraph` from `RESET_BASIC` — these are structural styles (make markers visible), not decorative ones the minimal theme intends to strip

## Test plan

- [ ] Create an email with the minimal theme
- [ ] Add a bullet list and a numbered list
- [ ] Verify bullet points and numbers are visible in both editor and rendered output
- [ ] Verify nested lists also display correctly
- [ ] Confirm basic theme behavior is unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves list styles in the minimal email theme so bullet and numbered markers are visible in the editor and in rendered emails. Restores structural list resets from the basic theme (list, nestedList, listItem, listParagraph) while keeping other minimal trims.

- **Dependencies**
  - Bumps `@react-email/editor` to 0.0.0-experimental.48

<sup>Written for commit 584dc2886d9d436a119cbf1acb1d074b13fbffea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

