### PR TITLE
feat(editor): skip EditorFocusScopeProvider when one already exists higher up

### DIFF
--- a/.changeset/puny-sloths-decide.md
+++ b/.changeset/puny-sloths-decide.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": minor
+---
+
+don't add an extra focus scope provider if there's already one present above Inspector.Root

--- a/packages/editor/src/ui/editor-focus-scope.tsx
+++ b/packages/editor/src/ui/editor-focus-scope.tsx
@@ -11,9 +11,8 @@ interface FocusScopeContextValue {
   unregisterScope: (el: HTMLElement | null) => void;
 }
 
-const FocusScopeContext = React.createContext<FocusScopeContextValue | null>(
-  null,
-);
+export const FocusScopeContext =
+  React.createContext<FocusScopeContextValue | null>(null);
 
 export function useEditorFocusScope() {
   const context = React.useContext(FocusScopeContext);

--- a/packages/editor/src/ui/inspector/root.tsx
+++ b/packages/editor/src/ui/inspector/root.tsx
@@ -7,6 +7,7 @@ import type { NodeClickedEvent } from '../../core';
 import {
   EditorFocusScope,
   EditorFocusScopeProvider,
+  FocusScopeContext,
 } from '../editor-focus-scope';
 
 const IGNORED_NODES = ['doc', 'text'];
@@ -127,6 +128,7 @@ export function useInspector() {
 export const InspectorRoot = React.forwardRef<HTMLElement, RootProps>(
   function InspectorRoot({ children, asChild, ...restProps }, forwardedRef) {
     const { editor } = useCurrentEditor();
+    const existingFocusScope = React.useContext(FocusScopeContext);
 
     if (editor) {
       const hasEmailTheming = editor.extensionManager.extensions.some(
@@ -210,6 +212,14 @@ export const InspectorRoot = React.forwardRef<HTMLElement, RootProps>(
 
     const Component = asChild ? Slot : 'aside';
 
+    const inspectorContent = (
+      <EditorFocusScope>
+        <Component ref={forwardedRef} {...restProps} tabIndex={-1}>
+          {children}
+        </Component>
+      </EditorFocusScope>
+    );
+
     return (
       <InspectorContext.Provider
         value={{
@@ -217,13 +227,13 @@ export const InspectorRoot = React.forwardRef<HTMLElement, RootProps>(
           pathFromRoot,
         }}
       >
-        <EditorFocusScopeProvider>
-          <EditorFocusScope>
-            <Component ref={forwardedRef} {...restProps} tabIndex={-1}>
-              {children}
-            </Component>
-          </EditorFocusScope>
-        </EditorFocusScopeProvider>
+        {existingFocusScope ? (
+          inspectorContent
+        ) : (
+          <EditorFocusScopeProvider>
+            {inspectorContent}
+          </EditorFocusScopeProvider>
+        )}
       </InspectorContext.Provider>
     );
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In `Inspector.Root`, adds a `useContext(FocusScopeContext)` check before rendering the `EditorFocusScopeProvider`. If a provider already exists higher in the component tree (placed there by the user), `Inspector.Root` skips creating its own, freeing users to define one themselves at a higher level when needed.

## Changes

- **`packages/editor/src/ui/editor-focus-scope.tsx`**: Export `FocusScopeContext` so it can be consumed externally (was previously module-private).
- **`packages/editor/src/ui/inspector/root.tsx`**: Import `FocusScopeContext` and call `useContext(FocusScopeContext)` at the top of `InspectorRoot`. Conditionally wrap children with `EditorFocusScopeProvider` only when no existing provider is found.

## Behavior

- **No provider above**: `Inspector.Root` creates its own `EditorFocusScopeProvider` as before (backward compatible).
- **Provider above**: `Inspector.Root` reuses the existing one, only rendering the `EditorFocusScope` scope registration wrapper around its content.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0A9HFCVA13/p1776269191349359?thread_ts=1776269191.349359&cid=C0A9HFCVA13)

<div><a href="https://cursor.com/agents/bc-820028e9-86c4-5f1d-a9fe-0c751d3d1b66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-820028e9-86c4-5f1d-a9fe-0c751d3d1b66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inspector.Root now reuses a parent `EditorFocusScopeProvider` when present, avoiding nested providers and letting apps control focus scope at higher levels. Also exports `FocusScopeContext` for external use.

- **New Features**
  - Export `FocusScopeContext` from `editor-focus-scope`.
  - In `Inspector.Root`, check `useContext(FocusScopeContext)` and only wrap with `EditorFocusScopeProvider` if none exists; always render `EditorFocusScope`.
  - Add changeset for a minor release of `@react-email/editor`.

<sup>Written for commit 210fb847627fdef96b06621d6252a52bafe1d7f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

