### PR TITLE
refactor(editor): collapse SlashCommand.Root, unexport CommandList

### DIFF
--- a/.changeset/slash-command-api-cleanup.md
+++ b/.changeset/slash-command-api-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+collapse `SlashCommand.Root` into `SlashCommand` and stop exporting internal `CommandList`/`CommandListProps`. Replace `<SlashCommand.Root ...>` with `<SlashCommand ...>`.

--- a/apps/docs/editor/api-reference/ui/slash-command.mdx
+++ b/apps/docs/editor/api-reference/ui/slash-command.mdx
@@ -7,12 +7,12 @@ icon: "terminal"
 
 Command menu triggered by typing a character (default: `/`).
 
-## SlashCommand.Root
+## SlashCommand
 
 ```tsx
 import { defaultSlashCommands, SlashCommand } from '@react-email/editor/ui';
 
-<SlashCommand.Root items={defaultSlashCommands} />
+<SlashCommand items={defaultSlashCommands} />
 ```
 
 <ResponseField name="items" type="SlashCommandItem[]" default="defaultSlashCommands">
@@ -44,7 +44,7 @@ and a callback to select an item:
 ```tsx
 import { defaultSlashCommands, SlashCommand } from '@react-email/editor/ui';
 
-<SlashCommand.Root items={defaultSlashCommands}>
+<SlashCommand items={defaultSlashCommands}>
   {({ items, query, selectedIndex, onSelect }) => (
     <div className="my-command-list">
       {items.map((item, index) => (
@@ -68,7 +68,7 @@ import { defaultSlashCommands, SlashCommand } from '@react-email/editor/ui';
       )}
     </div>
   )}
-</SlashCommand.Root>
+</SlashCommand>
 ```
 
 ### Custom commands
@@ -93,7 +93,7 @@ const customCommands = [
   },
 ];
 
-<SlashCommand.Root items={customCommands} />
+<SlashCommand items={customCommands} />
 ```
 
 ---

--- a/apps/docs/editor/features/buttons.mdx
+++ b/apps/docs/editor/features/buttons.mdx
@@ -27,7 +27,7 @@ export function MyEditor() {
   return (
     <EditorProvider extensions={extensions} content={content}>
       <BubbleMenu.ButtonDefault />
-      <SlashCommand.Root items={[BUTTON]} />
+      <SlashCommand items={[BUTTON]} />
     </EditorProvider>
   );
 }

--- a/apps/docs/editor/features/email-export.mdx
+++ b/apps/docs/editor/features/email-export.mdx
@@ -178,7 +178,7 @@ export function FullEmailBuilder() {
         <BubbleMenu hideWhenActiveNodes={['button']} hideWhenActiveMarks={['link']} />
         <BubbleMenu.LinkDefault />
         <BubbleMenu.ButtonDefault />
-        <SlashCommand.Root items={defaultSlashCommands} />
+        <SlashCommand items={defaultSlashCommands} />
         <ControlPanel />
       </EditorProvider>
     </div>

--- a/apps/docs/editor/features/slash-commands.mdx
+++ b/apps/docs/editor/features/slash-commands.mdx
@@ -7,7 +7,7 @@ icon: "slash-forward"
 
 ## Quick start
 
-Add `SlashCommand.Root` with the default command set:
+Add `SlashCommand` with the default command set:
 
 ```tsx
 import { StarterKit } from '@react-email/editor/extensions';
@@ -20,7 +20,7 @@ const extensions = [StarterKit];
 export function MyEditor() {
   return (
     <EditorProvider extensions={extensions} content={content}>
-      <SlashCommand.Root items={defaultSlashCommands} />
+      <SlashCommand items={defaultSlashCommands} />
     </EditorProvider>
   );
 }
@@ -59,7 +59,7 @@ Each command is also exported individually, so you can cherry-pick:
 ```tsx
 import { BUTTON, H1, H2, TEXT } from '@react-email/editor/ui';
 
-<SlashCommand.Root items={[TEXT, H1, H2, BUTTON]} />
+<SlashCommand items={[TEXT, H1, H2, BUTTON]} />
 ```
 
 ## Adding custom commands
@@ -96,7 +96,7 @@ const GREETING: SlashCommandItem = {
 export function MyEditor() {
   return (
     <EditorProvider extensions={extensions} content={content}>
-      <SlashCommand.Root
+      <SlashCommand
         items={[...defaultSlashCommands, GREETING]}
       />
     </EditorProvider>
@@ -137,7 +137,7 @@ You can cherry-pick from the default commands to show only specific options:
 ```tsx
 import { BUTTON, SlashCommand } from '@react-email/editor/ui';
 
-<SlashCommand.Root items={[BUTTON]} />
+<SlashCommand items={[BUTTON]} />
 ```
 
 This is useful when you want a minimal command palette. For example, only allowing button insertion.
@@ -153,7 +153,7 @@ This is useful when you want a minimal command palette. For example, only allowi
 </ResponseField>
 
 ```tsx
-<SlashCommand.Root
+<SlashCommand
   items={defaultSlashCommands}
   char="/"
   allow={({ editor }) => !editor.isActive('codeBlock')}

--- a/apps/web/src/app/editor/examples/buttons/example.tsx
+++ b/apps/web/src/app/editor/examples/buttons/example.tsx
@@ -25,7 +25,7 @@ export function Buttons() {
         immediatelyRender={false}
       >
         <BubbleMenu.ButtonDefault />
-        <SlashCommand.Root items={[BUTTON]} />
+        <SlashCommand items={[BUTTON]} />
       </EditorProvider>
     </ExampleShell>
   );

--- a/apps/web/src/app/editor/examples/full-email-builder/example.tsx
+++ b/apps/web/src/app/editor/examples/full-email-builder/example.tsx
@@ -155,7 +155,7 @@ export function FullEmailBuilder() {
             />
             <BubbleMenu.LinkDefault />
             <BubbleMenu.ButtonDefault />
-            <SlashCommand.Root items={defaultSlashCommands} />
+            <SlashCommand items={defaultSlashCommands} />
             <ExportPanel />
           </div>
           <Sidebar />

--- a/apps/web/src/app/editor/examples/slash-commands/example.tsx
+++ b/apps/web/src/app/editor/examples/slash-commands/example.tsx
@@ -69,7 +69,7 @@ export function SlashCommands() {
         content={content}
         immediatelyRender={false}
       >
-        <SlashCommand.Root items={[...defaultSlashCommands, CUSTOM_COMMAND]} />
+        <SlashCommand items={[...defaultSlashCommands, CUSTOM_COMMAND]} />
       </EditorProvider>
     </ExampleShell>
   );

--- a/packages/editor/src/ui/slash-command/command-list.tsx
+++ b/packages/editor/src/ui/slash-command/command-list.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useRef } from 'react';
-import type { CommandListProps, SlashCommandItem } from './types';
+import type { SlashCommandItem, SlashCommandRenderProps } from './types';
 import { updateScrollView } from './utils';
 
 const CATEGORY_ORDER = ['Text', 'Media', 'Layout', 'Utility'];
@@ -58,7 +58,7 @@ export function CommandList({
   query,
   selectedIndex,
   onSelect,
-}: CommandListProps) {
+}: SlashCommandRenderProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {

--- a/packages/editor/src/ui/slash-command/index.ts
+++ b/packages/editor/src/ui/slash-command/index.ts
@@ -1,12 +1,3 @@
-import { CommandList } from './command-list';
-import { SlashCommandRoot } from './root';
-
-export const SlashCommand = {
-  Root: SlashCommandRoot,
-  CommandList,
-} as const;
-
-export { CommandList } from './command-list';
 export {
   BULLET_LIST,
   BUTTON,
@@ -24,9 +15,9 @@ export {
   THREE_COLUMNS,
   TWO_COLUMNS,
 } from './commands';
+export { SlashCommandRoot as SlashCommand } from './root';
 export { filterAndRankItems, scoreItem } from './search';
 export type {
-  CommandListProps,
   SearchableItem,
   SlashCommandItem,
   SlashCommandProps,

--- a/packages/editor/src/ui/slash-command/types.ts
+++ b/packages/editor/src/ui/slash-command/types.ts
@@ -38,10 +38,3 @@ export interface SlashCommandRootProps {
   allow?: (props: { editor: Editor }) => boolean;
   children?: (props: SlashCommandRenderProps) => ReactNode;
 }
-
-export interface CommandListProps {
-  items: SlashCommandItem[];
-  query: string;
-  selectedIndex: number;
-  onSelect: (index: number) => void;
-}

--- a/skills/react-email/references/EDITOR.md
+++ b/skills/react-email/references/EDITOR.md
@@ -186,7 +186,7 @@ Insert content blocks by typing `/` in the editor.
 import { defaultSlashCommands, SlashCommand } from '@react-email/editor/ui';
 
 <EditorProvider extensions={extensions} content={content}>
-  <SlashCommand.Root items={defaultSlashCommands} />
+  <SlashCommand items={defaultSlashCommands} />
 </EditorProvider>
 ```
 
@@ -212,7 +212,7 @@ Cherry-pick individual commands:
 ```tsx
 import { BUTTON, H1, H2, TEXT } from '@react-email/editor/ui';
 
-<SlashCommand.Root items={[TEXT, H1, H2, BUTTON]} />
+<SlashCommand items={[TEXT, H1, H2, BUTTON]} />
 ```
 
 ## Inspector


### PR DESCRIPTION
## Summary

- `CommandList` + `CommandListProps` removed from public API (closes [PRODUCT-1844](https://linear.app/resend/issue/PRODUCT-1844/stop-exporting-internal-commandlist-from-slashcommand))
- `SlashCommand.Root` collapsed into `SlashCommand`; use `<SlashCommand />`
- docs, examples, skills updated; changeset added

## Test plan

- [x] `pnpm --filter @react-email/editor test:unit` (407 pass)
- [x] `pnpm --filter @react-email/editor build` (clean)
- [ ] manually verify `/` menu in the slash-commands example

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the SlashCommand API by collapsing `SlashCommand.Root` into `SlashCommand` and removing `CommandList` from the public API. This aligns with PRODUCT-1844 and makes usage cleaner without changing behavior.

- **Refactors**
  - Replaced `SlashCommand.Root` with a single `SlashCommand` component.
  - Unexported `CommandList` and `CommandListProps` from `@react-email/editor/ui`.
  - Updated docs, examples, and skills; no UI or behavior changes.

- **Migration**
  - Replace `<SlashCommand.Root items={...} />` with `<SlashCommand items={...} />`.
  - Remove imports of `CommandList`/`CommandListProps`. Use `SlashCommand` render props instead: `{ items, query, selectedIndex, onSelect }`.
  - No changes needed to `defaultSlashCommands` or individual command imports.

<sup>Written for commit fc14445ffaf5c2a46460af44b9593b99565bd22d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

