### PR TITLE
chore: ignore tsconfig package in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,7 @@
   "ignore": [
     "@benchmarks/preview-server",
     "@benchmarks/tailwind-component",
+    "tsconfig",
     "playground",
     "demo",
     "email-dev",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ignore `tsconfig` package in Changesets so config-only edits don’t trigger releases or version bumps. This reduces noise and avoids unnecessary publishes.

<sup>Written for commit 46bfa2e468f83a8c63e1c5cb772c5603b8c296d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

