### PR TITLE
chore(editor): update TrailingNode docs to reflect array support for `appendTo`

### DIFF
--- a/apps/docs/editor/advanced/extensions.mdx
+++ b/apps/docs/editor/advanced/extensions.mdx
@@ -48,8 +48,9 @@ and exported:
 
 - `Container` keeps top-level content inside a dedicated email content wrapper and
   serializes it with React Email's `Container` component.
-- `TrailingNode` appends an empty paragraph when a container does not already end in one, so
-  the caret can move below the last block and users can keep typing naturally.
+- `TrailingNode` appends an empty paragraph when a container, section, or column does not
+  already end in one, so the caret can move below the last block and users can keep typing
+  naturally.
 
 This is the default `StarterKit` behavior:
 
@@ -59,7 +60,7 @@ const extensions = [
     Container: {},
     TrailingNode: {
       node: 'paragraph',
-      appendTo: 'container',
+      appendTo: ['container', 'section', 'columnsColumn'],
     },
   }),
 ];

--- a/apps/docs/editor/api-reference/extensions-list.mdx
+++ b/apps/docs/editor/api-reference/extensions-list.mdx
@@ -361,7 +361,7 @@ Shows placeholder text when the editor is empty.
 
 Keeps an empty block at the end of the target node so the caret can move below the
 last block and users can continue typing. In `StarterKit`, it is configured to append
-an empty paragraph inside each `container`.
+an empty paragraph inside each `container`, `section`, and `columnsColumn`.
 
 <ResponseField
   name="node"
@@ -371,9 +371,10 @@ an empty paragraph inside each `container`.
   Node type to insert when a trailing block is needed.
 </ResponseField>
 
-<ResponseField name="appendTo" type="string" default="'doc'">
-  Node type that receives the trailing block. `StarterKit` overrides this to
-  `'container'`.
+<ResponseField name="appendTo" type="string | string[]" default="'doc'">
+  Node type (or array of node types) that receives the trailing block. When an array is
+  provided, a trailing node is appended inside every matching node type. `StarterKit`
+  overrides this to `['container', 'section', 'columnsColumn']`.
 </ResponseField>
 
 <ResponseField name="notAfter" type="string | string[]" default="[]">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #3269 — updates the TrailingNode documentation to reflect that the `appendTo` option now accepts `string | string[]`.

## Changes

### `apps/docs/editor/api-reference/extensions-list.mdx`
- Updated the `appendTo` type from `string` to `string | string[]`
- Updated the description to explain that an array of node types can be provided, with trailing nodes appended inside every matching type
- Updated the `StarterKit` default from `'container'` to `['container', 'section', 'columnsColumn']`
- Updated the introductory prose to mention all three default node types

### `apps/docs/editor/advanced/extensions.mdx`
- Updated the prose to mention containers, sections, and columns
- Updated the code example to show the new array default: `appendTo: ['container', 'section', 'columnsColumn']`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0A9HFCVA13/p1776167809104129?thread_ts=1776167809.104129&cid=C0A9HFCVA13)

<div><a href="https://cursor.com/agents/bc-df8e07a5-13a8-5ef1-a185-b9465af1575c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df8e07a5-13a8-5ef1-a185-b9465af1575c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `TrailingNode` docs to show `appendTo` supports `string | string[]` and that arrays append inside every matching node type. Also updates `StarterKit` defaults and examples to `['container', 'section', 'columnsColumn']` in the API reference and advanced guide.

<sup>Written for commit dc60f443e202077351386b1c767b92ce3362aa22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

