### PR TITLE
chore: don't ignore tsconfig in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,6 @@
   "ignore": [
     "@benchmarks/preview-server",
     "@benchmarks/tailwind-component",
-    "tsconfig",
     "playground",
     "demo",
     "email-dev",


### PR DESCRIPTION
This reverts commit ed25acdb54b06dca9dcc667ac6244632f666a793.

<img width="1616" height="786" alt="image" src="https://github.com/user-attachments/assets/dd7aeb67-f946-48ce-a8ee-f45b82a0b210" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the `tsconfig` package in Changesets again by removing it from the ignore list. This restores version bumps and changelog entries when `tsconfig` changes.

<sup>Written for commit bb907cd9c00e579e7df4f2b089a9216069d0c633. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

