### PR TITLE
feat(editor): add getEmailHTML/getEmailText, rename onChange to onUpdate

### DIFF
--- a/.changeset/get-email-html.md
+++ b/.changeset/get-email-html.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": major
+---
+
+add `getEmailHTML()` and `getEmailText()` to `EmailEditorRef`, remove `getHTML()`, rename `onChange` to `onUpdate`

--- a/apps/docs/editor/features/email-export.mdx
+++ b/apps/docs/editor/features/email-export.mdx
@@ -94,7 +94,7 @@ The ref exposes three export methods:
 |--------|---------|-------------|
 | `getEmailHTML()` | `Promise<string>` | Email-ready HTML |
 | `getEmailText()` | `Promise<string>` | Plain text version |
-| `export()` | `Promise<{ html, text }>` | Both in a single call |
+| `getEmail()` | `Promise<{ html, text }>` | Both in a single call |
 
 All three use `composeReactEmail` under the hood.
 

--- a/apps/docs/editor/features/email-export.mdx
+++ b/apps/docs/editor/features/email-export.mdx
@@ -60,6 +60,44 @@ export function MyEditor() {
 }
 ```
 
+## Using with EmailEditor
+
+If you use the standalone `EmailEditor` component, you can access the email HTML and plain text through ref methods — no need to call `composeReactEmail` directly.
+
+```tsx
+import { EmailEditor, type EmailEditorRef } from '@react-email/editor';
+import { useRef, useState } from 'react';
+
+export function MyEditor() {
+  const ref = useRef<EmailEditorRef>(null);
+  const [html, setHtml] = useState('');
+
+  const handleExport = async () => {
+    if (!ref.current) return;
+    const html = await ref.current.getEmailHTML();
+    setHtml(html);
+  };
+
+  return (
+    <div>
+      <EmailEditor ref={ref} content="<p>Edit me</p>" />
+      <button onClick={handleExport}>Export HTML</button>
+      {html && <textarea readOnly value={html} />}
+    </div>
+  );
+}
+```
+
+The ref exposes three export methods:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getEmailHTML()` | `Promise<string>` | Email-ready HTML |
+| `getEmailText()` | `Promise<string>` | Plain text version |
+| `export()` | `Promise<{ html, text }>` | Both in a single call |
+
+All three use `composeReactEmail` under the hood.
+
 ## How it works
 
 The `composeReactEmail` function follows this pipeline:

--- a/apps/web/src/app/editor/examples/standalone-editor-full/example.tsx
+++ b/apps/web/src/app/editor/examples/standalone-editor-full/example.tsx
@@ -31,8 +31,8 @@ export function StandaloneEditorFull() {
 
   const handleExportHtml = async () => {
     if (!editorRef.current) return;
-    const result = await editorRef.current.export();
-    setOutput(result.html);
+    const html = await editorRef.current.getEmailHTML();
+    setOutput(html);
   };
 
   const handleGetJson = () => {

--- a/apps/web/src/app/editor/examples/standalone-editor-full/page.tsx
+++ b/apps/web/src/app/editor/examples/standalone-editor-full/page.tsx
@@ -5,7 +5,7 @@ import { StandaloneEditorFull as Example } from './example';
 export const metadata: Metadata = {
   title: 'Standalone Editor — Full Features — Editor Examples',
   description:
-    'Theme switching, ref methods (export, getJSON), and callbacks — all with a single component.',
+    'Theme switching, ref methods (getEmailHTML, getJSON), and callbacks — all with a single component.',
   alternates: { canonical: '/editor/examples/standalone-editor-full' },
 };
 

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -22,14 +22,15 @@ import '../ui/themes/default.css';
 
 export interface EmailEditorRef {
   export: () => Promise<{ html: string; text: string }>;
+  getEmailHTML: () => Promise<string>;
+  getEmailText: () => Promise<string>;
   getJSON: () => JSONContent;
-  getHTML: () => string;
   editor: Editor | null;
 }
 
 export interface EmailEditorProps {
   content?: Content;
-  onChange?: (editor: Editor) => void;
+  onUpdate?: (editor: Editor) => void;
   onReady?: (editor: Editor) => void;
   theme?: 'basic' | 'minimal';
   editable?: boolean;
@@ -56,8 +57,17 @@ function RefBridge({ editorRef }: { editorRef: Ref<EmailEditorRef> }) {
         }
         return composeReactEmail({ editor });
       },
+      getEmailHTML: async () => {
+        if (!editor) return '';
+        const result = await composeReactEmail({ editor });
+        return result.html;
+      },
+      getEmailText: async () => {
+        if (!editor) return '';
+        const result = await composeReactEmail({ editor });
+        return result.text;
+      },
       getJSON: () => editor?.getJSON() ?? { type: 'doc', content: [] },
-      getHTML: () => editor?.getHTML() ?? '',
       editor,
     }),
     [editor],
@@ -70,7 +80,7 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
   (
     {
       content,
-      onChange,
+      onUpdate,
       onReady,
       theme = 'basic',
       editable = true,
@@ -118,7 +128,7 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
         editorProps={editorProps}
         editorContainerProps={{ className }}
         onCreate={({ editor }) => onReady?.(editor)}
-        onUpdate={({ editor }) => onChange?.(editor)}
+        onUpdate={({ editor }) => onUpdate?.(editor)}
       >
         <RefBridge editorRef={ref} />
         <BubbleMenu

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -8,8 +8,10 @@ import {
   forwardRef,
   type ReactNode,
   type Ref,
+  useEffect,
   useImperativeHandle,
   useMemo,
+  useRef,
 } from 'react';
 import { createPasteHandler } from '../core/create-paste-handler';
 import { composeReactEmail } from '../core/serializer/compose-react-email';
@@ -30,7 +32,7 @@ export interface EmailEditorRef {
 
 export interface EmailEditorProps {
   content?: Content;
-  onUpdate?: (editor: Editor) => void;
+  onUpdate?: (ref: EmailEditorRef) => void;
   onReady?: (editor: Editor) => void;
   theme?: 'basic' | 'minimal';
   editable?: boolean;
@@ -45,33 +47,52 @@ export interface EmailEditorProps {
   children?: ReactNode;
 }
 
-function RefBridge({ editorRef }: { editorRef: Ref<EmailEditorRef> }) {
+function buildRef(editor: Editor | null): EmailEditorRef {
+  return {
+    export: async () => {
+      if (!editor) return { html: '', text: '' };
+      return composeReactEmail({ editor });
+    },
+    getEmailHTML: async () => {
+      if (!editor) return '';
+      const result = await composeReactEmail({ editor });
+      return result.html;
+    },
+    getEmailText: async () => {
+      if (!editor) return '';
+      const result = await composeReactEmail({ editor });
+      return result.text;
+    },
+    getJSON: () => editor?.getJSON() ?? { type: 'doc', content: [] },
+    editor,
+  };
+}
+
+function RefBridge({
+  editorRef,
+  onUpdateRef,
+}: {
+  editorRef: Ref<EmailEditorRef>;
+  onUpdateRef: React.RefObject<((ref: EmailEditorRef) => void) | undefined>;
+}) {
   const { editor } = useCurrentEditor();
 
-  useImperativeHandle(
-    editorRef,
-    () => ({
-      export: async () => {
-        if (!editor) {
-          return { html: '', text: '' };
-        }
-        return composeReactEmail({ editor });
-      },
-      getEmailHTML: async () => {
-        if (!editor) return '';
-        const result = await composeReactEmail({ editor });
-        return result.html;
-      },
-      getEmailText: async () => {
-        if (!editor) return '';
-        const result = await composeReactEmail({ editor });
-        return result.text;
-      },
-      getJSON: () => editor?.getJSON() ?? { type: 'doc', content: [] },
-      editor,
-    }),
-    [editor],
-  );
+  const emailEditorRef = useMemo(() => buildRef(editor), [editor]);
+
+  useImperativeHandle(editorRef, () => emailEditorRef, [emailEditorRef]);
+
+  useEffect(() => {
+    if (!editor) return;
+
+    const handler = () => {
+      onUpdateRef.current?.(emailEditorRef);
+    };
+
+    editor.on('update', handler);
+    return () => {
+      editor.off('update', handler);
+    };
+  }, [editor, emailEditorRef, onUpdateRef]);
 
   return null;
 }
@@ -93,6 +114,9 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
     },
     ref,
   ) => {
+    const onUpdateRef = useRef(onUpdate);
+    onUpdateRef.current = onUpdate;
+
     const imageExtension = useMemo(() => {
       if (!onUploadImage) return null;
       return createImageExtension({ uploadImage: onUploadImage });
@@ -128,9 +152,8 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
         editorProps={editorProps}
         editorContainerProps={{ className }}
         onCreate={({ editor }) => onReady?.(editor)}
-        onUpdate={({ editor }) => onUpdate?.(editor)}
       >
-        <RefBridge editorRef={ref} />
+        <RefBridge editorRef={ref} onUpdateRef={onUpdateRef} />
         <BubbleMenu
           hideWhenActiveNodes={bubbleMenu?.hideWhenActiveNodes ?? ['button']}
           hideWhenActiveMarks={bubbleMenu?.hideWhenActiveMarks ?? ['link']}

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -23,7 +23,7 @@ import { SlashCommandRoot } from '../ui/slash-command/root';
 import '../ui/themes/default.css';
 
 export interface EmailEditorRef {
-  export: () => Promise<{ html: string; text: string }>;
+  getEmail: () => Promise<{ html: string; text: string }>;
   getEmailHTML: () => Promise<string>;
   getEmailText: () => Promise<string>;
   getJSON: () => JSONContent;
@@ -49,7 +49,7 @@ export interface EmailEditorProps {
 
 function buildRef(editor: Editor | null): EmailEditorRef {
   return {
-    export: async () => {
+    getEmail: async () => {
       if (!editor) return { html: '', text: '' };
       return composeReactEmail({ editor });
     },


### PR DESCRIPTION
## Summary

Replaces TipTap's raw `getHTML()` on `EmailEditorRef` with two new email-ready methods:

- **`getEmailHTML()`** — returns `Promise<string>` with the composed email HTML (uses `composeReactEmail` under the hood)
- **`getEmailText()`** — returns `Promise<string>` with the plain text version

The existing `export()` method is kept for getting both `{ html, text }` in a single call. The standalone `EmailEditor` component's `onChange` prop is renamed to `onUpdate` to align with TipTap's callback naming conventions.

Docs updated with a new "Using with EmailEditor" section in the email export guide, and the standalone-editor-full example now uses `getEmailHTML()`.

## Testing steps

- [ ] Verify `EmailEditorRef.getEmailHTML()` returns email-ready HTML string (not raw TipTap HTML)
- [ ] Verify `EmailEditorRef.getEmailText()` returns plain text version
- [ ] Verify `EmailEditorRef.export()` still returns `{ html, text }` as before
- [ ] Verify `EmailEditorRef.getJSON()` still works as before
- [ ] Verify `onUpdate` prop fires on content changes (previously `onChange`)
- [ ] Verify the standalone-editor-full example's "Export HTML" button works with `getEmailHTML()`
- [ ] Verify TypeScript compilation passes with no errors
- [ ] Check that `getHTML()` is no longer accessible on the ref type

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds email-ready export methods to `EmailEditor` and updates the change callback. Replaces TipTap `getHTML()` with `getEmailHTML()`/`getEmailText()`, renames `export()` to `getEmail()`, and `onChange` to `onUpdate`.

- **New Features**
  - `EmailEditorRef.getEmailHTML()` returns `Promise<string>` (via `composeReactEmail`)
  - `EmailEditorRef.getEmailText()` returns `Promise<string>`
  - `EmailEditorRef.getEmail()` returns `Promise<{ html, text }>`
  - Docs updated with a “Using with EmailEditor” section; example now uses `getEmailHTML()`

- **Migration**
  - `onChange` → `onUpdate` (callback now receives `EmailEditorRef`)
  - `getHTML()` removed → use `getEmailHTML()`
  - `export()` → `getEmail()`
  - Changeset marks `@react-email/editor` as a major release; `getJSON()` unchanged

<sup>Written for commit f0846bb3614505e4680058db6f7c4a7a060cc7a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

