### PR TITLE
fix: remove editor-examples from changeset pre.json

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,6 @@
   "ignore": [
     "@benchmarks/preview-server",
     "@benchmarks/tailwind-component",
-    "editor-examples",
     "playground",
     "demo",
     "email-dev",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -9,7 +9,6 @@
     "@benchmarks/tailwind-component": "0.0.0",
     "create-email": "1.2.3",
     "@react-email/editor": "0.0.0-experimental.48",
-    "editor-examples": "0.0.0",
     "@react-email/preview-server": "5.2.10",
     "react-email": "5.2.10",
     "email-dev": "0.0.6",


### PR DESCRIPTION
## Summary
- Removed deleted `editor-examples` app from `.changeset/pre.json`
- This was causing the changeset version command to fail during the "version packages" workflow since the package no longer exists

## Test plan
- [ ] "Version Packages" PR workflow runs successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove deleted `editor-examples` from `.changeset/pre.json` and `.changeset/config.json` ignore list to fix the Version Packages workflow. Clears stale references that caused the changeset version step to fail.

<sup>Written for commit 5f0ec4f056faa357bcfeaedd0a984690374fc6c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

