### PR TITLE
fix: drop line-height from default inbox email styles

### DIFF
--- a/.changeset/public-corners-carry.md
+++ b/.changeset/public-corners-carry.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+remove line height from default inbox styles

--- a/packages/editor/src/plugins/email-theming/themes.ts
+++ b/packages/editor/src/plugins/email-theming/themes.ts
@@ -770,7 +770,6 @@ export const INBOX_EMAIL_DEFAULTS: Partial<ResetTheme> = {
     fontFamily:
       "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif",
     fontSize: `${DEFAULT_INBOX_FONT_SIZE_PX}px`,
-    lineHeight: '155%',
   },
   container: {
     width: 600,


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the default line-height from the inbox email base styles in `@react-email/editor` to let clients control typography and avoid inconsistent text spacing across email clients.

<sup>Written for commit e2f4a83eed5f18c5c124fcf2c2da733904ed6a36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

