### PR TITLE
fix(web): build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "typecheck": "tsc --noEmit",
     "start": "next start",
     "test:watch": "vitest --bail 1",
     "test": "vitest run --bail 1",

--- a/apps/web/src/app/editor/examples/image-upload/example.tsx
+++ b/apps/web/src/app/editor/examples/image-upload/example.tsx
@@ -163,9 +163,7 @@ export function ImageUpload() {
         />
         <BubbleMenu hideWhenActiveNodes={['image']} />
         <BubbleMenu.ImageDefault />
-        <SlashCommand.Root
-          items={[...defaultSlashCommands, imageSlashCommand]}
-        />
+        <SlashCommand items={[...defaultSlashCommands, imageSlashCommand]} />
       </EditorProvider>
     </ExampleShell>
   );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the web build by updating the image upload example to use the correct `SlashCommand` API and by adding a `typecheck` script for CI. Replaces `SlashCommand.Root` with `SlashCommand`, and adds `typecheck`: `tsc --noEmit`.

<sup>Written for commit beef93e3c490c4ce0613c8619d6074418fd6bb27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

