### PR TITLE
chore(ci): token specific to bump action

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 1
+          persist-credentials: false
       - run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: pnpm setup
         uses: pnpm/action-setup@738f428026a1f5a72398de22aeed83d859c4a660

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -28,4 +28,4 @@ jobs:
           version: pnpm run version
           title: "chore(root): version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -28,4 +28,4 @@ jobs:
           version: pnpm run version
           title: "chore(root): version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BUMP_PULL_REQUEST_TOKEN }}


### PR DESCRIPTION
As you can see from https://github.com/resend/react-email/pull/3257, the CI that's meant to run for pull requests doesn't run because the action was created by a bot. For security reasons GitHUb doesn't really run that CI for bot created PRs exactly.

The recommended fix for this that I've found is to use a very strictly scoped PAT for bump. This worries me slightly, but I believe it's safe because it's scoped to React Email and to read and write pull requests, and the bump workflow can only run for code in canary. Eventually we should make our own app to generate a token for it and then open the PR with that, but right now we don't have the time.

References:
- https://github.com/changesets/action/issues/70
- https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the bump workflow to use a dedicated `secrets.BUMP_PULL_REQUEST_TOKEN` and set `actions/checkout` with `persist-credentials: false` so version bump PRs are opened with the scoped token and follow-up workflows run. This avoids permission issues with `secrets.GITHUB_TOKEN` and bot-created PRs.

<sup>Written for commit e746b1568608b2c02a4d91480208f075970d1641. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



