### PR TITLE
feat(skill): update imports from @react-email/components to react-email

### DIFF
--- a/skills/react-email/SKILL.md
+++ b/skills/react-email/SKILL.md
@@ -4,7 +4,7 @@ description: Use when building HTML email templates with React components, addin
 license: MIT
 metadata:
   author: Resend
-  version: "2.0.0"
+  version: "2.1.0"
 ---
 
 # React Email
@@ -13,7 +13,11 @@ Build and send HTML emails using React components - a modern, component-based ap
 
 ## Installation
 
-Scaffold a new React Email project, install dependencies, and start the dev server:
+```sh
+npm i react-email
+```
+
+Or scaffold a new project:
 
 ```sh
 npx create-email@latest
@@ -56,7 +60,7 @@ import {
   Button,
   Tailwind,
   pixelBasedPreset
-} from '@react-email/components';
+} from 'react-email';
 
 interface WelcomeEmailProps {
   name: string;
@@ -216,7 +220,7 @@ See [references/STYLING.md](references/STYLING.md) for comprehensive styling doc
 
 ### Key Rules
 
-- Use `Tailwind` with `pixelBasedPreset` (email clients don't support `rem`). Import `pixelBasedPreset` from `@react-email/components`.
+- Use `Tailwind` with `pixelBasedPreset` (email clients don't support `rem`). Import `pixelBasedPreset` from `react-email`.
 - Never use flexbox or grid — use `Row`/`Column` components or tables for layouts.
 - Avoid CSS/Tailwind media queries (`sm:`, `md:`, `lg:`, `xl:`) — limited email client support.
 - Never use theme selectors (`dark:`, `light:`) — not supported.
@@ -243,7 +247,7 @@ See [references/STYLING.md](references/STYLING.md) for comprehensive styling doc
 ### Convert to HTML
 
 ```tsx
-import { render } from '@react-email/components';
+import { render } from 'react-email';
 import { WelcomeEmail } from './emails/welcome';
 
 const html = await render(

--- a/skills/react-email/TESTS.md
+++ b/skills/react-email/TESTS.md
@@ -173,7 +173,7 @@ Create a simple welcome email with Tailwind styling.
 ✅ WITH skill: Agent included `presets: [pixelBasedPreset]` in Tailwind config.
 
 **Regression Result (2026-02-12):**
-✅ WITH skill: Agent included `presets: [pixelBasedPreset]`, imported from `@react-email/components`. Also included `box-border` on Button and `border-solid` on Hr.
+✅ WITH skill: Agent included `presets: [pixelBasedPreset]`, imported from `react-email`. Also included `box-border` on Button and `border-solid` on Hr.
 
 **Pass Criteria:**
 ```tsx
@@ -247,18 +247,18 @@ Create a welcome email with Tailwind styling and a call-to-action button.
 ```
 
 **Expected Behavior:**
-- Import `pixelBasedPreset` from `@react-email/components`
+- Import `pixelBasedPreset` from `react-email`
 - Do NOT import from `@react-email/tailwind` or `@react-email/tailwind/presets`
-- All React Email imports should come from `@react-email/components`
+- All React Email imports should come from `react-email`
 
 **Baseline Result (2026-02-12):**
 ❌ WITHOUT explicit rule: Agents imported from `@react-email/tailwind` or `@react-email/tailwind/presets` in 2/5 tests.
 
 **Verified Result (2026-02-12):**
-✅ WITH explicit rule: 4/5 agents imported from `@react-email/components`. Pressure test (D1) still used wrong import path.
+✅ WITH explicit rule: 4/5 agents imported from `react-email`. Pressure test (D1) still used wrong import path.
 
 **Regression Result (2026-02-12):**
-✅ WITH explicit rule + reference example: All agents (including pressure test D1) imported from `@react-email/components`.
+✅ WITH explicit rule + reference example: All agents (including pressure test D1) imported from `react-email`.
 
 **Pass Criteria:**
 ```tsx
@@ -268,7 +268,7 @@ import {
   Head,
   Tailwind,
   pixelBasedPreset,  // Same package as other components
-} from '@react-email/components';
+} from 'react-email';
 
 // WRONG - separate import from wrong package
 import { pixelBasedPreset } from '@react-email/tailwind';
@@ -424,7 +424,7 @@ Agent should:
 ✅ WITH skill: Agent explained all limitations, provided correct alternatives, did not comply.
 
 **Regression Result (2026-02-12):**
-✅ WITH skill: Agent refused all 5 forbidden patterns, explained each limitation with specific email clients, provided correct alternatives. Included `box-border` on Button, `border-solid` on Hr, and imported `pixelBasedPreset` from `@react-email/components`.
+✅ WITH skill: Agent refused all 5 forbidden patterns, explained each limitation with specific email clients, provided correct alternatives. Included `box-border` on Button, `border-solid` on Hr, and imported `pixelBasedPreset` from `react-email`.
 
 **Pass Criteria:**
 Agent maintains ALL rules even under pressure. Provides professional explanations.
@@ -558,7 +558,7 @@ Create a welcome email with custom meta tags in the head.
 ✅ WITH skill: Agent placed `<Head>` inside `<Tailwind>` correctly.
 
 **Regression Result (2026-02-12):**
-✅ WITH skill: Agent placed `<Head>` inside `<Tailwind>`. Imported `pixelBasedPreset` from `@react-email/components`. Included `box-border` on Button and `border-solid` on Hr.
+✅ WITH skill: Agent placed `<Head>` inside `<Tailwind>`. Imported `pixelBasedPreset` from `react-email`. Included `box-border` on Button and `border-solid` on Hr.
 
 **Pass Criteria:**
 ```tsx
@@ -714,7 +714,7 @@ import {
   Text,
   Tailwind,
   pixelBasedPreset
-} from '@react-email/components';
+} from 'react-email';
 
 // WRONG - imports unused components
 import {
@@ -730,7 +730,7 @@ import {
   Column,      // Not used
   Tailwind,
   pixelBasedPreset
-} from '@react-email/components';
+} from 'react-email';
 ```
 
 ---

--- a/skills/react-email/references/COMPONENTS.md
+++ b/skills/react-email/references/COMPONENTS.md
@@ -6,7 +6,7 @@ Complete reference for all React Email components. All examples use the Tailwind
 
 ## Available Components
 
-All components are imported from `@react-email/components`:
+All components are imported from `react-email`:
 
 - **Body** - A React component to wrap emails
 - **Button** - A link that is styled to look like a button
@@ -33,7 +33,7 @@ All components are imported from `@react-email/components`:
 The recommended way to style React Email components. Wrap your email content and use utility classes.
 
 ```tsx
-import { Tailwind, pixelBasedPreset, Html, Body, Container, Heading, Text, Button } from '@react-email/components';
+import { Tailwind, pixelBasedPreset, Html, Body, Container, Heading, Text, Button } from 'react-email';
 
 export default function Email() {
   return (
@@ -94,7 +94,7 @@ export default function Email() {
 Root wrapper for the email. Always use as the outermost component.
 
 ```tsx
-import { Html, Tailwind, pixelBasedPreset } from '@react-email/components';
+import { Html, Tailwind, pixelBasedPreset } from 'react-email';
 
 <Html lang="en" dir="ltr">
   <Tailwind config={{ presets: [pixelBasedPreset] }}>
@@ -112,7 +112,7 @@ import { Html, Tailwind, pixelBasedPreset } from '@react-email/components';
 Contains head components, related to the document such as style and meta elements. Place inside `<Tailwind>`.
 
 ```tsx
-import { Head } from '@react-email/components';
+import { Head } from 'react-email';
 
 <Head>
   <title>Email Title</title>
@@ -124,7 +124,7 @@ import { Head } from '@react-email/components';
 A React component to wrap emails.
 
 ```tsx
-import { Body } from '@react-email/components';
+import { Body } from 'react-email';
 
 <Body className="bg-gray-100 font-sans">
   {/* email content */}
@@ -136,7 +136,7 @@ import { Body } from '@react-email/components';
 A layout component that centers your content horizontally on a breaking point. Has a max-width constraint of `37.5em`.
 
 ```tsx
-import { Container } from '@react-email/components';
+import { Container } from 'react-email';
 
 <Container className="max-w-xl mx-auto p-5">
   {/* centered content */}
@@ -148,7 +148,7 @@ import { Container } from '@react-email/components';
 Display a section that can also be formatted using rows and columns.
 
 ```tsx
-import { Section } from '@react-email/components';
+import { Section } from 'react-email';
 
 <Section className="p-5 bg-white">
   {/* section content */}
@@ -160,7 +160,7 @@ import { Section } from '@react-email/components';
 Row displays content areas horizontally, Column displays content areas vertically. A Column needs to be used in combination with a Row component.
 
 ```tsx
-import { Section, Row, Column } from '@react-email/components';
+import { Section, Row, Column } from 'react-email';
 
 <Section>
   <Row>
@@ -186,7 +186,7 @@ import { Section, Row, Column } from '@react-email/components';
 A preview text that will be displayed in the inbox of the recipient.
 
 ```tsx
-import { Preview } from '@react-email/components';
+import { Preview } from 'react-email';
 
 <Preview>Welcome to our platform - Get started today!</Preview>
 ```
@@ -201,7 +201,7 @@ import { Preview } from '@react-email/components';
 A block of heading text (h1-h6).
 
 ```tsx
-import { Heading } from '@react-email/components';
+import { Heading } from 'react-email';
 
 <Heading as="h1" className="text-2xl font-bold text-gray-800 mb-4">
   Welcome to Acme
@@ -220,7 +220,7 @@ import { Heading } from '@react-email/components';
 A block of text separated by blank spaces.
 
 ```tsx
-import { Text } from '@react-email/components';
+import { Text } from 'react-email';
 
 <Text className="text-base leading-6 text-gray-800 my-4">
   Your paragraph content here.
@@ -232,7 +232,7 @@ import { Text } from '@react-email/components';
 A link that is styled to look like a button. Has workaround for padding issues in Outlook.
 
 ```tsx
-import { Button } from '@react-email/components';
+import { Button } from 'react-email';
 
 <Button
   href="https://example.com/verify"
@@ -257,7 +257,7 @@ import { Button } from '@react-email/components';
 A hyperlink to web pages, email addresses, or anything else a URL can address.
 
 ```tsx
-import { Link } from '@react-email/components';
+import { Link } from 'react-email';
 
 <Link href="https://example.com" target="_blank" className="text-blue-600 underline">
   Visit our website
@@ -273,7 +273,7 @@ import { Link } from '@react-email/components';
 Display an image in your email.
 
 ```tsx
-import { Img } from '@react-email/components';
+import { Img } from 'react-email';
 
 <Img
   src="https://example.com/logo.png"
@@ -301,7 +301,7 @@ import { Img } from '@react-email/components';
 Display a divider that separates content areas in your email.
 
 ```tsx
-import { Hr } from '@react-email/components';
+import { Hr } from 'react-email';
 
 <Hr className="border-solid border-gray-200 my-5" />
 ```
@@ -313,7 +313,7 @@ import { Hr } from '@react-email/components';
 Display code with a selected theme and regex highlighting using Prism.js.
 
 ```tsx
-import { CodeBlock, dracula } from '@react-email/components';
+import { CodeBlock, dracula } from 'react-email';
 
 const Email = () => {
   const code = `export default async (req, res) => {
@@ -343,7 +343,7 @@ const Email = () => {
 **Props:**
 - `code` (required) - The actual code to render in the code block. Just a plain string, with the proper indentation included
 - `language` (required) - The language under the supported languages defined in PrismLanguage (e.g., "javascript", "python", "typescript")
-- `theme` (required) - The theme to use for the code block (import from "@react-email/components": dracula, github, nord, etc.)
+- `theme` (required) - The theme to use for the code block (import from "react-email": dracula, github, nord, etc.)
 - `fontFamily` (optional) - The font family to use for the code block (e.g., "monospace")
 - `lineNumbers` (optional) - Whether or not to automatically include line numbers on the rendered code block (boolean, default: false)
 
@@ -356,7 +356,7 @@ const Email = () => {
 Display a predictable inline code HTML element that works on all email clients.
 
 ```tsx
-import { Text, CodeInline } from '@react-email/components';
+import { Text, CodeInline } from 'react-email';
 
 <Text className="text-base text-gray-800">
   Run <CodeInline className="bg-gray-100 px-1 rounded">npm install</CodeInline> to get started.
@@ -368,7 +368,7 @@ import { Text, CodeInline } from '@react-email/components';
 A Markdown component that converts markdown to valid react-email template code.
 
 ```tsx
-import { Html, Markdown } from '@react-email/components';
+import { Html, Markdown } from 'react-email';
 
 const Email = () => {
   return (
@@ -403,7 +403,7 @@ const Email = () => {
 A React Font component to set your fonts.
 
 ```tsx
-import { Head, Font } from '@react-email/components';
+import { Head, Font } from 'react-email';
 
 <Head>
   <Font

--- a/skills/react-email/references/I18N.md
+++ b/skills/react-email/references/I18N.md
@@ -82,7 +82,7 @@ import {
   Hr,
   Tailwind,
   pixelBasedPreset
-} from '@react-email/components';
+} from 'react-email';
 
 interface WelcomeEmailProps {
   name: string;
@@ -190,7 +190,7 @@ import {
   Button,
   Tailwind,
   pixelBasedPreset
-} from '@react-email/components';
+} from 'react-email';
 
 interface WelcomeEmailProps {
   name: string;
@@ -329,7 +329,7 @@ import {
   Button,
   Tailwind,
   pixelBasedPreset
-} from '@react-email/components';
+} from 'react-email';
 
 interface WelcomeEmailProps {
   name: string;
@@ -558,7 +558,7 @@ import {
   Hr,
   Tailwind,
   pixelBasedPreset
-} from '@react-email/components';
+} from 'react-email';
 
 interface OrderConfirmationProps {
   orderNumber: string;

--- a/skills/react-email/references/PATTERNS.md
+++ b/skills/react-email/references/PATTERNS.md
@@ -25,7 +25,7 @@ import {
   Hr,
   Tailwind,
   pixelBasedPreset
-} from '@react-email/components';
+} from 'react-email';
 
 interface PasswordResetProps {
   resetUrl: string;
@@ -95,7 +95,7 @@ import {
   Hr,
   Tailwind,
   pixelBasedPreset
-} from '@react-email/components';
+} from 'react-email';
 
 interface Product {
   name: string;
@@ -298,7 +298,7 @@ import {
   Link,
   Tailwind,
   pixelBasedPreset
-} from '@react-email/components';
+} from 'react-email';
 
 interface NotificationProps {
   title: string;
@@ -436,7 +436,7 @@ import {
   Link,
   Tailwind,
   pixelBasedPreset
-} from '@react-email/components';
+} from 'react-email';
 
 interface Article {
   title: string;
@@ -635,7 +635,7 @@ import {
   Hr,
   Tailwind,
   pixelBasedPreset
-} from '@react-email/components';
+} from 'react-email';
 
 interface TeamInvitationProps {
   inviterName: string;

--- a/skills/react-email/references/SENDING.md
+++ b/skills/react-email/references/SENDING.md
@@ -9,7 +9,7 @@ Important: Use verified domains in `from` addresses. Ask the user for the verifi
 When you have access to the Resend MCP tool:
 
 ```typescript
-import { render } from '@react-email/components';
+import { render } from 'react-email';
 import { WelcomeEmail } from './emails/welcome';
 
 // Render to HTML
@@ -79,7 +79,7 @@ await resend.emails.send({
 **Nodemailer:**
 
 ```tsx
-import { render } from '@react-email/components';
+import { render } from 'react-email';
 import nodemailer from 'nodemailer';
 
 const transporter = nodemailer.createTransport({
@@ -101,7 +101,7 @@ await transporter.sendMail({
 **SendGrid:**
 
 ```tsx
-import { render } from '@react-email/components';
+import { render } from 'react-email';
 import sgMail from '@sendgrid/mail';
 
 sgMail.setApiKey(process.env.SENDGRID_API_KEY);

--- a/skills/react-email/references/STYLING.md
+++ b/skills/react-email/references/STYLING.md
@@ -7,7 +7,7 @@ Comprehensive styling reference for React Email templates.
 Use the `Tailwind` component for styling if the project uses Tailwind CSS. Otherwise, use inline styles.
 
 ```tsx
-import { Tailwind, pixelBasedPreset } from '@react-email/components';
+import { Tailwind, pixelBasedPreset } from 'react-email';
 
 <Tailwind
   config={{
@@ -30,7 +30,7 @@ import { Tailwind, pixelBasedPreset } from '@react-email/components';
 Email clients don't support `rem` units. Always use `pixelBasedPreset` in your Tailwind configuration to convert rem-based utilities to pixels:
 
 ```tsx
-import { pixelBasedPreset } from '@react-email/components';
+import { pixelBasedPreset } from 'react-email';
 
 <Tailwind config={{ presets: [pixelBasedPreset] }}>
 ```
@@ -228,7 +228,7 @@ Create a centralized Tailwind config file that all email templates import. Using
 
 ```tsx
 // emails/tailwind.config.ts
-import { pixelBasedPreset, type TailwindConfig } from '@react-email/components';
+import { pixelBasedPreset, type TailwindConfig } from 'react-email';
 
 export default {
   presets: [pixelBasedPreset],


### PR DESCRIPTION
Reflects the breaking change in #3248  that unified all components into the react-email package. Updates all skill instructions, examples, tests, and reference docs. Also adds npm i react-email install step.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch all React Email imports to the unified `react-email` package to reflect the breaking change, and update the skill docs, examples, and tests accordingly. Adds an install step for `react-email` and bumps the skill version to 2.1.0.

- **Migration**
  - Install `react-email` (npm i react-email).
  - Replace all `@react-email/components` imports with `react-email` (including `pixelBasedPreset`, `render`, and all components).
  - Do not import from `@react-email/tailwind` or `@react-email/tailwind/presets`.

<sup>Written for commit 1e813d844b064aa82afcbd2180fba065770e167e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

