### PR TITLE
feat(editor): add EmailEditor + Inspector docs and example

### DIFF
--- a/.changeset/email-editor-children-prop.md
+++ b/.changeset/email-editor-children-prop.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Add `children` prop to `EmailEditor` for composing UI like the Inspector sidebar inside the editor context

--- a/apps/docs/editor/api-reference/ui/inspector.mdx
+++ b/apps/docs/editor/api-reference/ui/inspector.mdx
@@ -50,6 +50,12 @@ export function MyEditor() {
 }
 ```
 
+<Tip>
+  If you use the one-line `EmailEditor` component, pass the inspector as a
+  child — no `EditorContext.Provider` needed. See the
+  [Inspector feature guide](/editor/features/inspector#using-with-emaileditor).
+</Tip>
+
 <ResponseField name="asChild" type="boolean" default="false">
   Render without the default `aside` wrapper and pass props to the child via
   Radix UI's [Slot](https://www.radix-ui.com/primitives/docs/utilities/slot).

--- a/apps/docs/editor/features/inspector.mdx
+++ b/apps/docs/editor/features/inspector.mdx
@@ -429,7 +429,7 @@ See the inspector in action with runnable examples:
   <Card title="Inspector — Fully Custom" icon="code" href="https://react.email/editor/examples/inspector-custom">
     Fully custom inspector UI built from render props.
   </Card>
-  <Card title="One-Line Editor — Inspector" icon="code" href="https://editor-examples.react.email/#one-line-editor-inspector">
+  <Card title="One-Line Editor — Inspector" icon="code" href="https://react.email/editor/examples/one-line-editor-inspector">
     Inspector sidebar with the one-line EmailEditor component.
   </Card>
 </CardGroup>

--- a/apps/docs/editor/features/inspector.mdx
+++ b/apps/docs/editor/features/inspector.mdx
@@ -69,14 +69,12 @@ export function MyEditor() {
         content="<h1>Hello</h1><p>Click any element to inspect it.</p>"
         className="flex-1 min-w-0 overflow-y-auto p-4"
       >
-        <aside className="w-60 shrink-0 border-l p-4 overflow-y-auto">
-          <Inspector.Root>
-            <Inspector.Breadcrumb />
-            <Inspector.Document />
-            <Inspector.Node />
-            <Inspector.Text />
-          </Inspector.Root>
-        </aside>
+        <Inspector.Root className="w-60 shrink-0 border-l p-4 overflow-y-auto">
+          <Inspector.Breadcrumb />
+          <Inspector.Document />
+          <Inspector.Node />
+          <Inspector.Text />
+        </Inspector.Root>
       </EmailEditor>
     </div>
   );

--- a/apps/docs/editor/features/inspector.mdx
+++ b/apps/docs/editor/features/inspector.mdx
@@ -54,6 +54,43 @@ button to edit, or select text to switch to text controls.
   render props, the default panels can also be styled using <br/> [CSS variables and `data-re-*` selectors](/editor/features/styling#inspector).
 </Tip>
 
+## Using with EmailEditor
+
+If you use the one-line [`EmailEditor`](/editor/api-reference/email-editor) component, pass the inspector as a child instead of setting up `EditorProvider` manually.
+
+```tsx
+import { EmailEditor } from '@react-email/editor';
+import { Inspector } from '@react-email/editor/ui';
+
+export function MyEditor() {
+  return (
+    <div className="flex" style={{ height: '600px' }}>
+      <EmailEditor
+        content="<h1>Hello</h1><p>Click any element to inspect it.</p>"
+        className="flex-1 min-w-0 overflow-y-auto p-4"
+      >
+        <aside className="w-60 shrink-0 border-l p-4 overflow-y-auto">
+          <Inspector.Root>
+            <Inspector.Breadcrumb />
+            <Inspector.Document />
+            <Inspector.Node />
+            <Inspector.Text />
+          </Inspector.Root>
+        </aside>
+      </EmailEditor>
+    </div>
+  );
+}
+```
+
+`EmailEditor` includes `EmailTheming` in its default extensions, so the
+[required extension](#required-extension) is already covered.
+
+<Tip>
+  Children of `EmailEditor` render inside the Tiptap `EditorProvider` as DOM
+  siblings of the editor content area, so flex layouts work naturally.
+</Tip>
+
 ## Required extension
 
 `Inspector.Root` requires the [EmailTheming](/editor/api-reference/theming-api)
@@ -391,5 +428,8 @@ See the inspector in action with runnable examples:
   </Card>
   <Card title="Inspector — Fully Custom" icon="code" href="https://react.email/editor/examples/inspector-custom">
     Fully custom inspector UI built from render props.
+  </Card>
+  <Card title="One-Line Editor — Inspector" icon="code" href="https://editor-examples.react.email/#one-line-editor-inspector">
+    Inspector sidebar with the one-line EmailEditor component.
   </Card>
 </CardGroup>

--- a/apps/docs/editor/features/inspector.mdx
+++ b/apps/docs/editor/features/inspector.mdx
@@ -56,7 +56,7 @@ button to edit, or select text to switch to text controls.
 
 ## Using with EmailEditor
 
-If you use the one-line [`EmailEditor`](/editor/api-reference/email-editor) component, pass the inspector as a child instead of setting up `EditorProvider` manually.
+If you use the one-line `EmailEditor` component, pass the inspector as a child instead of setting up `EditorProvider` manually.
 
 ```tsx
 import { EmailEditor } from '@react-email/editor';

--- a/apps/docs/editor/getting-started.mdx
+++ b/apps/docs/editor/getting-started.mdx
@@ -158,6 +158,9 @@ See these features in action with runnable examples:
   <Card title="One-Line Editor — Full Features" icon="code" href="https://react.email/editor/examples/one-line-editor-full">
     Theme toggle, HTML export, and JSON output.
   </Card>
+  <Card title="One-Line Editor — Inspector" icon="code" href="https://react.email/editor/examples/one-line-editor-inspector">
+    Add an inspector sidebar with zero manual setup.
+  </Card>
   <Card title="All Examples" icon="folder-open" href="https://react.email/editor/examples">
     Browse the complete set of interactive examples.
   </Card>

--- a/apps/web/src/app/editor/examples/one-line-editor-inspector/example.tsx
+++ b/apps/web/src/app/editor/examples/one-line-editor-inspector/example.tsx
@@ -35,14 +35,12 @@ export function OneLineEditorInspector() {
 
 function Sidebar() {
   return (
-    <aside className="w-60 shrink-0 border-l border-(--re-border) p-4 flex flex-col gap-4 overflow-y-auto text-xs">
-      <Inspector.Root>
-        <Breadcrumb />
-        <Inspector.Document />
-        <Inspector.Node />
-        <Inspector.Text />
-      </Inspector.Root>
-    </aside>
+    <Inspector.Root className="w-60 shrink-0 border-l border-(--re-border) p-4 flex flex-col gap-4 overflow-y-auto text-xs">
+      <Breadcrumb />
+      <Inspector.Document />
+      <Inspector.Node />
+      <Inspector.Text />
+    </Inspector.Root>
   );
 }
 

--- a/apps/web/src/app/editor/examples/one-line-editor-inspector/example.tsx
+++ b/apps/web/src/app/editor/examples/one-line-editor-inspector/example.tsx
@@ -2,7 +2,6 @@
 
 import { EmailEditor } from '@react-email/editor';
 import { Inspector } from '@react-email/editor/ui';
-import '@react-email/editor/styles/inspector.css';
 import { ExampleShell } from '../example-shell';
 
 const content = `

--- a/apps/web/src/app/editor/examples/one-line-editor-inspector/example.tsx
+++ b/apps/web/src/app/editor/examples/one-line-editor-inspector/example.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { EmailEditor } from '@react-email/editor';
+import { Inspector } from '@react-email/editor/ui';
+import '@react-email/editor/styles/inspector.css';
+import { ExampleShell } from '../example-shell';
+
+const content = `
+  <h1>Newsletter Preview</h1>
+  <p>Click any element to inspect it in the sidebar. Select text to see text controls, or click the background for document-level styles.</p>
+  <div class="align-left"><a class="node-button button" data-id="react-email-button" href="https://react.email">Read More</a></div>
+  <p>The inspector sidebar is rendered as a child of EmailEditor.</p>
+  <img src="https://placehold.co/600x200" alt="Placeholder" />
+`;
+
+export function OneLineEditorInspector() {
+  return (
+    <ExampleShell
+      title="One-Line Editor — Inspector"
+      description="Add an inspector sidebar alongside the one-line EmailEditor — no manual EditorProvider setup needed."
+    >
+      <div
+        className="flex flex-1 min-h-0 overflow-hidden -m-4 border-t border-(--re-border)"
+        style={{ height: '32rem' }}
+      >
+        <EmailEditor
+          content={content}
+          className="flex-1 min-w-0 overflow-y-auto p-4"
+        >
+          <Sidebar />
+        </EmailEditor>
+      </div>
+    </ExampleShell>
+  );
+}
+
+function Sidebar() {
+  return (
+    <aside className="w-60 shrink-0 border-l border-(--re-border) p-4 flex flex-col gap-4 overflow-y-auto text-xs">
+      <Inspector.Root>
+        <Breadcrumb />
+        <Inspector.Document />
+        <Inspector.Node />
+        <Inspector.Text />
+      </Inspector.Root>
+    </aside>
+  );
+}
+
+function Breadcrumb() {
+  return (
+    <nav>
+      <ol className="flex items-center gap-1 list-none m-0 p-0">
+        <Inspector.Breadcrumb>
+          {(segments) =>
+            segments.map((segment, i) => {
+              const label = segment.node?.nodeType ?? 'Layout';
+              return (
+                <li key={i} className="flex items-center gap-1">
+                  {i !== 0 && (
+                    <span className="text-(--re-text-muted)">/</span>
+                  )}
+                  <button
+                    type="button"
+                    className="bg-transparent border-0 cursor-pointer text-(--re-text) p-0 text-xs hover:underline"
+                    onClick={() => segment.focus()}
+                  >
+                    {label}
+                  </button>
+                </li>
+              );
+            })
+          }
+        </Inspector.Breadcrumb>
+      </ol>
+    </nav>
+  );
+}

--- a/apps/web/src/app/editor/examples/one-line-editor-inspector/example.tsx
+++ b/apps/web/src/app/editor/examples/one-line-editor-inspector/example.tsx
@@ -56,9 +56,7 @@ function Breadcrumb() {
               const label = segment.node?.nodeType ?? 'Layout';
               return (
                 <li key={i} className="flex items-center gap-1">
-                  {i !== 0 && (
-                    <span className="text-(--re-text-muted)">/</span>
-                  )}
+                  {i !== 0 && <span className="text-(--re-text-muted)">/</span>}
                   <button
                     type="button"
                     className="bg-transparent border-0 cursor-pointer text-(--re-text) p-0 text-xs hover:underline"

--- a/apps/web/src/app/editor/examples/one-line-editor-inspector/page.tsx
+++ b/apps/web/src/app/editor/examples/one-line-editor-inspector/page.tsx
@@ -4,8 +4,7 @@ import { OneLineEditorInspector as Example } from './example';
 
 export const metadata: Metadata = {
   title: 'One-Line Editor — Inspector — Editor Examples',
-  description:
-    'Add an inspector sidebar alongside the one-line EmailEditor.',
+  description: 'Add an inspector sidebar alongside the one-line EmailEditor.',
   alternates: { canonical: '/editor/examples/one-line-editor-inspector' },
 };
 

--- a/apps/web/src/app/editor/examples/one-line-editor-inspector/page.tsx
+++ b/apps/web/src/app/editor/examples/one-line-editor-inspector/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import { ExamplePageShell } from '../example-page-shell';
+import { OneLineEditorInspector as Example } from './example';
+
+export const metadata: Metadata = {
+  title: 'One-Line Editor — Inspector — Editor Examples',
+  description:
+    'Add an inspector sidebar alongside the one-line EmailEditor.',
+  alternates: { canonical: '/editor/examples/one-line-editor-inspector' },
+};
+
+export default function Page() {
+  return (
+    <ExamplePageShell
+      slug="one-line-editor-inspector"
+      title="One-Line Editor — Inspector"
+      docsUrl="https://react.email/docs/editor/features/inspector"
+    >
+      <Example />
+    </ExamplePageShell>
+  );
+}

--- a/apps/web/src/app/editor/examples/page.tsx
+++ b/apps/web/src/app/editor/examples/page.tsx
@@ -37,6 +37,14 @@ const sections: ExampleSection[] = [
         section: 'One-Line Editor',
         docsUrl: 'https://react.email/docs/editor/getting-started',
       },
+      {
+        slug: 'one-line-editor-inspector',
+        title: 'One-Line Editor — Inspector',
+        description:
+          'Add an inspector sidebar alongside the one-line EmailEditor — no manual EditorProvider setup needed.',
+        section: 'One-Line Editor',
+        docsUrl: 'https://react.email/docs/editor/features/inspector',
+      },
     ],
   },
   {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/editor",
-  "version": "0.0.0-experimental.49",
+  "version": "0.0.0-experimental.48",
   "description": "A rich text editor for editing and building email templates",
   "sideEffects": [
     "**/*.css"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/editor",
-  "version": "0.0.0-experimental.48",
+  "version": "0.0.0-experimental.49",
   "description": "A rich text editor for editing and building email templates",
   "sideEffects": [
     "**/*.css"

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -4,7 +4,7 @@ import {
   type UseEditorOptions,
   useCurrentEditor,
 } from '@tiptap/react';
-import { forwardRef, type Ref, useImperativeHandle, useMemo } from 'react';
+import { forwardRef, type Ref, useImperativeHandle, useMemo, type ReactNode } from 'react';
 import { createDropHandler } from '../core/create-drop-handler';
 import {
   createPasteHandler,
@@ -38,6 +38,7 @@ export interface EmailEditorProps {
   };
   extensions?: Extensions;
   className?: string;
+  children?: ReactNode;
 }
 
 function RefBridge({ editorRef }: { editorRef: Ref<EmailEditorRef> }) {
@@ -75,6 +76,7 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
       bubbleMenu,
       extensions: extensionsProp,
       className,
+      children,
     },
     ref,
   ) => {
@@ -125,6 +127,7 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
         <BubbleMenu.ButtonDefault />
         <BubbleMenu.ImageDefault />
         <SlashCommandRoot />
+        {children}
       </EditorProvider>
     );
   },

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -4,7 +4,13 @@ import {
   type UseEditorOptions,
   useCurrentEditor,
 } from '@tiptap/react';
-import { forwardRef, type Ref, useImperativeHandle, useMemo, type ReactNode } from 'react';
+import {
+  forwardRef,
+  type ReactNode,
+  type Ref,
+  useImperativeHandle,
+  useMemo,
+} from 'react';
 import { createDropHandler } from '../core/create-drop-handler';
 import {
   createPasteHandler,


### PR DESCRIPTION
## Summary

- Add `children` prop to `EmailEditor` so users can compose Inspector (or other UI) inside the editor context without dropping to manual `EditorProvider` setup
- Create `one-line-editor-inspector` example demonstrating the pattern
- Add "Using with EmailEditor" section to inspector feature docs, plus cross-references in getting-started and API reference pages

## Test plan

- [ ] `cd packages/editor && pnpm build` passes
- [ ] Visit `/editor/examples` — new card appears in "One-Line Editor" section
- [ ] Visit `/editor/examples/one-line-editor-inspector` — editor on left, inspector sidebar on right
- [ ] Click elements — inspector switches between Document/Node/Text panels
- [ ] Breadcrumb navigation works
- [ ] Docs dev server renders "Using with EmailEditor" section on inspector page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `children` prop to `EmailEditor` so you can render the Inspector (or any UI) inside the editor context. Also adds a one-line example and docs, removes a redundant `inspector.css` import, fixes a broken docs link, bumps `@react-email/editor` to `0.0.0-experimental.49`, and cleans up formatting/import order.

- **New Features**
  - `EmailEditor` now renders `children` inside the Tiptap `EditorProvider`, enabling an Inspector sidebar without custom providers.
  - New example: One-Line Editor — Inspector, plus examples index entry (uses `@react-email/editor` and `@react-email/editor/ui`).

- **Docs**
  - Inspector feature page adds a “Using with EmailEditor” section and an example link card; API reference includes a tip for `EmailEditor` usage.
  - Getting Started adds a card linking to the new example.

<sup>Written for commit 1ab4507c428c5a511f557e13c5ebf38c4072e19c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

