### PR TITLE
chore(docs): update updating guide

### DIFF
--- a/apps/docs/getting-started/updating-react-email.mdx
+++ b/apps/docs/getting-started/updating-react-email.mdx
@@ -12,20 +12,41 @@ import NextSteps from '/snippets/next-steps.mdx';
 
 All components (previously in `@react-email/components` or individual packages like `@react-email/button`) and rendering utilities (previously in `@react-email/render`) are now exported directly from `react-email`. This unifies the install and import experience into a single package.
 
+Now, what was previously `@react-email/preview-server` was moved over to `@react-email/ui`, so you will also need to replace that.
+
 To update:
 
-1. **Update your dependencies** -- remove `@react-email/components`, keep `react-email`:
+1. **Update your dependencies** -- remove `@react-email/components` and `@react-email/preview-server`, keep `react-email` and add `@react-email/ui`:
 
-   ```diff
-   - npm install @react-email/components react-email @react-email/ui
-   + npm install react-email @react-email/ui
+   <CodeGroup>
+
+   ```sh npm
+   npm uninstall @react-email/components @react-email/preview-server
+   npm install react-email@latest @react-email/ui@latest
    ```
+
+   ```sh yarn
+   yarn remove @react-email/components @react-email/preview-server
+   yarn install react-email@latest @react-email/ui@latest
+   ```
+
+   ```sh pnpm
+   pnpm remove @react-email/components @react-email/preview-server
+   pnpm install react-email@latest @react-email/ui@latest
+   ```
+
+   ```sh bun
+   bun remove @react-email/components @react-email/preview-server
+   bun install react-email@latest @react-email/ui@latest
+   ```
+
+   </CodeGroup>
 
 2. **Update your imports**:
 
-   ```diff
-   - import { Button, Html, Head, render } from "@react-email/components";
-   + import { Button, Html, Head, render } from "react-email";
+   ```tsx
+   import { Button, Html, Head, render } from "@react-email/components"; // [!code --]
+   import { Button, Html, Head, render } from "react-email"; // [!code ++]
    ```
 
 3. The `@react-email/ui` and `@react-email/editor` packages are not included in `react-email`


### PR DESCRIPTION
1. talk about the @react-email/preview-server -> @react-email/ui move
2. improve the code block to use mintlify's added/removed lines syntax
3. add uninstall/install scripts for pnpm, yarn and bun

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the “Updating React Email” guide to reflect the move from `@react-email/preview-server` to `@react-email/ui` and the unified imports from `react-email`, with clearer, copy‑pasteable install steps.

- **Migration**
  - Replace `@react-email/preview-server` with `@react-email/ui`.
  - Add uninstall/install commands for npm, yarn, pnpm, and bun in a `CodeGroup`.
  - Update import example to use `react-email` with Mintlify added/removed line syntax.
  - Clarify that `@react-email/ui` and `@react-email/editor` are not included in `react-email`.

<sup>Written for commit 49165a05987427ca457d82c7721dc55e8db766a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

