### PR TITLE
fix(render): reorder `node` above `convex` in exports map

### DIFF
--- a/.changeset/vast-bushes-post.md
+++ b/.changeset/vast-bushes-post.md
@@ -1,0 +1,5 @@
+---
+"@react-email/render": patch
+---
+
+fix export map ordering between convex and node

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -51,16 +51,6 @@
           "default": "./dist/edge/index.cjs"
         }
       },
-      "convex": {
-        "import": {
-          "types": "./dist/edge/index.d.mts",
-          "default": "./dist/edge/index.mjs"
-        },
-        "require": {
-          "types": "./dist/edge/index.d.cts",
-          "default": "./dist/edge/index.cjs"
-        }
-      },
       "node": {
         "import": {
           "types": "./dist/node/index.d.mts",
@@ -69,6 +59,16 @@
         "require": {
           "types": "./dist/node/index.d.cts",
           "default": "./dist/node/index.cjs"
+        }
+      },
+      "convex": {
+        "import": {
+          "types": "./dist/edge/index.d.mts",
+          "default": "./dist/edge/index.mjs"
+        },
+        "require": {
+          "types": "./dist/edge/index.d.cts",
+          "default": "./dist/edge/index.cjs"
         }
       },
       "browser": {


### PR DESCRIPTION
## Summary

`@react-email/render`'s exports map currently lists the `convex` condition before `node`. Convex's bundler sets conditions `["convex", "module", ...]` for every action, and additionally adds the `node` condition for `"use node"` (Node.js runtime) actions. Because exports-map matching is first-match-wins, `"use node"` actions resolve the **edge** build and fail at runtime with:

```
reactDOMServer.renderToReadableStream is not a function
```

Downstream report: https://github.com/get-convex/resend/issues/75

## Fix

Move the `node` condition above `convex` in `packages/render/package.json`. This way:

- **`"use node"` Convex actions** (both `convex` and `node` conditions set) → match `node` first → get the node build (`renderToPipeableStream`). ✅
- **Convex V8 isolate runtime** (only `convex` set, no `node`) → falls through `node` and matches `convex` → still gets the edge build as intended. ✅

## Reproduction

Using Convex's exact bundler configuration (`platform: "node"`, `conditions: ["convex", "module"]`, from `convex/dist/esm/bundler/debugBundle.js`) with esbuild:

**Before (unpatched 2.0.6):** resolves `dist/edge/index.mjs` → throws `reactDOMServer.renderToReadableStream is not a function`.

**After (this PR):** resolves `dist/node/index.mjs` → renders HTML successfully.

## Test plan

- [x] Reproduced the exact user-reported error with unpatched package
- [x] Verified fix resolves correctly to the node build under Convex's bundler conditions
- [x] Verified fix does not affect other runtimes (V8 isolate still matches `convex`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the exports map in `@react-email/render` to put the `node` condition before `convex`, so Convex "use node" actions resolve the Node build (`renderToPipeableStream`) instead of Edge and avoid "reactDOMServer.renderToReadableStream is not a function"; the isolate runtime still uses Edge. Added a changeset for a patch release.

<sup>Written for commit 4c1979f2dd2cb5e89c0907587e12ae261e2f618b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

