### PR TITLE
chore(editor): add docs links to editor examples page

### DIFF
--- a/apps/web/src/app/editor/examples/page.tsx
+++ b/apps/web/src/app/editor/examples/page.tsx
@@ -197,6 +197,7 @@ export default function EditorExamplesPage() {
             <a
               className="text-slate-11 transition-colors hover:text-slate-12"
               href="https://react.email/docs/editor/overview"
+              rel="noopener"
               target="_blank"
             >
               Overview
@@ -205,6 +206,7 @@ export default function EditorExamplesPage() {
             <a
               className="text-slate-11 transition-colors hover:text-slate-12"
               href="https://react.email/docs/editor/getting-started"
+              rel="noopener"
               target="_blank"
             >
               Getting Started
@@ -213,6 +215,7 @@ export default function EditorExamplesPage() {
             <a
               className="text-slate-11 transition-colors hover:text-slate-12"
               href="https://react.email/docs/editor/api-reference"
+              rel="noopener"
               target="_blank"
             >
               API Reference

--- a/apps/web/src/app/editor/examples/page.tsx
+++ b/apps/web/src/app/editor/examples/page.tsx
@@ -193,6 +193,31 @@ export default function EditorExamplesPage() {
             Interactive examples showing how to build email editors with
             @react-email/editor.
           </p>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+            <a
+              className="text-slate-11 transition-colors hover:text-slate-12"
+              href="https://react.email/docs/editor/overview"
+              target="_blank"
+            >
+              Overview
+            </a>
+            <span className="text-slate-6">·</span>
+            <a
+              className="text-slate-11 transition-colors hover:text-slate-12"
+              href="https://react.email/docs/editor/getting-started"
+              target="_blank"
+            >
+              Getting Started
+            </a>
+            <span className="text-slate-6">·</span>
+            <a
+              className="text-slate-11 transition-colors hover:text-slate-12"
+              href="https://react.email/docs/editor/api-reference"
+              target="_blank"
+            >
+              API Reference
+            </a>
+          </div>
         </div>
 
         <div className="flex flex-col gap-12 px-6 pb-10 md:px-8">


### PR DESCRIPTION
## Summary

- adds Overview, Getting Started, and API Reference doc links below the editor examples page description
- links open in a new tab and are styled consistently with the page

<img width="2478" height="1332" alt="CleanShot 2026-04-13 at 16 46 24@2x" src="https://github.com/user-attachments/assets/fac4ef57-1d84-4f94-8d12-a466bf703c40" />

## Testing

- Visit `/editor/examples` and verify three doc links appear below the description
- Confirm links open correct `react.email/docs/editor/*` URLs in a new tab
- Check hover styles apply correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added doc links on /editor/examples for the `@react-email/editor` Overview, Getting Started, and API Reference. Links open in a new tab, match hover styles, and use rel="noopener".

<sup>Written for commit 652ae9a2a76a8b258e7f0dce27d2061a0a015d96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

