### PR TITLE
fix: remove margin from send button and fix typos

### DIFF
--- a/.changeset/vast-pigs-shine.md
+++ b/.changeset/vast-pigs-shine.md
@@ -1,0 +1,5 @@
+---
+"@react-email/ui": major
+---
+
+remove extra margin from sending button

--- a/.changeset/vast-pigs-shine.md
+++ b/.changeset/vast-pigs-shine.md
@@ -1,5 +1,5 @@
 ---
-"@react-email/ui": major
+"@react-email/ui": patch
 ---
 
 remove extra margin from sending button

--- a/apps/demo/emails/01-Barebone/feature-announcement.tsx
+++ b/apps/demo/emails/01-Barebone/feature-announcement.tsx
@@ -69,7 +69,7 @@ export const FeatureAnnouncementEmail = ({
               <Section className="bg-bg-2 mb-6 mobile:mb-2 px-6 mobile:px-4 py-20 mobile:py-12 pb-16 mobile:pb-10 rounded-[10px]">
                 <Section className="mx-auto mb-16 max-w-[422px] text-center">
                   <Text className="mt-0 mb-4 font-13 font-sans text-fg-3">
-                    The new from {companyName}
+                    What's new from {companyName}
                   </Text>
                   <Heading
                     as="h1"

--- a/apps/demo/emails/04-Arcane/order-confirmation.tsx
+++ b/apps/demo/emails/04-Arcane/order-confirmation.tsx
@@ -66,7 +66,7 @@ export const OrderConfirmationEmail = ({
               <Section className="mobile:px-6 px-[40px] pt-[80px] pb-[56px]">
                 <Section className="mb-[48px]">
                   <Text className="font-72 text-fg mb-8 max-w-[480px] font-serif">
-                    Your Order has been placed
+                    Your order has been placed
                   </Text>
                   <Text className="font-15 text-fg-2 m-0 mt-3 max-w-[480px] font-sans">
                     Your order #1234567890 has been confirmed!

--- a/apps/demo/emails/04-Arcane/order-shipping.tsx
+++ b/apps/demo/emails/04-Arcane/order-shipping.tsx
@@ -87,7 +87,7 @@ export const OrderShippingEmail = ({
               <Section className="mobile:px-6 px-[40px] pt-[80px] pb-[56px]">
                 <Section className="mb-[48px]">
                   <Text className="font-72 text-fg mb-8 max-w-[480px] font-serif">
-                    Your Order has Shipped
+                    Your order has shipped
                   </Text>
                   <Text className="font-15 text-fg-2 m-0 mt-3 max-w-[480px] font-sans">
                     Order #1234567890 is on the way.

--- a/apps/demo/emails/05-Studio/order-confirmation.tsx
+++ b/apps/demo/emails/05-Studio/order-confirmation.tsx
@@ -65,7 +65,7 @@ export const TechOrderConfirmationEmail = ({
                 <Section className="mx-auto px-8 mobile:px-0">
                   <Section className="max-w-[420px]">
                     <Text className="m-0 font-40 font-geist text-fg">
-                      Your Order has been placed
+                      Your order has been placed
                     </Text>
                     <Text className="m-0 mt-6 font-14 font-sans text-fg-2">
                       Order #1234567890 is locked in—we&apos;re prepping your

--- a/apps/demo/emails/05-Studio/order-shipping.tsx
+++ b/apps/demo/emails/05-Studio/order-shipping.tsx
@@ -83,7 +83,7 @@ export const TechOrderShippingEmail = ({
                 <Section className="mx-auto">
                   <Section className="max-w-[420px]">
                     <Text className="m-0 font-40 font-geist text-fg">
-                      Your Order has Shipped
+                      Your order has shipped
                     </Text>
                     <Text className="m-0 mt-6 font-14 font-sans text-fg-2">
                       Order #1234567890 with your Halo ring is on the way. Tap

--- a/apps/demo/emails/Community/newsletters/codepen-challengers.tsx
+++ b/apps/demo/emails/Community/newsletters/codepen-challengers.tsx
@@ -77,7 +77,7 @@ export const CodepenChallengersEmail = () => (
             <Text className="text-base">
               This week's starter template features an ice cube emoji to help
               inspire a "cool" idea for your Pen. As always, the template is
-              just as jumping off point. Feel free to incorporate the 🧊 in your
+              just a jumping off point. Feel free to incorporate the 🧊 in your
               creation, add more elements, or freeze it out completely and start
               over from scratch!
             </Text>

--- a/packages/ui/src/components/send.tsx
+++ b/packages/ui/src/components/send.tsx
@@ -111,7 +111,7 @@ export const Send = ({ markup }: { markup: string }) => {
               type="checkbox"
             />
             <div className="mt-3 flex items-center justify-between">
-              <div className="flex flex-col inline-block">
+              <div className="inline-flex flex-col">
                 <Text size="1">
                   Powered by{' '}
                   <a
@@ -125,7 +125,7 @@ export const Send = ({ markup }: { markup: string }) => {
                 </Text>
               </div>
               <Button
-                className="disabled:border-transparent disabled:bg-slate-11"
+                className="disabled:border-transparent disabled:bg-slate-11 m-0"
                 disabled={subject.length === 0 || to.length === 0 || isSending}
                 type="submit"
               >


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes unintended margin from the `Send` button in `@react-email/ui` to fix spacing and alignment. Also corrects typos and capitalization in demo email templates.

- **Bug Fixes**
  - `@react-email/ui`: removed extra margin from `Send` button, switched to `inline-flex`, and added a patch changeset.
  - Demo emails: fixed copy to "What's new…", "Your order has been placed/shipped", and "just a jumping off point".

<sup>Written for commit c208d03e93b7d73acc22e8594f68fc24fea8d691. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

