### PR TITLE
feat(ci): use depot

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -6,7 +6,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   bump:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-32
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-32
     container:
       image: node:22
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-32
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   pin-dependencies-check:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-32
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -7,7 +7,7 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   preview-release:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-32
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/pull-request-title-check.yml
+++ b/.github/workflows/pull-request-title-check.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 jobs:
   pull-request-title-check:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-32
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
-    runs-on: depot-ubuntu-22.04-32
+    # npm trusted publishing (OIDC) is only supported on GitHub-hosted `ubuntu-latest` runners.
+    runs-on: ubuntu-latest
     permissions: 
       id-token: write
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-32
     permissions: 
       id-token: write
       contents: write

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-32
     steps:
       - name: Trigger sync on resend-skills
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-32
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     steps:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates GitHub Actions workflows from `ubuntu-latest` to Depot runners (`depot-ubuntu-22.04-32`), except `release.yml`, which must stay on GitHub-hosted Ubuntu for npm trusted publishing.

## Changes

- **8 workflow files** under `.github/workflows/` now use `runs-on: depot-ubuntu-22.04-32`.
- **`release.yml`** remains on `ubuntu-latest` with an inline comment: npm trusted publishing (OIDC) is only supported on GitHub-hosted `ubuntu-latest` runners.

No other CI logic was changed.

## Notes

- Requires the Depot GitHub App / runner labels to be enabled for this repository (same as other repos using this label).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0eab4b9-0eb9-44ca-9325-7e095239b633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0eab4b9-0eb9-44ca-9325-7e095239b633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved CI workflows to Depot runners `depot-ubuntu-22.04-32` for faster runs. Kept `release.yml` on `ubuntu-latest` to support npm trusted publishing (OIDC). No workflow logic changed.

- **Migration**
  - Ensure the Depot GitHub App is installed and the `depot-ubuntu-22.04-32` runner label is available on this repo.

<sup>Written for commit 322c771a987874b9021bf16caaae1c229d489f2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

