### PR TITLE
fix(editor): root color picker autoclosing on click

### DIFF
--- a/.changeset/loud-experts-think.md
+++ b/.changeset/loud-experts-think.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+fix color pickers closing and not letting drag happen in root node

--- a/packages/editor/src/ui/editor-focus-scope.tsx
+++ b/packages/editor/src/ui/editor-focus-scope.tsx
@@ -39,15 +39,19 @@ export function EditorFocusScopeProvider({
 
   const handleFocusIn = React.useCallback(
     (event: FocusEvent) => {
-      if (editor) {
-        editor.isFocused = true;
-
-        const transaction = editor.state.tr
-          .setMeta('focus', { event })
-          .setMeta('addToHistory', false);
-
-        editor.view.dispatch(transaction);
+      if (!editor) return;
+      const t = event.target;
+      if (!(t instanceof Node) || !editor.view.dom.contains(t)) {
+        return;
       }
+
+      editor.isFocused = true;
+
+      const transaction = editor.state.tr
+        .setMeta('focus', { event })
+        .setMeta('addToHistory', false);
+
+      editor.view.dispatch(transaction);
     },
     [editor],
   );
@@ -72,7 +76,7 @@ export function EditorFocusScopeProvider({
         editor.view.dispatch(transaction);
       }
     },
-    [editor],
+    [editor, clearSelectionOnBlur],
   );
 
   const registerScope = React.useCallback(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the root inspector color picker closing on click and restores drag without closing. Focus and blur handling is now scoped to the editor DOM.

- **Bug Fixes**
  - Guard `handleFocusIn` to only dispatch when the event target is inside `editor.view.dom`.
  - Include `clearSelectionOnBlur` in the blur handler deps to prevent stale behavior that closed the picker.

- **Dependencies**
  - Add changeset to publish a patch for `@react-email/editor`.

<sup>Written for commit b2236280425f81891c96610a0d864178cc76aa80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

