### PR TITLE
chore(docs): backfill the changelog

### DIFF
--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,22 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## March 17, 2026
+
+**React Email 5.2.10**
+**Preview Server 5.2.10**
+
+- fix fragment prop usage warnings
+
+**Tailwind 2.0.6**
+
+- allow for any peer version on body, button, code-block, code-inline, container, heading, hr, img, link, preview, text
+
+**Components 1.0.10**
+
+- Updated dependencies
+    - @react-email/tailwind@2.0.6
+
 ## March 11, 2026
 
 **Body 0.3.0**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,13 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## February 5, 2026
+
+**React Email 5.2.7**
+**Preview Server 5.2.7**
+
+- fix default imports of node modules breaking
+
 ## February 4, 2026
 
 **React Email 5.2.6**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,135 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## December 29, 2025
+
+**React Email 5.1.1**
+**Preview Server 5.1.1**
+
+- remove use of devEngines which npm detects
+
+**Render 2.0.1**
+
+- add fallback for m.default when importing react-dom
+- remove use of devEngines which npm detects
+
+**Tailwind 2.0.3**
+
+- remove use of devEngines which npm detects
+- Updated dependencies
+    - @react-email/code-inline@0.0.6
+    - @react-email/code-block@0.2.1
+    - @react-email/container@0.0.16
+    - @react-email/heading@0.0.16
+    - @react-email/preview@0.0.14
+    - @react-email/button@0.2.1
+    - @react-email/body@0.2.1
+    - @react-email/link@0.0.13
+    - @react-email/text@0.1.6
+    - @react-email/img@0.0.12
+    - @react-email/hr@0.0.12
+
+**Components 1.0.3**
+
+- remove use of devEngines which npm detects
+- Updated dependencies
+    - @react-email/render@2.0.1
+    - @react-email/code-inline@0.0.6
+    - @react-email/code-block@0.2.1
+    - @react-email/container@0.0.16
+    - @react-email/markdown@0.0.18
+    - @react-email/tailwind@2.0.3
+    - @react-email/heading@0.0.16
+    - @react-email/preview@0.0.14
+    - @react-email/section@0.0.17
+    - @react-email/button@0.2.1
+    - @react-email/column@0.0.14
+    - @react-email/body@0.2.1
+    - @react-email/font@0.0.10
+    - @react-email/head@0.0.13
+    - @react-email/html@0.0.12
+    - @react-email/link@0.0.13
+    - @react-email/text@0.1.6
+    - @react-email/img@0.0.12
+    - @react-email/row@0.0.13
+    - @react-email/hr@0.0.12
+
+**Create Email 1.2.3**
+
+- remove use of devEngines which npm detects
+
+**Markdown 0.0.18**
+
+- remove use of devEngines which npm detects
+
+**Section 0.0.17**
+
+- remove use of devEngines which npm detects
+
+**Heading 0.0.16**
+
+- remove use of devEngines which npm detects
+
+**Container 0.0.16**
+
+- remove use of devEngines which npm detects
+
+**Preview 0.0.14**
+
+- remove use of devEngines which npm detects
+
+**Column 0.0.14**
+
+- remove use of devEngines which npm detects
+
+**Link 0.0.13**
+
+- remove use of devEngines which npm detects
+
+**Head 0.0.13**
+
+- remove use of devEngines which npm detects
+
+**Row 0.0.13**
+
+- remove use of devEngines which npm detects
+
+**Html 0.0.12**
+
+- remove use of devEngines which npm detects
+
+**Img 0.0.12**
+
+- remove use of devEngines which npm detects
+
+**Hr 0.0.12**
+
+- remove use of devEngines which npm detects
+
+**Text 0.1.6**
+
+- remove use of devEngines which npm detects
+
+**Font 0.0.10**
+
+- remove use of devEngines which npm detects
+
+**Code Inline 0.0.6**
+
+- remove use of devEngines which npm detects
+
+**Code Block 0.2.1**
+
+- remove use of devEngines which npm detects
+
+**Button 0.2.1**
+
+- remove use of devEngines which npm detects
+
+**Body 0.2.1**
+
+- remove use of devEngines which npm detects
+
 ## December 18, 2025
 
 **React Email 5.1.0**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,17 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## January 20, 2026
+
+**Render 2.0.4**
+
+- fixed new ErrorBoundary breaking rendering in server components
+
+**Components 1.0.6**
+
+- Updated dependencies
+    - @react-email/render@2.0.4
+
 ## January 19, 2026
 
 **Render 2.0.3**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,23 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## December 18, 2025
+
+**React Email 5.1.0**
+**Preview Server 5.1.0**
+
+- use turbo for `email build`
+- buffer logs written to console.log, info, warn, error until spinner is done
+
+**Tailwind 2.0.2**
+
+- update tailwindcss, fixing camelCased colors not working
+
+**Components 1.0.2**
+
+- Updated dependencies
+    - @react-email/tailwind@2.0.2
+
 ## December 12, 2025
 
 **React Email 5.0.8**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,14 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## November 11, 2025
+
+**React Email 5.0.2**
+**Preview Server 5.0.2**
+
+- fix sidebar misalignment with the topbar
+- fix scrolling not working on email frame right after resizing
+
 ## November 7, 2025
 
 **React Email 5.0.0**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,13 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## December 12, 2025
+
+**React Email 5.0.8**
+**Preview Server 5.0.8**
+
+- add better feedback for when test sending is rate limited
+
 ## December 10, 2025
 
 **React Email 5.0.7**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,13 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## November 13, 2025
+
+**React Email 5.0.4**
+**Preview Server 5.0.4**
+
+- fix file names and extensions not being used in download
+
 ## November 12, 2025
 
 **React Email 5.0.3**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,13 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## February 27, 2026
+
+**React Email 5.2.9**
+**Preview Server 5.2.9**
+
+- manually determine esbuild binary path to avoid forcing a host version
+
 ## February 18, 2026
 
 **Tailwind 2.0.5**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,16 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## January 13, 2026
+
+**React Email 5.2.3**
+
+- `email build` always failing
+
+**Preview Server 5.2.3**
+
+- fix `email dev` not working
+
 ## January 12, 2026
 
 **React Email 5.2.2**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,17 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## April 9, 2026
+
+**Render 2.0.6**
+
+- await stream.allReady before reading renderToReadableStream output
+
+**Components 1.0.12**
+
+- Updated dependencies
+    - @react-email/render@2.0.6
+
 ## March 31, 2026
 
 **Tailwind 2.0.7**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,14 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## December 10, 2025
+
+**React Email 5.0.7**
+**Preview Server 5.0.7**
+
+- fixed broken links to html code view tab
+- use tailwindcss v4 in the UI
+
 ## December 7, 2025
 
 **React Email 5.0.6**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,22 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## March 31, 2026
+
+**Tailwind 2.0.7**
+
+- use unpinned version for tailwindcss again
+
+**Render 2.0.5**
+
+- fix process crashes in client errors
+
+**Components 1.0.11**
+
+- Updated dependencies
+    - @react-email/tailwind@2.0.7
+    - @react-email/render@2.0.5
+
 ## March 17, 2026
 
 **React Email 5.2.10**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,54 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## January 7, 2026
+
+**React Email 5.2.1**
+**Preview Server 5.2.1**
+
+- fix toolbar loading spinner in the opposite direction
+- fix hot reloading on Windows
+
+**React Email 5.2.0**
+
+- increase timeout to 10 minutes by default, disable build workers
+
+**Preview Server 5.2.0**
+
+- bundle emails for preview to ESM
+- fix property access on null during dark mode inversion
+- fix compatibility checking for styles nested in other objects
+- fix instanceof not working with regexes
+
+**Render 2.0.2**
+
+- fix custom selectors overwriting the ones we defined
+- fix pipeable stream errors not being handled
+
+**Components 1.0.4**
+
+- Updated dependencies
+    - @react-email/render@2.0.2
+    - @react-email/body@0.2.1
+    - @react-email/button@0.2.1
+    - @react-email/code-block@0.2.1
+    - @react-email/code-inline@0.0.6
+    - @react-email/column@0.0.14
+    - @react-email/container@0.0.16
+    - @react-email/font@0.0.10
+    - @react-email/head@0.0.13
+    - @react-email/heading@0.0.16
+    - @react-email/hr@0.0.12
+    - @react-email/html@0.0.12
+    - @react-email/img@0.0.12
+    - @react-email/link@0.0.13
+    - @react-email/markdown@0.0.18
+    - @react-email/preview@0.0.14
+    - @react-email/row@0.0.13
+    - @react-email/section@0.0.17
+    - @react-email/tailwind@2.0.3
+    - @react-email/text@0.1.6
+
 ## December 29, 2025
 
 **React Email 5.1.1**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,18 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## January 14, 2026
+
+**React Email 5.2.5**
+**Preview Server 5.2.5**
+
+- revert changes to fix compatibility with alpine
+
+**React Email 5.2.4**
+**Preview Server 5.2.4**
+
+- fix support for alpine
+
 ## January 13, 2026
 
 **React Email 5.2.3**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,26 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## February 4, 2026
+
+**React Email 5.2.6**
+
+- fix RESEND_API_KEY being overwritten in email preview
+
+**Preview Server 5.2.6**
+
+- improve error messages for when an email template is missing
+- fix RESEND_API_KEY being overwritten in email preview
+
+**Tailwind 2.0.4**
+
+- fix non-inlined styles getting html entities in React 18
+
+**Components 1.0.7**
+
+- Updated dependencies
+    - @react-email/tailwind@2.0.4
+
 ## January 20, 2026
 
 **Render 2.0.4**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,23 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## November 12, 2025
+
+**React Email 5.0.3**
+**Preview Server 5.0.3**
+
+- move most dependencies to devDependencies
+- fix unwanted dependency installation when typescript's not installed
+
+**Tailwind 2.0.1**
+
+- unpin tailwindcss to avoid duplicate dependencies
+
+**Components 1.0.1**
+
+- Updated dependencies
+    - @react-email/tailwind@2.0.1
+
 ## November 11, 2025
 
 **React Email 5.0.2**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,13 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## February 6, 2026
+
+**React Email 5.2.8**
+**Preview Server 5.2.8**
+
+- update to latest Next.js
+
 ## February 5, 2026
 
 **React Email 5.2.7**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,14 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## December 7, 2025
+
+**React Email 5.0.6**
+**Preview Server 5.0.6**
+
+- add missing favicon
+- fix multiple lockfile warning during email build
+
 ## November 21, 2025
 
 **React Email 5.0.5**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,13 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## November 21, 2025
+
+**React Email 5.0.5**
+**Preview Server 5.0.5**
+
+- fixed broken links to React lines of code in the toolbar
+
 ## November 13, 2025
 
 **React Email 5.0.4**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,17 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## March 11, 2026
+
+**Body 0.3.0**
+
+- reset padding properties in `<body>` tag when there's any user defined padding properties
+
+**Components 1.0.9**
+
+- Updated dependencies
+    - @react-email/body@0.3.0
+
 ## February 27, 2026
 
 **React Email 5.2.9**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,17 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## January 19, 2026
+
+**Render 2.0.3**
+
+- fixed client side rendering fallbacks
+
+**Components 1.0.5**
+
+- Updated dependencies
+    - @react-email/render@2.0.3
+
 ## January 14, 2026
 
 **React Email 5.2.5**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,13 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## January 12, 2026
+
+**React Email 5.2.2**
+**Preview Server 5.2.2**
+
+- fix intermittent (void 0) is not a function errors
+
 ## January 7, 2026
 
 **React Email 5.2.1**

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,18 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## February 18, 2026
+
+**Tailwind 2.0.5**
+
+- fix mixed pseudo selectors not being split
+- enhance CSS rule extraction and inline style handling
+
+**Components 1.0.8**
+
+- Updated dependencies
+    - @react-email/tailwind@2.0.5
+
 ## February 6, 2026
 
 **React Email 5.2.8**

--- a/scripts/backfill-changelog-entries.mts
+++ b/scripts/backfill-changelog-entries.mts
@@ -82,7 +82,7 @@ Extract the meaningful changes from each release body and rewrite the entry to m
 
 ### Grouping packages with the same changes
 
-When React Email and Preview Server (or any packages) share the same version number, and maybe even changes,
+When React Email and Preview Server (or any packages) share the same version number and same changes,
 stack their bold headings together with a single shared bullet list:
 
 **React Email 4.3.0**
@@ -145,7 +145,7 @@ Use indented sub-items under an "Updated dependencies" bullet:
 - Strip conventional commit scopes (e.g. "fix(render): description" → "fix description")
 - Strip "by @author in https://..." suffixes
 - Strip "**Full Changelog**" links
-- React Email and Preview Server always come in pairs — if only one is present, add the other with the same version and changes
+- React Email and Preview Server always come in pairs — if only one is present, add the other with the same version and, if the other was not present, also changes
 - Keep bullet points concise, lowercase start unless proper noun
 - Do NOT invent changes, only rephrase or reorder what is given
 - Do NOT add migration guide links unless one was in the raw entry

--- a/scripts/backfill-changelog-entries.mts
+++ b/scripts/backfill-changelog-entries.mts
@@ -82,7 +82,7 @@ Extract the meaningful changes from each release body and rewrite the entry to m
 
 ### Grouping packages with the same changes
 
-When React Email and Preview Server (or any packages) share the same version number and same changes,
+When React Email and Preview Server (or any packages) share the same version number, and maybe even changes,
 stack their bold headings together with a single shared bullet list:
 
 **React Email 4.3.0**
@@ -145,6 +145,7 @@ Use indented sub-items under an "Updated dependencies" bullet:
 - Strip conventional commit scopes (e.g. "fix(render): description" → "fix description")
 - Strip "by @author in https://..." suffixes
 - Strip "**Full Changelog**" links
+- React Email and Preview Server always come in pairs — if only one is present, add the other with the same version and changes
 - Keep bullet points concise, lowercase start unless proper noun
 - Do NOT invent changes, only rephrase or reorder what is given
 - Do NOT add migration guide links unless one was in the raw entry

--- a/scripts/backfill-changelog-entries.mts
+++ b/scripts/backfill-changelog-entries.mts
@@ -8,7 +8,6 @@ const execFile = promisify(execFileCb);
 
 const REPO_OWNER = 'resend';
 const REPO_NAME = 'react-email';
-const CUTOFF = new Date('2025-11-08T00:00:00Z');
 
 const CHANGELOG_PATH = path.resolve(
   import.meta.dirname,
@@ -20,6 +19,21 @@ if (!token) {
   console.error('Set GITHUB_TOKEN env var.');
   process.exit(1);
 }
+
+let sinceDate: string | undefined;
+const args = process.argv.slice(2);
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--since' && args[i + 1]) {
+    sinceDate = args[++i];
+  }
+}
+
+if (!sinceDate) {
+  console.error('Missing --since flag. Usage: --since YYYY-MM-DD');
+  process.exit(1);
+}
+
+const CUTOFF = new Date(`${sinceDate}T00:00:00Z`);
 
 function toDisplayName(packageName: string): string {
   const name = packageName.replace('@react-email/', '');
@@ -251,7 +265,7 @@ while (!done) {
 }
 
 if (byDate.size === 0) {
-  console.error('No releases found after November 7, 2025.');
+  console.error(`No releases found since ${sinceDate}.`);
   process.exit(0);
 }
 

--- a/scripts/backfill-changelog-entries.mts
+++ b/scripts/backfill-changelog-entries.mts
@@ -43,29 +43,6 @@ function toDisplayName(packageName: string): string {
     .join(' ');
 }
 
-function extractChanges(body: string): string[] {
-  const lines = body.split('\n');
-  const changes: string[] = [];
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-
-    if (/^-\s+/.test(trimmed)) {
-      const text = trimmed.replace(/^-\s+/, '').trim();
-      if (text.length > 0) {
-        changes.push(text);
-      }
-    } else if (/^\s+-\s+/.test(line) && changes.length > 0) {
-      const text = line.replace(/^\s+-\s+/, '').trim();
-      if (text.length > 0) {
-        changes.push(`    - ${text}`);
-      }
-    }
-  }
-
-  return changes;
-}
-
 function toDateKey(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
@@ -80,30 +57,26 @@ function formatDateHeading(dateKey: string): string {
   });
 }
 
+interface ReleaseEntry {
+  displayName: string;
+  version: string;
+  body: string;
+}
+
 function buildRawEntry(dateKey: string, entries: ReleaseEntry[]): string {
   const lines: string[] = [`## ${formatDateHeading(dateKey)}`, ''];
 
   for (const entry of entries) {
     lines.push(`**${entry.displayName} ${entry.version}**`, '');
-
-    if (entry.changes.length > 0) {
-      for (const change of entry.changes) {
-        if (change.startsWith('    -')) {
-          lines.push(change);
-        } else {
-          lines.push(`- ${change}`);
-        }
-      }
-      lines.push('');
-    }
+    lines.push('GitHub release body:', '```', entry.body, '```', '');
   }
 
   return lines.join('\n');
 }
 
 async function polishWithClaude(rawEntry: string): Promise<string> {
-  const prompt = `You are editing a changelog file. Below is a raw changelog entry generated from GitHub releases.
-Rewrite the raw entry to match the style conventions shown in the examples below.
+  const prompt = `You are editing a changelog file. Below is a raw changelog entry with GitHub release bodies included verbatim.
+Extract the meaningful changes from each release body and rewrite the entry to match the style conventions shown in the examples below.
 
 ## Style examples
 
@@ -167,6 +140,11 @@ Use indented sub-items under an "Updated dependencies" bullet:
 
 - Keep the ## date heading exactly as-is
 - Keep **Package Name X.Y.Z** bold headings
+- Extract changes from the release bodies — they may use different formats (changeset markdown, GitHub auto-generated, etc.)
+- Strip commit hashes (e.g. "698f962: fix something" → "fix something")
+- Strip conventional commit scopes (e.g. "fix(render): description" → "fix description")
+- Strip "by @author in https://..." suffixes
+- Strip "**Full Changelog**" links
 - Keep bullet points concise, lowercase start unless proper noun
 - Do NOT invent changes, only rephrase or reorder what is given
 - Do NOT add migration guide links unless one was in the raw entry
@@ -205,15 +183,11 @@ async function commitWithDate(dateKey: string) {
   await execFile('git', ['add', CHANGELOG_PATH]);
   await execFile('git', [
     'commit',
-    '--date', commitDate,
-    '-m', `docs: add changelog entry for ${heading}`,
+    '--date',
+    commitDate,
+    '-m',
+    `docs: add changelog entry for ${heading}`,
   ]);
-}
-
-interface ReleaseEntry {
-  displayName: string;
-  version: string;
-  changes: string[];
 }
 
 const octokit = new Octokit({ auth: token });
@@ -222,15 +196,12 @@ let page = 1;
 let done = false;
 
 while (!done) {
-  const { data } = await octokit.request(
-    'GET /repos/{owner}/{repo}/releases',
-    {
-      owner: REPO_OWNER,
-      repo: REPO_NAME,
-      per_page: 100,
-      page,
-    },
-  );
+  const { data } = await octokit.request('GET /repos/{owner}/{repo}/releases', {
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
+    per_page: 100,
+    page,
+  });
 
   if (data.length === 0) break;
 
@@ -256,7 +227,7 @@ while (!done) {
     entries.push({
       displayName: toDisplayName(packageName),
       version,
-      changes: extractChanges(release.body || ''),
+      body: release.body || '',
     });
     byDate.set(dateKey, entries);
   }
@@ -284,10 +255,10 @@ for (const dateKey of sortedDates) {
   console.error(polished);
   console.error('--- end ---\n');
 
-  console.error(`Inserting into changelog...`);
+  console.error('Inserting into changelog...');
   await insertEntry(polished);
 
-  console.error(`Committing...`);
+  console.error('Committing...');
   await commitWithDate(dateKey);
 
   console.error(`Done: ${formatDateHeading(dateKey)}\n`);

--- a/scripts/backfill-changelog-entries.mts
+++ b/scripts/backfill-changelog-entries.mts
@@ -211,14 +211,14 @@ while (!done) {
   if (data.length === 0) break;
 
   for (const release of data) {
+    if (release.draft || release.prerelease) continue;
+
     const publishedAt = new Date(release.published_at || release.created_at);
 
     if (publishedAt < CUTOFF) {
       done = true;
       break;
     }
-
-    if (release.prerelease) continue;
 
     const tagName = release.tag_name;
     const atIndex = tagName.lastIndexOf('@');

--- a/scripts/backfill-changelog-entries.mts
+++ b/scripts/backfill-changelog-entries.mts
@@ -34,6 +34,10 @@ if (!sinceDate) {
 }
 
 const CUTOFF = new Date(`${sinceDate}T00:00:00Z`);
+if (Number.isNaN(CUTOFF.getTime())) {
+  console.error(`Invalid date: ${sinceDate}. Use YYYY-MM-DD format.`);
+  process.exit(1);
+}
 
 function toDisplayName(packageName: string): string {
   const name = packageName.replace('@react-email/', '');

--- a/scripts/backfill-changelog-entries.mts
+++ b/scripts/backfill-changelog-entries.mts
@@ -1,0 +1,282 @@
+import { execFile as execFileCb } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { Octokit } from '@octokit/core';
+
+const execFile = promisify(execFileCb);
+
+const REPO_OWNER = 'resend';
+const REPO_NAME = 'react-email';
+const CUTOFF = new Date('2025-11-08T00:00:00Z');
+
+const CHANGELOG_PATH = path.resolve(
+  import.meta.dirname,
+  '../apps/docs/changelog.mdx',
+);
+
+const token = process.env.GITHUB_TOKEN;
+if (!token) {
+  console.error('Set GITHUB_TOKEN env var.');
+  process.exit(1);
+}
+
+function toDisplayName(packageName: string): string {
+  const name = packageName.replace('@react-email/', '');
+  return name
+    .split('-')
+    .map((w) => w[0].toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function extractChanges(body: string): string[] {
+  const lines = body.split('\n');
+  const changes: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (/^-\s+/.test(trimmed)) {
+      const text = trimmed.replace(/^-\s+/, '').trim();
+      if (text.length > 0) {
+        changes.push(text);
+      }
+    } else if (/^\s+-\s+/.test(line) && changes.length > 0) {
+      const text = line.replace(/^\s+-\s+/, '').trim();
+      if (text.length > 0) {
+        changes.push(`    - ${text}`);
+      }
+    }
+  }
+
+  return changes;
+}
+
+function toDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function formatDateHeading(dateKey: string): string {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  const date = new Date(year, month - 1, day);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function buildRawEntry(dateKey: string, entries: ReleaseEntry[]): string {
+  const lines: string[] = [`## ${formatDateHeading(dateKey)}`, ''];
+
+  for (const entry of entries) {
+    lines.push(`**${entry.displayName} ${entry.version}**`, '');
+
+    if (entry.changes.length > 0) {
+      for (const change of entry.changes) {
+        if (change.startsWith('    -')) {
+          lines.push(change);
+        } else {
+          lines.push(`- ${change}`);
+        }
+      }
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+async function polishWithClaude(rawEntry: string): Promise<string> {
+  const prompt = `You are editing a changelog file. Below is a raw changelog entry generated from GitHub releases.
+Rewrite the raw entry to match the style conventions shown in the examples below.
+
+## Style examples
+
+### Grouping packages with the same changes
+
+When React Email and Preview Server (or any packages) share the same version number and same changes,
+stack their bold headings together with a single shared bullet list:
+
+**React Email 4.3.0**
+**Preview Server 4.3.0**
+
+- Added resize snapping, refined UI and improved presets
+
+### Updated dependencies format
+
+Use indented sub-items under an "Updated dependencies" bullet:
+
+**Components 0.5.7**
+
+- markdown: move out of md-to-react-email
+- render: disable wordwrap in toPlainText by default
+- Updated dependencies
+    - @react-email/markdown@0.0.16
+    - @react-email/render@1.4.0
+
+### Standalone package entry
+
+**Render 1.3.1**
+
+- fixed multi-byte characters causing problems during stream reading
+
+### Multiple releases on the same day
+
+## October 17, 2025
+
+**React Email 4.3.1**
+
+- hot reloading errors when importing .json and other file extensions
+
+**Preview Server 4.3.1**
+
+- make everything in the global for the UI available to email contexts using a Proxy
+
+**Render 1.4.0**
+
+- disable wordwrap in toPlainText by default
+
+**Markdown 0.0.16**
+
+- move out of md-to-react-email
+
+**Components 0.5.7**
+
+- markdown: move out of md-to-react-email
+- render: disable wordwrap in toPlainText by default
+- Updated dependencies
+    - @react-email/markdown@0.0.16
+    - @react-email/render@1.4.0
+
+## Rules
+
+- Keep the ## date heading exactly as-is
+- Keep **Package Name X.Y.Z** bold headings
+- Keep bullet points concise, lowercase start unless proper noun
+- Do NOT invent changes, only rephrase or reorder what is given
+- Do NOT add migration guide links unless one was in the raw entry
+- Output ONLY the final markdown — no preamble, no explanation, no surrounding text whatsoever
+
+## Raw entry
+
+${rawEntry}`;
+
+  const { stdout } = await execFile('claude', ['-p', prompt], {
+    maxBuffer: 1024 * 1024,
+  });
+
+  const trimmed = stdout.trim();
+  const headingIndex = trimmed.indexOf('## ');
+  if (headingIndex > 0) return trimmed.slice(headingIndex);
+  return trimmed;
+}
+
+async function insertEntry(polishedEntry: string) {
+  const content = await fs.readFile(CHANGELOG_PATH, 'utf8');
+
+  const frontmatterEnd = content.indexOf('---', content.indexOf('---') + 3);
+  const insertPos = content.indexOf('\n', frontmatterEnd) + 1;
+
+  const before = content.slice(0, insertPos);
+  const after = content.slice(insertPos);
+
+  await fs.writeFile(CHANGELOG_PATH, `${before}\n${polishedEntry}\n${after}`);
+}
+
+async function commitWithDate(dateKey: string) {
+  const commitDate = `${dateKey}T12:00:00`;
+  const heading = formatDateHeading(dateKey);
+
+  await execFile('git', ['add', CHANGELOG_PATH]);
+  await execFile('git', [
+    'commit',
+    '--date', commitDate,
+    '-m', `docs: add changelog entry for ${heading}`,
+  ]);
+}
+
+interface ReleaseEntry {
+  displayName: string;
+  version: string;
+  changes: string[];
+}
+
+const octokit = new Octokit({ auth: token });
+const byDate = new Map<string, ReleaseEntry[]>();
+let page = 1;
+let done = false;
+
+while (!done) {
+  const { data } = await octokit.request(
+    'GET /repos/{owner}/{repo}/releases',
+    {
+      owner: REPO_OWNER,
+      repo: REPO_NAME,
+      per_page: 100,
+      page,
+    },
+  );
+
+  if (data.length === 0) break;
+
+  for (const release of data) {
+    const publishedAt = new Date(release.published_at || release.created_at);
+
+    if (publishedAt < CUTOFF) {
+      done = true;
+      break;
+    }
+
+    if (release.prerelease) continue;
+
+    const tagName = release.tag_name;
+    const atIndex = tagName.lastIndexOf('@');
+    if (atIndex <= 0 && !tagName.includes('@')) continue;
+
+    const packageName = tagName.substring(0, atIndex);
+    const version = tagName.substring(atIndex + 1);
+    const dateKey = toDateKey(publishedAt);
+
+    const entries = byDate.get(dateKey) ?? [];
+    entries.push({
+      displayName: toDisplayName(packageName),
+      version,
+      changes: extractChanges(release.body || ''),
+    });
+    byDate.set(dateKey, entries);
+  }
+
+  page++;
+}
+
+if (byDate.size === 0) {
+  console.error('No releases found after November 7, 2025.');
+  process.exit(0);
+}
+
+const sortedDates = [...byDate.keys()].sort(
+  (a, b) => new Date(a).getTime() - new Date(b).getTime(),
+);
+
+for (const dateKey of sortedDates) {
+  const entries = byDate.get(dateKey)!;
+  const raw = buildRawEntry(dateKey, entries);
+
+  console.error(`Polishing ${formatDateHeading(dateKey)}...`);
+  const polished = await polishWithClaude(raw);
+
+  console.error('\n--- Claude output ---');
+  console.error(polished);
+  console.error('--- end ---\n');
+
+  console.error(`Inserting into changelog...`);
+  await insertEntry(polished);
+
+  console.error(`Committing...`);
+  await commitWithDate(dateKey);
+
+  console.error(`Done: ${formatDateHeading(dateKey)}\n`);
+}
+
+console.error(`All ${sortedDates.length} entries committed.`);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a script to backfill the docs changelog from GitHub releases and auto-insert dated entries. Backfilled `apps/docs/changelog.mdx` from Nov 11, 2025 to Apr 9, 2026 using a tighter `claude` prompt for consistent formatting.

- **New Features**
  - Added `scripts/backfill-changelog-entries.mts` using `@octokit/core`; skips drafts and prereleases, groups by date, inserts into `apps/docs/changelog.mdx`, and commits each date with that date.
  - Sends raw release bodies to `claude` with stricter rules: group same-version packages, nest “Updated dependencies”, strip hashes/scopes/authors/links, pair React Email/Preview Server, keep the date heading, output only final markdown.
  - Validates `--since` date (YYYY-MM-DD) and exits with a clear error when invalid.
  - Backfilled entries from Nov 11, 2025 to Apr 9, 2026.

- **Migration**
  - Set `GITHUB_TOKEN` and install the `claude` CLI (on your PATH).
  - The `--since YYYY-MM-DD` flag is required.
  - Run: `pnpm tsx scripts/backfill-changelog-entries.mts --since 2025-11-01`.

<sup>Written for commit 1619c16f23a196b278bd69a8f7490f86fd4f00e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

