### PR TITLE
fix: resolve biome warnings that can't be auto-fixed

### DIFF
--- a/apps/docs/style.css
+++ b/apps/docs/style.css
@@ -2,24 +2,29 @@
 @media (min-width: 1024px) {
   /* Fix logo container width to match sidebar */
   #navbar .flex-1.flex.items-center.gap-x-4:has(img.nav-logo):has(> a) {
+    /* biome-ignore lint/complexity/noImportantStyles: required to override Mintlify's inline styles */
     flex: none !important;
     width: 14.75rem;
   }
 
   /* Let tabs fill remaining space */
   #navbar .flex.items-center.gap-4:has(.nav-tabs) {
+    /* biome-ignore lint/complexity/noImportantStyles: required to override Mintlify's inline styles */
     flex: 1 !important;
   }
 
   /* Spread tabs and push search/icons to the right */
   #navbar .ml-auto:has(.nav-tabs) {
+    /* biome-ignore lint/complexity/noImportantStyles: required to override Mintlify's inline styles */
     margin-left: 0 !important;
     justify-content: space-between;
+    /* biome-ignore lint/complexity/noImportantStyles: required to override Mintlify's inline styles */
     flex: 1 !important;
   }
 
   /* Right-align the search/icons nav */
   #navbar .gap-x-6:has(.nav-tabs) > nav {
+    /* biome-ignore lint/complexity/noImportantStyles: required to override Mintlify's inline styles */
     margin-left: auto !important;
   }
 }

--- a/packages/editor/src/core/types.ts
+++ b/packages/editor/src/core/types.ts
@@ -3,7 +3,6 @@
  * These types are used across the core module and can be imported by plugins and UI.
  */
 
-import type { Attrs } from '@tiptap/pm/model';
 import type { EditorEventMap, EditorEventName } from './event-bus';
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes all 6 biome lint warnings that `biome check --write` cannot auto-fix (they are marked as "unsafe" fixes).

### Changes

**`packages/editor/src/core/types.ts`**
- Removed unused `Attrs` import from `@tiptap/pm/model` (`noUnusedImports` warning). The type is already imported and used in `event-bus.ts` where it's needed.

**`apps/docs/style.css`**
- Added `biome-ignore` comments for 5 intentional `!important` declarations (`noImportantStyles` warnings). These `!important` styles are required to override Mintlify's inline styles on the navbar and cannot simply be removed.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0AG3A0TP7W/p1776266765742019?thread_ts=1776266765.742019&cid=C0AG3A0TP7W)

<div><a href="https://cursor.com/agents/bc-9d8db498-725b-5bd9-97a7-550cf7ee029b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d8db498-725b-5bd9-97a7-550cf7ee029b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remaining Biome lint warnings that auto-fix can’t handle by removing an unused import and documenting required `!important` overrides in the docs navbar.

- **Bug Fixes**
  - Removed unused `Attrs` import from `@tiptap/pm/model` in packages/editor/src/core/types.ts.
  - Added `biome-ignore` comments for 5 intentional `!important` rules in apps/docs/style.css to override Mintlify’s inline navbar styles.

<sup>Written for commit 0b5e5c140a50ca8417ff15d8c93c7fe5349fb9d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

