### PR TITLE
chore: enter canary, ignore adjustments

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,6 +9,7 @@
     "@benchmarks/preview-server",
     "@benchmarks/tailwind-component",
     "editor-examples",
+    "playground",
     "demo",
     "email-dev",
     "web"

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,6 @@
   "ignore": [
     "@benchmarks/preview-server",
     "@benchmarks/tailwind-component",
-    "@react-email/editor",
     "editor-examples",
     "demo",
     "email-dev",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,21 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "demo": "0.0.0",
+    "docs": "0.0.0",
+    "web": "0.0.0",
+    "@benchmarks/preview-server": "0.0.0",
+    "@benchmarks/tailwind-component": "0.0.0",
+    "create-email": "1.2.3",
+    "@react-email/editor": "0.0.0-experimental.48",
+    "editor-examples": "0.0.0",
+    "@react-email/preview-server": "5.2.10",
+    "react-email": "5.2.10",
+    "email-dev": "0.0.6",
+    "@react-email/render": "2.0.6",
+    "tsconfig": "0.0.0",
+    "playground": "0.0.20"
+  },
+  "changesets": []
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable canary prerelease mode to publish canary builds across packages. Adds `.changeset/pre.json` (tag `canary`, initial versions) and updates `.changeset/config.json` to include `@react-email/editor` in releases and ignore `playground`.

<sup>Written for commit 386ebf7179e49e3e7f45177b19a3ee0001cd6fb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

