### PR TITLE
chore(docs): install editor as canary not experimental

### DIFF
--- a/apps/docs/snippets/editor-install.mdx
+++ b/apps/docs/snippets/editor-install.mdx
@@ -1,19 +1,19 @@
 <CodeGroup>
 
 ```sh npm
-npm install @react-email/editor@experimental
+npm install @react-email/editor@canary
 ```
 
 ```sh yarn
-yarn add @react-email/editor@experimental
+yarn add @react-email/editor@canary
 ```
 
 ```sh pnpm
-pnpm add @react-email/editor@experimental
+pnpm add @react-email/editor@canary
 ```
 
 ```sh bun
-bun add @react-email/editor@experimental
+bun add @react-email/editor@canary
 ```
 
 </CodeGroup>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update installation docs to use the `@react-email/editor@canary` tag instead of `@experimental` across npm, yarn, pnpm, and bun. This aligns the instructions with the current release channel and avoids confusion.

<sup>Written for commit 176526d9280470a11072cbffcd1da10015939e47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

