### PR TITLE
feat: add canary tip banner to Editor examples page

### DIFF
--- a/apps/web/src/app/editor/examples/page.tsx
+++ b/apps/web/src/app/editor/examples/page.tsx
@@ -246,8 +246,9 @@ export default function EditorExamplesPage() {
             />
           </svg>
           <p className="text-sm text-cyan-11">
-            You are viewing the <span className="font-medium text-cyan-12">canary</span> version
-            of the editor. APIs and features may change without notice.
+            You are viewing the{' '}
+            <span className="font-medium text-cyan-12">canary</span> version of
+            the editor. APIs and features may change without notice.
           </p>
         </div>
 

--- a/apps/web/src/app/editor/examples/page.tsx
+++ b/apps/web/src/app/editor/examples/page.tsx
@@ -231,6 +231,26 @@ export default function EditorExamplesPage() {
           </div>
         </div>
 
+        <div className="mx-6 mb-10 flex items-start gap-3 rounded-lg border border-cyan-4 bg-cyan-2 p-4 md:mx-8">
+          <svg
+            className="mt-0.5 shrink-0 text-cyan-11"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M8 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM8 5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 8 5Zm0 8a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Z"
+              fill="currentColor"
+            />
+          </svg>
+          <p className="text-sm text-cyan-11">
+            You are viewing the <span className="font-medium text-cyan-12">canary</span> version
+            of the editor. APIs and features may change without notice.
+          </p>
+        </div>
+
         <div className="flex flex-col gap-12 px-6 pb-10 md:px-8">
           {sections.map((section) => (
             <div key={section.title}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a canary tip banner to the Editor examples page (`/editor/examples`) in `apps/web`, positioned between the intro section and the example cards grid.

### Design decisions

- **Color**: Uses the existing cyan color scale from the Radix dark alpha palette (`border-cyan-4`, `bg-cyan-2`, `text-cyan-11`, `text-cyan-12`) — consistent with the site's bluish/teal brand identity and matching the "Standalone Editor" section badge style already on this page.
- **Border radius**: Uses `rounded-lg` to match the card borders (`rounded-lg`) used for example cards on the same page.
- **Layout**: Horizontally aligned info icon + text, with responsive horizontal margins (`mx-6 md:mx-8`) matching the page's existing content padding.
- **Copy**: "You are viewing the **canary** version of the editor. APIs and features may change without notice."
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0A9HFCVA13/p1776269367465189?thread_ts=1776269367.465189&cid=C0A9HFCVA13)

<div><a href="https://cursor.com/agents/bc-9244188a-36b1-5e1d-87a0-1b5a1fe14003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9244188a-36b1-5e1d-87a0-1b5a1fe14003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a canary tip banner to the Editor examples page (`/editor/examples`) in `apps/web` to note users are on the canary editor and that APIs/features may change. It sits below the intro, matches page spacing, uses the cyan palette with `rounded-lg`, and includes a `Biome` text-formatting fix.

<sup>Written for commit ce4259a6c1ece1270dbc34a777e2ffaf18ead603. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

