### PR TITLE
chore(editor): add custom theme examples and documentation

### DIFF
--- a/apps/docs/editor/api-reference/theming-api.mdx
+++ b/apps/docs/editor/api-reference/theming-api.mdx
@@ -41,13 +41,33 @@ type EditorThemeInput = EditorTheme | ThemeConfig;
 
 ---
 
+### ThemeableComponent
+
+The subset of `KnownThemeComponents` that can be customized via `ThemeComponentStyles`:
+
+```tsx
+type ThemeableComponent =
+  | 'body'
+  | 'container'
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'link'
+  | 'image'
+  | 'button'
+  | 'codeBlock'
+  | 'inlineCode';
+```
+
+---
+
 ### ThemeComponentStyles
 
-CSS-in-JS styles keyed by component name:
+CSS-in-JS styles keyed by themeable component name:
 
 ```tsx
 type ThemeComponentStyles = {
-  [K in KnownThemeComponents]?: React.CSSProperties & {
+  [K in ThemeableComponent]?: React.CSSProperties & {
     align?: 'center' | 'left' | 'right';
   };
 };

--- a/apps/docs/editor/api-reference/theming-api.mdx
+++ b/apps/docs/editor/api-reference/theming-api.mdx
@@ -16,8 +16,9 @@ import { EmailTheming } from '@react-email/editor/plugins';
 const extensions = [StarterKit, EmailTheming.configure({ theme: 'basic' })];
 ```
 
-<ResponseField name="theme" type="EditorTheme" default="'basic'">
-  The active theme. Built-in options: `'basic'` or `'minimal'`.
+<ResponseField name="theme" type="EditorThemeInput" default="'basic'">
+  The active theme. Accepts a built-in preset (`'basic'` or `'minimal'`) or a `ThemeConfig`
+  object for custom themes.
 </ResponseField>
 
 ## Types
@@ -27,6 +28,51 @@ const extensions = [StarterKit, EmailTheming.configure({ theme: 'basic' })];
 ```tsx
 type EditorTheme = 'basic' | 'minimal';
 ```
+
+---
+
+### EditorThemeInput
+
+The widened theme type accepted by the `theme` prop and `EmailTheming.configure()`:
+
+```tsx
+type EditorThemeInput = EditorTheme | ThemeConfig;
+```
+
+---
+
+### ThemeComponentStyles
+
+CSS-in-JS styles keyed by component name:
+
+```tsx
+type ThemeComponentStyles = {
+  [K in KnownThemeComponents]?: React.CSSProperties & {
+    align?: 'center' | 'left' | 'right';
+  };
+};
+```
+
+---
+
+### ThemeConfig
+
+A custom theme configuration object:
+
+```tsx
+interface ThemeConfig {
+  extends?: EditorTheme;
+  styles: ThemeComponentStyles;
+}
+```
+
+<ResponseField name="extends" type="EditorTheme">
+  The built-in theme to inherit from. If omitted, uses `'minimal'` reset styles as a base.
+</ResponseField>
+
+<ResponseField name="styles" type="ThemeComponentStyles" required>
+  CSS-in-JS styles keyed by component name. Values are merged on top of the base theme.
+</ResponseField>
 
 ---
 
@@ -119,6 +165,54 @@ interface PanelInputProperty {
   category?: string;
 }
 ```
+
+## Theme helpers
+
+### createTheme
+
+Creates a custom theme from scratch (uses `minimal` reset as base):
+
+```tsx
+import { createTheme } from '@react-email/editor/plugins';
+
+const theme = createTheme({
+  body: { backgroundColor: '#1a1a2e', color: '#e2e8f0' },
+  button: { backgroundColor: '#3b82f6', color: '#fff' },
+});
+```
+
+<ResponseField name="styles" type="ThemeComponentStyles" required>
+  CSS-in-JS styles keyed by component name.
+</ResponseField>
+
+Returns a `ThemeConfig` object.
+
+---
+
+### extendTheme
+
+Extends a built-in theme with style overrides:
+
+```tsx
+import { extendTheme } from '@react-email/editor/plugins';
+
+const theme = extendTheme('basic', {
+  body: { backgroundColor: '#eff6ff' },
+  button: { backgroundColor: '#2563eb', borderRadius: '6px' },
+});
+```
+
+<ResponseField name="base" type="EditorTheme" required>
+  The built-in theme to extend (`'basic'` or `'minimal'`).
+</ResponseField>
+
+<ResponseField name="overrides" type="ThemeComponentStyles" required>
+  CSS-in-JS styles to merge on top of the base theme.
+</ResponseField>
+
+Returns a `ThemeConfig` object.
+
+---
 
 ## Utility functions
 

--- a/apps/docs/editor/features/theming.mdx
+++ b/apps/docs/editor/features/theming.mdx
@@ -93,6 +93,77 @@ export function MyEditor() {
   ensuring the new theme is applied cleanly.
 </Info>
 
+## Custom themes
+
+Instead of being limited to built-in presets, you can define custom themes using a CSS-in-JS
+object that maps component names to styles.
+
+### Extending a built-in theme
+
+Use `extendTheme` to start from a built-in theme and override specific styles:
+
+```tsx
+import { StarterKit } from '@react-email/editor/extensions';
+import { EmailTheming, extendTheme } from '@react-email/editor/plugins';
+import { EditorProvider } from '@tiptap/react';
+
+const brandTheme = extendTheme('basic', {
+  body: { backgroundColor: '#eff6ff' },
+  h1: { color: '#1e40af', fontSize: '28px' },
+  button: { backgroundColor: '#2563eb', color: '#fff', borderRadius: '6px' },
+  link: { color: '#2563eb' },
+});
+
+const extensions = [StarterKit, EmailTheming.configure({ theme: brandTheme })];
+
+export function MyEditor() {
+  return (
+    <EditorProvider extensions={extensions} content={content}>
+      {/* ... */}
+    </EditorProvider>
+  );
+}
+```
+
+### Creating a theme from scratch
+
+Use `createTheme` to build a theme without inheriting from a built-in preset.
+When no `extends` is set, the `minimal` reset is used as a base:
+
+```tsx
+import { createTheme } from '@react-email/editor/plugins';
+
+const darkTheme = createTheme({
+  body: { backgroundColor: '#1a1a2e', color: '#e2e8f0' },
+  container: { backgroundColor: '#16213e', color: '#e2e8f0' },
+  h1: { color: '#e2e8f0' },
+  link: { color: '#60a5fa' },
+  button: { backgroundColor: '#3b82f6', color: '#fff', borderRadius: '4px' },
+});
+```
+
+### Passing a theme config inline
+
+You can also pass a `ThemeConfig` object directly to the `theme` prop without using the
+helper functions:
+
+```tsx
+<EmailEditor
+  theme={{
+    extends: 'basic',
+    styles: {
+      body: { backgroundColor: '#f4f4f5' },
+      button: { backgroundColor: '#0670DB' },
+    },
+  }}
+/>
+```
+
+<Info>
+  Custom theme values appear in the inspector UI, and users can still tweak them
+  interactively. The inspector doesn't distinguish between built-in and custom values.
+</Info>
+
 ## Theme components
 
 Themes define styles for the following email components:
@@ -140,6 +211,9 @@ See theming in action with a runnable example:
 
 <CardGroup cols={2}>
   <Card title="Email Theming" icon="code" href="https://react.email/editor/examples/email-theming">
-    Basic/Minimal theme toggle with live preview.
+    Basic/Minimal/Custom theme toggle with live preview.
+  </Card>
+  <Card title="Custom Themes" icon="palette" href="https://react.email/editor/examples/custom-theme">
+    Define custom themes with createTheme and extendTheme.
   </Card>
 </CardGroup>

--- a/apps/web/src/app/editor/examples/custom-theme/example.tsx
+++ b/apps/web/src/app/editor/examples/custom-theme/example.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { StarterKit } from '@react-email/editor/extensions';
+import {
+  createTheme,
+  type EditorThemeInput,
+  EmailTheming,
+  extendTheme,
+} from '@react-email/editor/plugins';
+import { BubbleMenu } from '@react-email/editor/ui';
+import type { JSONContent } from '@tiptap/react';
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react';
+import { useRef, useState } from 'react';
+import { ExampleShell } from '../example-shell';
+
+const initialContent = {
+  type: 'doc',
+  content: [
+    {
+      type: 'heading',
+      attrs: { level: 1 },
+      content: [{ type: 'text', text: 'Custom Theme Demo' }],
+    },
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'This example shows three approaches to theme customization: extending a built-in theme, creating one from scratch, and using a built-in preset.',
+        },
+      ],
+    },
+    {
+      type: 'heading',
+      attrs: { level: 2 },
+      content: [{ type: 'text', text: 'Try switching themes' }],
+    },
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'Notice how colors, typography, and spacing change between each option.',
+        },
+      ],
+    },
+  ],
+};
+
+const brandTheme = extendTheme('basic', {
+  body: { backgroundColor: '#eff6ff' },
+  container: { backgroundColor: '#ffffff' },
+  h1: { color: '#1e40af', fontSize: '28px' },
+  h2: { color: '#2563eb' },
+  link: { color: '#2563eb', textDecoration: 'underline' },
+  button: {
+    backgroundColor: '#2563eb',
+    color: '#ffffff',
+    borderRadius: '6px',
+  },
+});
+
+const darkTheme = createTheme({
+  body: { backgroundColor: '#1a1a2e', color: '#e2e8f0' },
+  container: {
+    backgroundColor: '#16213e',
+    color: '#e2e8f0',
+    paddingTop: '24px',
+    paddingBottom: '24px',
+    paddingLeft: '24px',
+    paddingRight: '24px',
+  },
+  h1: { color: '#e2e8f0', fontSize: '28px' },
+  h2: { color: '#94a3b8' },
+  link: { color: '#60a5fa', textDecoration: 'underline' },
+  button: {
+    backgroundColor: '#3b82f6',
+    color: '#ffffff',
+    borderRadius: '4px',
+  },
+});
+
+type ThemeOption = 'basic' | 'brand' | 'dark';
+
+const themes: Record<ThemeOption, { label: string; theme: EditorThemeInput }> =
+  {
+    basic: { label: 'Basic (built-in)', theme: 'basic' },
+    brand: { label: 'Brand (extendTheme)', theme: brandTheme },
+    dark: { label: 'Dark (createTheme)', theme: darkTheme },
+  };
+
+export function CustomThemeExample() {
+  const [selected, setSelected] = useState<ThemeOption>('basic');
+  const contentRef = useRef<JSONContent>(initialContent);
+  const { theme } = themes[selected];
+
+  const editor = useEditor(
+    {
+      extensions: [StarterKit, EmailTheming.configure({ theme })],
+      content: contentRef.current,
+      immediatelyRender: false,
+      onUpdate: ({ editor: e }) => {
+        contentRef.current = e.getJSON();
+      },
+    },
+    [selected],
+  );
+
+  return (
+    <ExampleShell
+      title="Custom themes"
+      description="Define custom themes with createTheme and extendTheme."
+    >
+      <div className="flex gap-2 mb-4 flex-wrap">
+        {(Object.keys(themes) as ThemeOption[]).map((key) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setSelected(key)}
+            className={`px-3 py-1.5 border border-(--re-border) rounded-lg cursor-pointer text-[0.8125rem] ${
+              selected === key
+                ? 'bg-(--re-text) text-(--re-bg) font-medium'
+                : 'bg-(--re-bg) text-(--re-text) hover:bg-(--re-hover)'
+            }`}
+          >
+            {themes[key].label}
+          </button>
+        ))}
+      </div>
+      <EditorContext.Provider value={{ editor }}>
+        <EditorContent editor={editor} />
+        <BubbleMenu />
+      </EditorContext.Provider>
+    </ExampleShell>
+  );
+}

--- a/apps/web/src/app/editor/examples/custom-theme/page.tsx
+++ b/apps/web/src/app/editor/examples/custom-theme/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next';
+import { ExamplePageShell } from '../example-page-shell';
+import { getExampleGitHubUrl, getExampleSource } from '../get-example-source';
+import { CustomThemeExample as Example } from './example';
+
+export const metadata: Metadata = {
+  title: 'Custom themes — Editor examples',
+  description:
+    'Define custom themes with createTheme and extendTheme helpers.',
+  alternates: { canonical: '/editor/examples/custom-theme' },
+};
+
+export default async function Page() {
+  const sourceCode = await getExampleSource('custom-theme');
+
+  return (
+    <ExamplePageShell
+      slug="custom-theme"
+      heading="Custom themes"
+      docsUrl="https://react.email/docs/editor/features/theming"
+      sourceCode={sourceCode}
+      githubUrl={getExampleGitHubUrl('custom-theme')}
+    >
+      <Example />
+    </ExamplePageShell>
+  );
+}

--- a/apps/web/src/app/editor/examples/custom-theme/page.tsx
+++ b/apps/web/src/app/editor/examples/custom-theme/page.tsx
@@ -5,8 +5,7 @@ import { CustomThemeExample as Example } from './example';
 
 export const metadata: Metadata = {
   title: 'Custom themes — Editor examples',
-  description:
-    'Define custom themes with createTheme and extendTheme helpers.',
+  description: 'Define custom themes with createTheme and extendTheme helpers.',
   alternates: { canonical: '/editor/examples/custom-theme' },
 };
 

--- a/apps/web/src/app/editor/examples/email-theming/example.tsx
+++ b/apps/web/src/app/editor/examples/email-theming/example.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { StarterKit } from '@react-email/editor/extensions';
-import { EmailTheming } from '@react-email/editor/plugins';
+import {
+  type EditorThemeInput,
+  EmailTheming,
+  extendTheme,
+} from '@react-email/editor/plugins';
 import { BubbleMenu } from '@react-email/editor/ui';
 import type { JSONContent } from '@tiptap/react';
 import { EditorContent, EditorContext, useEditor } from '@tiptap/react';
@@ -21,7 +25,7 @@ const initialContent = {
       content: [
         {
           type: 'text',
-          text: 'This is a themed email editor. Toggle between Basic and Minimal themes to see how styles change.',
+          text: 'This is a themed email editor. Toggle between Basic, Minimal, and Custom themes to see how styles change.',
         },
       ],
     },
@@ -37,11 +41,32 @@ const initialContent = {
   ],
 };
 
-type EditorTheme = 'basic' | 'minimal';
+const customTheme = extendTheme('basic', {
+  body: { backgroundColor: '#f8f4ff' },
+  container: { backgroundColor: '#ffffff', borderRadius: '8px' },
+  h1: { color: '#6d28d9' },
+  h2: { color: '#7c3aed' },
+  h3: { color: '#8b5cf6' },
+  link: { color: '#7c3aed' },
+  button: {
+    backgroundColor: '#7c3aed',
+    color: '#ffffff',
+    borderRadius: '6px',
+  },
+});
+
+type ThemeOption = 'basic' | 'minimal' | 'custom';
+
+const themeMap: Record<ThemeOption, EditorThemeInput> = {
+  basic: 'basic',
+  minimal: 'minimal',
+  custom: customTheme,
+};
 
 export function EmailThemingExample() {
-  const [theme, setTheme] = useState<EditorTheme>('basic');
+  const [selected, setSelected] = useState<ThemeOption>('basic');
   const contentRef = useRef<JSONContent>(initialContent);
+  const theme = themeMap[selected];
 
   const editor = useEditor(
     {
@@ -52,37 +77,29 @@ export function EmailThemingExample() {
         contentRef.current = e.getJSON();
       },
     },
-    [theme],
+    [selected],
   );
 
   return (
     <ExampleShell
       title="Email theming"
-      description="Switch between Basic and Minimal themes to see how email styles change."
+      description="Switch between Basic, Minimal, and Custom themes to see how email styles change."
     >
       <div className="flex gap-2 mb-4">
-        <button
-          type="button"
-          onClick={() => setTheme('basic')}
-          className={`px-3 py-1.5 border border-(--re-border) rounded-lg cursor-pointer text-[0.8125rem] ${
-            theme === 'basic'
-              ? 'bg-(--re-text) text-(--re-bg) font-medium'
-              : 'bg-(--re-bg) text-(--re-text) hover:bg-(--re-hover)'
-          }`}
-        >
-          Basic
-        </button>
-        <button
-          type="button"
-          onClick={() => setTheme('minimal')}
-          className={`px-3 py-1.5 border border-(--re-border) rounded-lg cursor-pointer text-[0.8125rem] ${
-            theme === 'minimal'
-              ? 'bg-(--re-text) text-(--re-bg) font-medium'
-              : 'bg-(--re-bg) text-(--re-text) hover:bg-(--re-hover)'
-          }`}
-        >
-          Minimal
-        </button>
+        {(['basic', 'minimal', 'custom'] as const).map((option) => (
+          <button
+            key={option}
+            type="button"
+            onClick={() => setSelected(option)}
+            className={`px-3 py-1.5 border border-(--re-border) rounded-lg cursor-pointer text-[0.8125rem] capitalize ${
+              selected === option
+                ? 'bg-(--re-text) text-(--re-bg) font-medium'
+                : 'bg-(--re-bg) text-(--re-text) hover:bg-(--re-hover)'
+            }`}
+          >
+            {option}
+          </button>
+        ))}
       </div>
       <EditorContext.Provider value={{ editor }}>
         <EditorContent editor={editor} />

--- a/apps/web/src/app/editor/examples/page.tsx
+++ b/apps/web/src/app/editor/examples/page.tsx
@@ -124,7 +124,14 @@ const sections: Section[] = [
         slug: 'email-theming',
         title: 'Email theming',
         description:
-          'Switch between Basic and Minimal themes to see how email styles change.',
+          'Switch between Basic, Minimal, and Custom themes to see how email styles change.',
+        docsUrl: 'https://react.email/docs/editor/features/theming',
+      },
+      {
+        slug: 'custom-theme',
+        title: 'Custom themes',
+        description:
+          'Define custom themes with createTheme and extendTheme helpers.',
         docsUrl: 'https://react.email/docs/editor/features/theming',
       },
       {

--- a/apps/web/src/illustrations/editor-examples/custom-theme.tsx
+++ b/apps/web/src/illustrations/editor-examples/custom-theme.tsx
@@ -1,0 +1,6 @@
+import { IllustrationPlaceholder } from './illustration-placeholder';
+import type { IllustrationProps } from './illustration-shared';
+
+export default function Illustration({ tone }: IllustrationProps) {
+  return <IllustrationPlaceholder tone={tone} />;
+}


### PR DESCRIPTION
## Summary

Adds documentation and interactive examples for the theme customization API introduced in #3301.

**Documentation updates:**
- `theming.mdx` — new "Custom themes" section with `extendTheme`, `createTheme`, and inline `ThemeConfig` examples
- `theming-api.mdx` — new types (`ThemeConfig`, `ThemeComponentStyles`, `EditorThemeInput`) and theme helper functions (`createTheme`, `extendTheme`)

**Example updates:**
- Updated `email-theming` example with a third "Custom" toggle (uses `extendTheme` with purple brand colors)
- New `custom-theme` example showing all three approaches: built-in preset, `extendTheme` (brand theme), and `createTheme` (dark theme)
- Registered new example in the examples index page

## Testing steps

- [ ] Visit `/editor/examples/email-theming` — verify Basic, Minimal, and Custom toggles work
- [ ] Visit `/editor/examples/custom-theme` — verify Basic, Brand, and Dark toggles work
- [ ] Verify custom theme styles are visible in the editor preview (e.g. purple headings, blue buttons)
- [ ] Verify inspector reflects custom theme values when a custom theme is active
- [ ] Review `theming.mdx` docs render correctly on the docs site
- [ ] Review `theming-api.mdx` docs render correctly with new types and helpers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs and interactive examples for custom editor themes, including `createTheme`/`extendTheme` and a new Custom toggle in the theming demo. Updates the API to accept `EditorThemeInput` and documents `ThemeConfig`, `ThemeableComponent`, and `ThemeComponentStyles`.

- **New Features**
  - Docs & API: `theming.mdx` adds “Custom themes” with `extendTheme`, `createTheme`, and inline `ThemeConfig`. `theming-api.mdx` widens `theme` to `EditorThemeInput`, adds `ThemeableComponent`, fixes `ThemeComponentStyles` to use it, and documents `createTheme`/`extendTheme` from `@react-email/editor/plugins`.
  - Examples: `email-theming` adds a “Custom” option using `extendTheme`. New `custom-theme` example shows a built‑in preset, a brand theme via `extendTheme`, and a dark theme via `createTheme`. Both are listed on the examples page, with an illustration placeholder for the new example.

<sup>Written for commit eda95e731b46c5540fe3b456973ba31002b8a39b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

