### PR TITLE
chore(ci): use the right size for depot runners

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -6,7 +6,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   bump:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: depot-ubuntu-22.04-2
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   e2e:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: depot-ubuntu-22.04-8
     container:
       image: node:22
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   lint:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   pin-dependencies-check:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -7,7 +7,7 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   preview-release:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: depot-ubuntu-22.04-8
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/pull-request-title-check.yml
+++ b/.github/workflows/pull-request-title-check.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 jobs:
   pull-request-title-check:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: depot-ubuntu-22.04-2
     steps:
       - name: Trigger sync on resend-skills
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   tests:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: depot-ubuntu-22.04-8
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Right-sized Depot runners in GitHub Actions to match job needs and reduce cost. Light jobs use 2-core runners; heavier jobs use 8-core runners for stable performance.

- **Refactors**
  - Light jobs to `depot-ubuntu-22.04-2`: lint, pin-dependencies-check, pull-request-title-check, bump, sync-skills.
  - Heavier jobs to `depot-ubuntu-22.04-8`: tests, e2e, preview-release.

<sup>Written for commit 025d87bb4d615d3e5e6d569ee272e18eea3ea626. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

