### PR TITLE
fix: avoid layout shift on the public page

### DIFF
--- a/apps/web/src/components/menu.tsx
+++ b/apps/web/src/components/menu.tsx
@@ -15,16 +15,6 @@ interface MenuItemProps {
 
 const GITHUB_URL = 'https://github.com/resend/react-email';
 
-async function getRepoStarCount() {
-  const res = await fetch('https://api.github.com/repos/resend/react-email');
-  const data = await res.json();
-  const starCount = data.stargazers_count;
-  if (starCount > 999) {
-    return `${(starCount / 1000).toFixed(1)}K`;
-  }
-  return starCount;
-}
-
 function MenuItem({ className, children, href, onClick }: MenuItemProps) {
   const pathname = usePathname();
   const [, activeItem] = pathname?.split('/') ?? [];
@@ -93,13 +83,13 @@ function MenuIcon() {
   );
 }
 
-function SocialIcons({ onItemClick }: { onItemClick: () => void }) {
-  const [starCount, setStarCount] = React.useState<string | number>('');
-
-  React.useEffect(() => {
-    getRepoStarCount().then(setStarCount);
-  }, []);
-
+function SocialIcons({
+  onItemClick,
+  starCount,
+}: {
+  onItemClick: () => void;
+  starCount: string;
+}) {
   return (
     <MenuItem
       className="w-fit gap-1.5 justify-center px-2"
@@ -117,12 +107,12 @@ function SocialIcons({ onItemClick }: { onItemClick: () => void }) {
           fill="currentColor"
         />
       </svg>
-      {starCount && <span>{starCount}</span>}
+      <span>{starCount}</span>
     </MenuItem>
   );
 }
 
-export function Menu() {
+export function Menu({ starCount }: { starCount: string }) {
   const [isDrawerOpen, setDrawerOpen] = React.useState(false);
 
   const handleItemClick = () => {
@@ -140,11 +130,11 @@ export function Menu() {
           className="sm:inline-block! mx-2 hidden h-5 w-px bg-slate-6"
         />
         <ul className="flex gap-2">
-          <SocialIcons onItemClick={handleItemClick} />
+          <SocialIcons onItemClick={handleItemClick} starCount={starCount} />
         </ul>
       </nav>
       <nav className="relative flex items-center gap-1 md:hidden">
-        <SocialIcons onItemClick={handleItemClick} />
+        <SocialIcons onItemClick={handleItemClick} starCount={starCount} />
         <ul className="flex gap-2">
           <Drawer.Root
             onOpenChange={setDrawerOpen}

--- a/apps/web/src/components/topbar.tsx
+++ b/apps/web/src/components/topbar.tsx
@@ -4,10 +4,24 @@ import type * as React from 'react';
 import { Logo } from './logo';
 import { Menu } from './menu';
 
-export function Topbar({
+async function getRepoStarCount() {
+  const res = await fetch('https://api.github.com/repos/resend/react-email', {
+    next: { revalidate: 3600, tags: ['github-repo-stars'] },
+  });
+  const data = await res.json();
+  const starCount = data.stargazers_count as number;
+  if (starCount > 999) {
+    return `${(starCount / 1000).toFixed(1)}K`;
+  }
+  return `${starCount}`;
+}
+
+export async function Topbar({
   className,
   ...props
 }: Omit<React.ComponentProps<'header'>, 'children'>) {
+  const starCount = await getRepoStarCount();
+
   return (
     <header
       className={classNames(
@@ -23,7 +37,7 @@ export function Topbar({
         <Logo />
         <span className="sr-only">Home</span>
       </Link>
-      <Menu />
+      <Menu starCount={starCount} />
     </header>
   );
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes layout shift in the public page header by moving the GitHub star count fetch to the server and rendering a stable star count in the menu.

- **Bug Fixes**
  - Fetch repo stars in `Topbar` on the server with `revalidate: 3600` and tag `github-repo-stars`.
  - Pass `starCount` to `Menu`/`SocialIcons`; remove client-side fetch/state and always render the star count to keep width stable.
  - Reduces client API calls and prevents header flicker on load.

<sup>Written for commit 8ef217efe42f3635eb2d42cfc89098fbdbc12385. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

