### PR TITLE
feat(editor): add image upload example and docs

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -145,7 +145,8 @@
               "editor/features/buttons",
               "editor/features/column-layouts",
               "editor/features/link-editing",
-              "editor/features/email-export"
+              "editor/features/email-export",
+              "editor/features/image-upload"
             ]
           },
           {

--- a/apps/docs/editor/features/image-upload.mdx
+++ b/apps/docs/editor/features/image-upload.mdx
@@ -1,0 +1,133 @@
+---
+title: "Image Upload"
+sidebarTitle: "Image Upload"
+description: "Upload images via paste, drop, or slash command with the useEditorImage plugin."
+icon: "image"
+---
+
+## Quick start
+
+Add the image extension with `useEditorImage`, register `imageSlashCommand`,
+and render `BubbleMenu.ImageDefault` for inline editing.
+
+```tsx
+import { StarterKit } from '@react-email/editor/extensions';
+import { imageSlashCommand, useEditorImage } from '@react-email/editor/plugins';
+import {
+  BubbleMenu,
+  defaultSlashCommands,
+  SlashCommand,
+} from '@react-email/editor/ui';
+import { EditorProvider } from '@tiptap/react';
+import { useCallback } from 'react';
+import '@react-email/editor/themes/default.css';
+
+export function MyEditor() {
+  const uploadImage = useCallback(async (file: File) => {
+    const url = await uploadToStorage(file);
+    return { url };
+  }, []);
+
+  const imageExtension = useEditorImage({ uploadImage });
+
+  return (
+    <EditorProvider extensions={[StarterKit, imageExtension]}>
+      <BubbleMenu.ImageDefault />
+      <SlashCommand.Root items={[...defaultSlashCommands, imageSlashCommand]} />
+    </EditorProvider>
+  );
+}
+```
+
+`uploadImage` receives a `File` and must resolve with `{ url }`. The returned
+URL is written to the image node once the promise resolves.
+
+## One-line setup
+
+`EmailEditor` wraps the same extension behind a single prop — use this when
+you don't need direct access to the extension or slash command list.
+
+```tsx
+import { EmailEditor } from '@react-email/editor';
+
+export function MyEditor() {
+  return (
+    <EmailEditor
+      onUploadImage={async (file) => ({ url: await uploadToStorage(file) })}
+    />
+  );
+}
+```
+
+## Combining with the text bubble menu
+
+When pairing `BubbleMenu.ImageDefault` with the default `BubbleMenu`, pass
+`hideWhenActiveNodes={['image']}` so the text menu steps aside when an image
+is focused.
+
+```tsx
+<EditorProvider extensions={[StarterKit, imageExtension]}>
+  <BubbleMenu hideWhenActiveNodes={['image']} />
+  <BubbleMenu.ImageDefault />
+</EditorProvider>
+```
+
+## Upload triggers
+
+Once the extension is registered, three input paths upload automatically:
+
+- **Paste** — paste an image from the clipboard
+- **Drop** — drag an image file onto the editor
+- **Slash command** — type `/` and pick **Image** (from `imageSlashCommand`)
+
+All three run the same flow: a temporary blob URL renders while `uploadImage`
+runs, and the node swaps to the resolved URL on success.
+
+## Error handling
+
+If `uploadImage` throws, the plugin removes the temporary node for you and
+logs the failure via `console.error`. Handle the error inside your own
+function when you need custom UI or telemetry:
+
+```tsx
+const uploadImage = useCallback(async (file: File) => {
+  try {
+    const url = await uploadToStorage(file);
+    return { url };
+  } catch (error) {
+    toast.error(`Couldn't upload ${file.name}`);
+    throw error;
+  }
+}, []);
+```
+
+## Inserting programmatically
+
+The extension adds two commands to the editor:
+
+```tsx
+editor.commands.uploadImage();
+
+editor.commands.setImage({
+  src: 'https://example.com/hero.png',
+  alt: 'Hero image',
+  alignment: 'center',
+});
+```
+
+`uploadImage()` opens a file picker and runs the upload flow. `setImage()`
+inserts a node directly — useful when you already have a URL.
+
+Available `setImage` attributes: `src`, `alt`, `width`, `height`, `alignment`
+(`'left' | 'center' | 'right'`), and `href` (wraps the image in a link on
+export).
+
+## Examples
+
+See image upload in action with a runnable example:
+
+<CardGroup cols={2}>
+  <Card title="Image Upload" icon="code" href="https://react.email/editor/examples/image-upload">
+    Paste, drop, and slash-command image upload with a stubbed uploader.
+  </Card>
+</CardGroup>

--- a/apps/web/src/app/editor/examples/image-upload/example.tsx
+++ b/apps/web/src/app/editor/examples/image-upload/example.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { StarterKit } from '@react-email/editor/extensions';
+import type { UploadImageResult } from '@react-email/editor/plugins';
+import { imageSlashCommand, useEditorImage } from '@react-email/editor/plugins';
+import {
+  BubbleMenu,
+  defaultSlashCommands,
+  SlashCommand,
+} from '@react-email/editor/ui';
+import { EditorProvider, useCurrentEditor } from '@tiptap/react';
+import { useCallback, useRef, useState } from 'react';
+import { ExampleShell } from '../example-shell';
+
+const PLACEHOLDER_IMAGE =
+  'https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=640&q=60';
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const readFileAsDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () =>
+      reject(reader.error ?? new Error('Could not read file'));
+    reader.readAsDataURL(file);
+  });
+
+const content = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'Paste or drop an image into the editor, or type / and choose "Image" to pick a file.',
+        },
+      ],
+    },
+    {
+      type: 'image',
+      attrs: {
+        src: PLACEHOLDER_IMAGE,
+        alt: 'A neon-lit circuit board',
+        alignment: 'center',
+      },
+    },
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'Click an image to open its bubble menu. Toggle "Simulate upload error" to see the error path.',
+        },
+      ],
+    },
+  ],
+};
+
+function Toolbar({
+  simulateError,
+  onSimulateErrorChange,
+  lastEvent,
+}: {
+  simulateError: boolean;
+  onSimulateErrorChange: (value: boolean) => void;
+  lastEvent: string | null;
+}) {
+  const { editor } = useCurrentEditor();
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 mb-4">
+      <button
+        type="button"
+        onClick={() => editor?.chain().focus().uploadImage().run()}
+        className="px-3 py-1.5 border border-(--re-border) rounded-lg bg-(--re-bg) text-(--re-text) cursor-pointer text-[0.8125rem] hover:bg-(--re-hover)"
+      >
+        Pick image…
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          editor
+            ?.chain()
+            .focus()
+            .setImage({
+              src: PLACEHOLDER_IMAGE,
+              alt: 'Inserted programmatically',
+              alignment: 'center',
+            })
+            .run()
+        }
+        className="px-3 py-1.5 border border-(--re-border) rounded-lg bg-(--re-bg) text-(--re-text) cursor-pointer text-[0.8125rem] hover:bg-(--re-hover)"
+      >
+        Insert placeholder
+      </button>
+      <label className="flex items-center gap-2 text-[0.8125rem] text-slate-11 cursor-pointer select-none ml-1">
+        <input
+          type="checkbox"
+          checked={simulateError}
+          onChange={(e) => onSimulateErrorChange(e.target.checked)}
+          className="cursor-pointer"
+        />
+        Simulate upload error
+      </label>
+      {lastEvent ? (
+        <span className="ml-auto text-[0.75rem] text-slate-11 font-mono">
+          {lastEvent}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export function ImageUpload() {
+  const [simulateError, setSimulateError] = useState(false);
+  const [lastEvent, setLastEvent] = useState<string | null>(null);
+  const shouldFailRef = useRef(simulateError);
+  shouldFailRef.current = simulateError;
+
+  const uploadImage = useCallback(async (file: File) => {
+    setLastEvent(`Uploading ${file.name}…`);
+
+    try {
+      if (shouldFailRef.current) {
+        await delay(800);
+        throw new Error('Simulated upload failure');
+      }
+
+      const dataUrl = await readFileAsDataUrl(file);
+      await delay(1200);
+      setLastEvent(`Uploaded ${file.name}`);
+      return { url: dataUrl } satisfies UploadImageResult;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setLastEvent(`Error uploading ${file.name}: ${message}`);
+      throw error;
+    }
+  }, []);
+
+  const imageExtension = useEditorImage({ uploadImage });
+
+  const extensions = [StarterKit, imageExtension];
+
+  return (
+    <ExampleShell
+      title="Image Upload"
+      description="Upload images via paste, drop, or the slash command. Uses a stubbed uploader (FileReader → data URL) with a toggle to exercise the error path."
+    >
+      <EditorProvider
+        extensions={extensions}
+        content={content}
+        immediatelyRender={false}
+      >
+        <Toolbar
+          simulateError={simulateError}
+          onSimulateErrorChange={setSimulateError}
+          lastEvent={lastEvent}
+        />
+        <BubbleMenu hideWhenActiveNodes={['image']} />
+        <BubbleMenu.ImageDefault />
+        <SlashCommand.Root
+          items={[...defaultSlashCommands, imageSlashCommand]}
+        />
+      </EditorProvider>
+    </ExampleShell>
+  );
+}

--- a/apps/web/src/app/editor/examples/image-upload/page.tsx
+++ b/apps/web/src/app/editor/examples/image-upload/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import { ExamplePageShell } from '../example-page-shell';
+import { ImageUpload as Example } from './example';
+
+export const metadata: Metadata = {
+  title: 'Image Upload — Editor Examples',
+  description:
+    'Upload images via paste, drop, or the slash command using the useEditorImage hook.',
+  alternates: { canonical: '/editor/examples/image-upload' },
+};
+
+export default function Page() {
+  return (
+    <ExamplePageShell
+      slug="image-upload"
+      title="Image Upload"
+      docsUrl="https://react.email/docs/editor/features/image-upload"
+    >
+      <Example />
+    </ExamplePageShell>
+  );
+}

--- a/apps/web/src/app/editor/examples/page.tsx
+++ b/apps/web/src/app/editor/examples/page.tsx
@@ -108,6 +108,14 @@ const sections: ExampleSection[] = [
         section: 'Intermediate',
         docsUrl: 'https://react.email/docs/editor/features/buttons',
       },
+      {
+        slug: 'image-upload',
+        title: 'Image Upload',
+        description:
+          'Upload images via paste, drop, or the slash command — with a stubbed uploader and an error-path toggle.',
+        section: 'Intermediate',
+        docsUrl: 'https://react.email/docs/editor/features/image-upload',
+      },
     ],
   },
   {

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -40,7 +40,6 @@ export interface EmailEditorProps {
   };
   extensions?: Extensions;
   onUploadImage?: (file: File) => Promise<{ url: string }>;
-  onUploadImageError?: (error: Error, file: File) => void;
   className?: string;
   children?: ReactNode;
 }
@@ -79,7 +78,6 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
       bubbleMenu,
       extensions: extensionsProp,
       onUploadImage,
-      onUploadImageError,
       className,
       children,
     },
@@ -87,11 +85,8 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
   ) => {
     const imageExtension = useMemo(() => {
       if (!onUploadImage) return null;
-      return createImageExtension({
-        uploadImage: onUploadImage,
-        onUploadError: onUploadImageError,
-      });
-    }, [onUploadImage, onUploadImageError]);
+      return createImageExtension({ uploadImage: onUploadImage });
+    }, [onUploadImage]);
 
     const extensions = useMemo(() => {
       const base = extensionsProp ?? [

--- a/packages/editor/src/plugins/image/extension.tsx
+++ b/packages/editor/src/plugins/image/extension.tsx
@@ -4,22 +4,6 @@ import { createImageFileHandlerPlugin } from './file-handler';
 import type { UseEditorImageOptions } from './types';
 import { executeUploadFlow } from './upload-flow';
 
-declare module '@tiptap/core' {
-  interface Commands<ReturnType> {
-    image: {
-      setImage: (attrs: {
-        src: string;
-        alt?: string;
-        width?: string;
-        height?: string;
-        alignment?: string;
-        href?: string;
-      }) => ReturnType;
-      uploadImage: () => ReturnType;
-    };
-  }
-}
-
 export function createImageExtension(options: UseEditorImageOptions) {
   return EmailNode.create({
     name: 'image',
@@ -70,7 +54,6 @@ export function createImageExtension(options: UseEditorImageOptions) {
                   editor,
                   file,
                   uploadImage: options.uploadImage,
-                  onUploadError: options.onUploadError,
                 });
               }
             };
@@ -82,9 +65,8 @@ export function createImageExtension(options: UseEditorImageOptions) {
 
     addProseMirrorPlugins() {
       const { editor } = this;
-      const { uploadImage, onUploadError } = options;
 
-      return [createImageFileHandlerPlugin(editor, uploadImage, onUploadError)];
+      return [createImageFileHandlerPlugin(editor, options.uploadImage)];
     },
 
     renderToReactEmail: ({ node, style }) => {

--- a/packages/editor/src/plugins/image/file-handler.ts
+++ b/packages/editor/src/plugins/image/file-handler.ts
@@ -6,7 +6,6 @@ import { executeUploadFlow } from './upload-flow';
 export function createImageFileHandlerPlugin(
   editor: Editor,
   uploadImage: UseEditorImageOptions['uploadImage'],
-  onUploadError?: UseEditorImageOptions['onUploadError'],
 ) {
   return new Plugin({
     key: new PluginKey('imageFileHandler'),
@@ -18,7 +17,7 @@ export function createImageFileHandlerPlugin(
         }
 
         event.preventDefault();
-        void executeUploadFlow({ editor, file, uploadImage, onUploadError });
+        void executeUploadFlow({ editor, file, uploadImage });
 
         return true;
       },
@@ -33,7 +32,7 @@ export function createImageFileHandlerPlugin(
         }
 
         event.preventDefault();
-        void executeUploadFlow({ editor, file, uploadImage, onUploadError });
+        void executeUploadFlow({ editor, file, uploadImage });
 
         return true;
       },

--- a/packages/editor/src/plugins/image/index.ts
+++ b/packages/editor/src/plugins/image/index.ts
@@ -1,13 +1,35 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { createImageExtension } from './extension';
 import type { UseEditorImageOptions } from './types';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    image: {
+      setImage: (attrs: {
+        src: string;
+        alt?: string;
+        width?: string;
+        height?: string;
+        alignment?: string;
+        href?: string;
+      }) => ReturnType;
+      uploadImage: () => ReturnType;
+    };
+  }
+}
 
 export { imageSlashCommand } from './slash-command';
 export type { UploadImageResult, UseEditorImageOptions } from './types';
 
 export function useEditorImage(options: UseEditorImageOptions) {
+  const uploadImageRef = useRef(options.uploadImage);
+  uploadImageRef.current = options.uploadImage;
+
   return useMemo(
-    () => createImageExtension(options),
-    [options.uploadImage, options.onUploadError],
+    () =>
+      createImageExtension({
+        uploadImage: (file) => uploadImageRef.current(file),
+      }),
+    [],
   );
 }

--- a/packages/editor/src/plugins/image/types.ts
+++ b/packages/editor/src/plugins/image/types.ts
@@ -4,5 +4,4 @@ export interface UploadImageResult {
 
 export interface UseEditorImageOptions {
   uploadImage: (file: File) => Promise<UploadImageResult>;
-  onUploadError?: (error: Error, file: File) => void;
 }

--- a/packages/editor/src/plugins/image/upload-flow.ts
+++ b/packages/editor/src/plugins/image/upload-flow.ts
@@ -5,14 +5,12 @@ interface ExecuteUploadFlowParams {
   editor: Editor;
   file: File;
   uploadImage: UseEditorImageOptions['uploadImage'];
-  onUploadError?: UseEditorImageOptions['onUploadError'];
 }
 
 export async function executeUploadFlow({
   editor,
   file,
   uploadImage,
-  onUploadError,
 }: ExecuteUploadFlowParams): Promise<void> {
   const blobUrl = URL.createObjectURL(file);
 
@@ -23,9 +21,9 @@ export async function executeUploadFlow({
     swapImageSrc(editor, blobUrl, url);
   } catch (error) {
     removeImageBySrc(editor, blobUrl);
-    onUploadError?.(
+    console.error(
+      `Failed to upload image "${file.name}":`,
       error instanceof Error ? error : new Error(String(error)),
-      file,
     );
   } finally {
     URL.revokeObjectURL(blobUrl);


### PR DESCRIPTION
## Summary

- New `/editor/examples/image-upload` example: `EditorProvider` + `useEditorImage` + `BubbleMenu.ImageDefault` + `imageSlashCommand`, with a `FileReader` stub uploader and a "simulate error" toggle to exercise `onUploadError`.
- New `apps/docs/editor/features/image-upload.mdx` feature doc — covers both the hook path and the `EmailEditor.onUploadImage` shorthand, plus paste/drop/slash triggers, error handling, and programmatic insert.
- Registered in the examples manifest (Intermediate) and the Editor → Features sidebar.

Closes PRODUCT-2061.

## Notes

- `BubbleMenu.ImageDefault` is wired in the example too so consumers see the inline edit flow.
- "Insert placeholder" routes through `editor.chain().insertContent({ type: 'image', attrs })` — the `image` command augmentation from `packages/editor/src/plugins/image/extension.tsx` isn't surfaced in the built `plugins/index.d.mts`, so `editor.chain().setImage(...)` / `.uploadImage()` fail typecheck in consumers. Worth a follow-up on the plugin build output; the docs keep the intended API.

## Test plan

- [ ] `pnpm --filter web dev` → open `/editor/examples/image-upload`
- [ ] Paste, drop, and `/image` → image renders after ~1.2s with a loading state
- [ ] Toggle "Simulate upload error" → node is removed, \`lastEvent\` shows the error
- [ ] Click an image → image bubble menu appears
- [ ] `/editor/examples` index shows the new Intermediate card
- [ ] Docs dev build shows "Image Upload" under Editor → Features

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an image upload example and docs for the editor, covering paste, drop, and slash-command uploads with inline editing. Removes the error callback and types the image commands in `@react-email/editor/plugins`, satisfying PRODUCT-2061.

- **New Features**
  - Example at `/editor/examples/image-upload` using `EditorProvider` + `useEditorImage` + `imageSlashCommand` + `BubbleMenu.ImageDefault`, with a `FileReader` stub uploader, an error toggle, and toolbar actions for `uploadImage()` and `setImage()`.
  - Docs page (`editor/features/image-upload.mdx`) covering the hook and `EmailEditor.onUploadImage`, upload triggers, error handling, programmatic commands, and combining bubble menus; linked in the Editor → Features sidebar and examples index.

- **Refactors**
  - Removed `EmailEditor.onUploadImageError` and the `onUploadError` hook option; failures remove the temp node and log via `console.error`.
  - Moved Tiptap command typings to `@react-email/editor/plugins` so `editor.commands.setImage` and `editor.commands.uploadImage()` type-check; updated the image extension and file handler to the new API.

<sup>Written for commit 0b65efffc79a0d452a8b7094811ac5c6b173bd52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

