### PR TITLE
chore(ci): revert token specific to bump action 

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 1
-          persist-credentials: false
       - run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: pnpm setup
         uses: pnpm/action-setup@738f428026a1f5a72398de22aeed83d859c4a660
@@ -29,4 +28,4 @@ jobs:
           version: pnpm run version
           title: "chore(root): version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.BUMP_PULL_REQUEST_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit 860544f13681404fc33df6da7b2eb94570cdf5d8.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the bump workflow to use `secrets.GITHUB_TOKEN` and default `actions/checkout` credentials, fixing token permission issues and simplifying CI secrets. Removes `persist-credentials: false` and replaces `secrets.BUMP_PULL_REQUEST_TOKEN` with `secrets.GITHUB_TOKEN`.

<sup>Written for commit 6f7128ed1c8403287b783a424183e8dc446fd162. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

