### PR TITLE
feat(docs): editor focus scope API docs

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -170,6 +170,8 @@
                 "icon": "window",
                 "pages": [
                   "editor/api-reference/ui/bubble-menu",
+                  "editor/api-reference/ui/editor-focus-scope",
+                  "editor/api-reference/ui/editor-focus-scope-provider",
                   "editor/api-reference/ui/inspector",
                   "editor/api-reference/ui/slash-command"
                 ]

--- a/apps/docs/editor/api-reference/ui/editor-focus-scope-provider.mdx
+++ b/apps/docs/editor/api-reference/ui/editor-focus-scope-provider.mdx
@@ -1,0 +1,81 @@
+---
+title: "EditorFocusScopeProvider"
+sidebarTitle: "EditorFocusScopeProvider"
+description: "Provide editor focus tracking across registered focus scopes."
+icon: "panel-right-open"
+---
+
+Everything is accessed through a single import:
+
+```tsx
+import { EditorFocusScopeProvider } from '@react-email/editor/ui';
+```
+
+Wrap your editor UI with `EditorFocusScopeProvider` when you need focus-aware
+portals outside the built-in Inspector. The provider tracks registered scopes
+from [EditorFocusScope](/editor/api-reference/ui/editor-focus-scope) and keeps
+the editor's focus and blur behavior in sync across them.
+
+`EditorFocusScopeProvider` must be rendered inside the current editor context so
+it can access the active editor instance.
+
+<Tip>
+  `Inspector.Root` already renders `EditorFocusScopeProvider` and
+  [EditorFocusScope](/editor/api-reference/ui/editor-focus-scope) by default,
+  so the Inspector handles the editor's focus idiomatically and reliably. If
+  you are only using the Inspector, you usually do not need to render this
+  provider manually.
+</Tip>
+
+## Example
+
+```tsx
+import {
+  EditorFocusScope,
+  EditorFocusScopeProvider,
+} from '@react-email/editor/ui';
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react';
+import * as Popover from '@radix-ui/react-popover';
+
+export function MyEditor() {
+  const editor = useEditor({
+    extensions,
+    content,
+  });
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorFocusScopeProvider clearSelectionOnBlur={false}>
+        <EditorContent editor={editor} />
+
+        <Popover.Root>
+          <Popover.Trigger type="button">Theme presets</Popover.Trigger>
+
+          <Popover.Portal>
+            <EditorFocusScope>
+              <Popover.Content sideOffset={8}>
+                <button type="button">Apply preset</button>
+              </Popover.Content>
+            </EditorFocusScope>
+          </Popover.Portal>
+        </Popover.Root>
+      </EditorFocusScopeProvider>
+    </EditorContext.Provider>
+  );
+}
+```
+
+Use [EditorFocusScope](/editor/api-reference/ui/editor-focus-scope) for each
+portaled surface that should still count as being inside the editor UI.
+
+## Props
+
+<ResponseField name="children" type="ReactNode">
+  The editor UI subtree that should share focus tracking.
+</ResponseField>
+
+<ResponseField name="clearSelectionOnBlur" type="boolean" default="true">
+  When focus leaves every registered scope, clear the current selection as part
+  of blur handling. Set this to `false` if you want to preserve the selection
+  when the editor truly loses focus.
+</ResponseField>

--- a/apps/docs/editor/api-reference/ui/editor-focus-scope-provider.mdx
+++ b/apps/docs/editor/api-reference/ui/editor-focus-scope-provider.mdx
@@ -21,7 +21,7 @@ it can access the active editor instance.
 
 <Tip>
   `Inspector.Root` itself uses the
-  [EditorFocusScope](/editor/api-reference/ui/editor-focus-scope)by default, so
+  [EditorFocusScope](/editor/api-reference/ui/editor-focus-scope) by default, so
   the Inspector handles the editor's focus idiomatically and reliably. If you
   are only using the Inspector, you usually do not need to render this provider
   manually.

--- a/apps/docs/editor/api-reference/ui/editor-focus-scope-provider.mdx
+++ b/apps/docs/editor/api-reference/ui/editor-focus-scope-provider.mdx
@@ -20,11 +20,11 @@ the editor's focus and blur behavior in sync across them.
 it can access the active editor instance.
 
 <Tip>
-  `Inspector.Root` already renders `EditorFocusScopeProvider` and
-  [EditorFocusScope](/editor/api-reference/ui/editor-focus-scope) by default,
-  so the Inspector handles the editor's focus idiomatically and reliably. If
-  you are only using the Inspector, you usually do not need to render this
-  provider manually.
+  `Inspector.Root` itself uses the
+  [EditorFocusScope](/editor/api-reference/ui/editor-focus-scope)by default, so
+  the Inspector handles the editor's focus idiomatically and reliably. If you
+  are only using the Inspector, you usually do not need to render this provider
+  manually.
 </Tip>
 
 ## Example

--- a/apps/docs/editor/api-reference/ui/editor-focus-scope.mdx
+++ b/apps/docs/editor/api-reference/ui/editor-focus-scope.mdx
@@ -1,0 +1,79 @@
+---
+title: "EditorFocusScope"
+sidebarTitle: "EditorFocusScope"
+description: "Register portaled UI as part of the editor's focus scope."
+icon: "crosshair"
+---
+
+Everything is accessed through a single import:
+
+```tsx
+import { EditorFocusScope } from '@react-email/editor/ui';
+```
+
+Use `EditorFocusScope` around portaled UI like Radix `Select.Content`,
+`Popover.Content`, or dialog content so moving focus into that portal is still
+treated as staying inside the editor UI.
+
+`EditorFocusScope` must be used inside
+[EditorFocusScopeProvider](/editor/api-reference/ui/editor-focus-scope-provider),
+which tracks registered focus scopes and updates the editor's focus state for
+them.
+
+<Tip>
+  `Inspector.Root` already renders
+  [EditorFocusScopeProvider](/editor/api-reference/ui/editor-focus-scope-provider)
+  and wraps itself in `EditorFocusScope` by default, so the Inspector handles
+  the editor's focus idiomatically and reliably. Inside a custom inspector, you
+  usually only add `EditorFocusScope` around extra portaled content.
+</Tip>
+
+## Example
+
+```tsx
+import { EditorFocusScope, Inspector } from '@react-email/editor/ui';
+import * as Select from '@radix-ui/react-select';
+
+<Inspector.Node>
+  {({ getAttr, setAttr }) => (
+    <Select.Root
+      value={String(getAttr('alignment') ?? 'left')}
+      onValueChange={(value) => setAttr('alignment', value)}
+    >
+      <Select.Trigger>
+        <Select.Value />
+      </Select.Trigger>
+
+      <Select.Portal>
+        <EditorFocusScope>
+          <Select.Content>
+            <Select.Viewport>
+              <Select.Item value="left">
+                <Select.ItemText>Left</Select.ItemText>
+              </Select.Item>
+              <Select.Item value="center">
+                <Select.ItemText>Center</Select.ItemText>
+              </Select.Item>
+              <Select.Item value="right">
+                <Select.ItemText>Right</Select.ItemText>
+              </Select.Item>
+            </Select.Viewport>
+          </Select.Content>
+        </EditorFocusScope>
+      </Select.Portal>
+    </Select.Root>
+  )}
+</Inspector.Node>
+```
+
+If you are building a focus-aware editor shell outside `Inspector.Root`, wrap
+the editor with
+[EditorFocusScopeProvider](/editor/api-reference/ui/editor-focus-scope-provider)
+and then use `EditorFocusScope` for each portaled surface.
+
+## Props
+
+<ResponseField name="children" type="ReactNode">
+  The element or subtree to register as an additional editor focus scope. Wrap
+  the portaled container that receives focus.
+</ResponseField>

--- a/apps/docs/editor/api-reference/ui/inspector.mdx
+++ b/apps/docs/editor/api-reference/ui/inspector.mdx
@@ -60,6 +60,16 @@ export function MyEditor() {
   [Inspector feature guide](/editor/features/inspector#using-with-emaileditor).
 </Tip>
 
+<Tip>
+  `Inspector.Root` already renders
+  [EditorFocusScopeProvider](/editor/api-reference/ui/editor-focus-scope-provider)
+  and wraps itself in
+  [EditorFocusScope](/editor/api-reference/ui/editor-focus-scope) by default,
+  so the Inspector handles the editor's focus idiomatically and reliably. Add
+  `EditorFocusScope` yourself only when custom inspector controls render
+  additional portaled content.
+</Tip>
+
 <ResponseField name="asChild" type="boolean" default="false">
   Render without the default `aside` wrapper and pass props to the child via
   Radix UI's [Slot](https://www.radix-ui.com/primitives/docs/utilities/slot).

--- a/apps/docs/editor/features/inspector.mdx
+++ b/apps/docs/editor/features/inspector.mdx
@@ -342,8 +342,9 @@ dropdown content, moving focus into that portal can make the editor think it
 blurred. That can switch the active inspector target or clear the current text
 selection.
 
-Wrap the portaled content with `EditorFocusScope` so focus inside the portal is
-still treated as part of the editor UI.
+Wrap the portaled content with
+[`EditorFocusScope`](/editor/api-reference/ui/editor-focus-scope) so focus
+inside the portal is still treated as part of the editor UI.
 
 ```tsx
 import { EditorFocusScope, Inspector } from '@react-email/editor/ui';
@@ -381,10 +382,13 @@ import * as Select from '@radix-ui/react-select';
 </Inspector.Node>
 ```
 
-`Inspector.Root` already includes the required focus-scope provider, so inside
-a custom inspector you only need to add `EditorFocusScope` around the portaled
-content. The same pattern works for other portaled Radix components, not just
-`Select`.
+`Inspector.Root` already includes
+[`EditorFocusScopeProvider`](/editor/api-reference/ui/editor-focus-scope-provider),
+and it uses both focus-scope components by default to handle the editor's focus
+idiomatically and reliably. Inside a custom inspector you usually only need to
+add [`EditorFocusScope`](/editor/api-reference/ui/editor-focus-scope) around
+the portaled content. The same pattern works for other portaled Radix
+components, not just `Select`.
 
 ## Reusing built-in sections
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add standalone API reference pages for `EditorFocusScope` and `EditorFocusScopeProvider`
- document that `Inspector.Root` uses these focus-scope components by default to handle editor focus idiomatically and reliably
- link the two focus-scope docs to each other and register them in the docs navigation

## Testing
- `python3` script to validate the docs navigation entry and required cross-links/phrasing in the updated MDX files
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0A9HFCVA13/p1776167914853519?thread_ts=1776167914.853519&cid=C0A9HFCVA13)

<div><a href="https://cursor.com/agents/bc-b7bc1625-3031-5f4a-9d90-0ffa560da800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7bc1625-3031-5f4a-9d90-0ffa560da800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds API reference pages for `EditorFocusScope` and `EditorFocusScopeProvider` in `@react-email/editor/ui`, and clarifies the Inspector’s default focus-scope behavior for portaled UI.

- **New Features**
  - New API pages with examples and props; document `clearSelectionOnBlur` default (`true`) and that the provider must be inside the editor context.
  - Updated `Inspector` API and feature docs with a clear Tip that `Inspector.Root` renders `EditorFocusScopeProvider` and wraps itself in `EditorFocusScope` by default; advise adding `EditorFocusScope` only for extra portaled content; added cross-links, registered pages in navigation, and fixed minor typos.

<sup>Written for commit 8a1efec88293115aec2e6c93437f2dad7ff04469. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

