### PR TITLE
fix(docs): outdated codebase overview

### DIFF
--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -74,42 +74,13 @@ corepack prepare pnpm@latest --activate
 
 Currently, we have the following packages:
 
-<div className="grid gap-2" style={{ gridTemplateColumns: '1fr 1fr 1fr' }}>
-  <div>
-    - [@react-email/body](https://github.com/resend/react-email/tree/canary/packages/body)
-    - [@react-email/button](https://github.com/resend/react-email/tree/canary/packages/button)
-    - [@react-email/code-block](https://github.com/resend/react-email/tree/canary/packages/code-block)
-    - [@react-email/code-inline](https://github.com/resend/react-email/tree/canary/packages/code-inline)
-    - [@react-email/column](https://github.com/resend/react-email/tree/canary/packages/column)
-    - [@react-email/components](https://github.com/resend/react-email/tree/canary/packages/components)
-    - [@react-email/container](https://github.com/resend/react-email/tree/canary/packages/container)
-    - [create-email](https://github.com/resend/react-email/tree/canary/packages/create-email)
-      - <span className="text-xs">Used for our [automatic setup](/getting-started/automatic-setup)</span>
-  </div>
-  <div>
-    - [@react-email/font](https://github.com/resend/react-email/tree/canary/packages/font)
-    - [@react-email/head](https://github.com/resend/react-email/tree/canary/packages/head)
-    - [@react-email/heading](https://github.com/resend/react-email/tree/canary/packages/heading)
-    - [@react-email/hr](https://github.com/resend/react-email/tree/canary/packages/hr)
-    - [@react-email/html](https://github.com/resend/react-email/tree/canary/packages/html)
-    - [@react-email/img](https://github.com/resend/react-email/tree/canary/packages/img)
-    - [@react-email/link](https://github.com/resend/react-email/tree/canary/packages/link)
-    - [@react-email/markdown](https://github.com/resend/react-email/tree/canary/packages/markdown)
-    - [@react-email/preview](https://github.com/resend/react-email/tree/canary/packages/preview)
-  </div>
-  <div>
-    - [react-email](https://github.com/resend/react-email/tree/canary/packages/react-email)
-      - <span className="text-xs">The package for our [email CLI](/cli)</span>
-    - [@react-email/preview-server](https://github.com/resend/react-email/tree/canary/packages/preview-server)
-    - [@react-email/render](https://github.com/resend/react-email/tree/canary/packages/render)
-    - [@react-email/row](https://github.com/resend/react-email/tree/canary/packages/row)
-    - [@react-email/section](https://github.com/resend/react-email/tree/canary/packages/section)
-    - [@react-email/tailwind](https://github.com/resend/react-email/tree/canary/packages/tailwind)
-    - [@react-email/text](https://github.com/resend/react-email/tree/canary/packages/text)
-  </div>
-</div>
-
-Most of these packages are very small and can be easily understood by reading the code, so feel free to explore.
+- [react-email](https://github.com/resend/react-email/tree/canary/packages/react-email)
+    - <span className="text-xs">The package for our [email CLI](/cli), and for all of our components</span>
+- [@react-email/render](https://github.com/resend/react-email/tree/canary/packages/render)
+    - <span className="text-xs">The [render](/utilities/render) utility. Can also be imported from `react-email`.</span>
+- [@react-email/preview-server](https://github.com/resend/react-email/tree/canary/packages/preview-server)
+- [create-email](https://github.com/resend/react-email/tree/canary/packages/create-email)
+    - <span className="text-xs">Used for our [automatic setup](/getting-started/automatic-setup)</span>
 
 ### Turborepo
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Codebase Overview to reflect the current package structure. Replaced the outdated component grid with a concise list: `react-email` (CLI and all components), `@react-email/render` (also importable from `react-email`), `@react-email/preview-server`, and `create-email`.

<sup>Written for commit 3182d6a686a2bf43d96c7a5501a4b95872a9359f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

