### PR TITLE
fix: avoid injecting css with undefined value

### DIFF
--- a/.changeset/bitter-boxes-fetch.md
+++ b/.changeset/bitter-boxes-fetch.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": major
+---
+
+avoid injecting undefined css values

--- a/packages/editor/src/plugins/email-theming/css-transforms.ts
+++ b/packages/editor/src/plugins/email-theming/css-transforms.ts
@@ -94,6 +94,10 @@ export function injectThemeCss(
     const cssString = Object.entries(value).reduce((acc, [prop, val]) => {
       const normalizeProp = prop.replace(/([A-Z])/g, '-$1').toLowerCase();
 
+      if (val === undefined) {
+        return acc;
+      }
+
       return `${acc}${normalizeProp}:${val};`;
     }, '');
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->
Close https://linear.app/resend/issue/PRODUCT-2067/ignore-undefined-css-values-before-style-injection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip undefined style values in the theming CSS builder so we never inject invalid rules (e.g., color: undefined), preventing broken inline styles in `@react-email/editor`. Addresses Linear PRODUCT-2067.

<sup>Written for commit 23fa9360e44cf1cee02d8496db6e3afa51d27644. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

