### PR TITLE
feat(editor): pass editor container to EmailEditor onReady

### DIFF
--- a/.changeset/funny-pears-listen.md
+++ b/.changeset/funny-pears-listen.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Align `EmailEditor`'s `onReady` callback with `onUpdate` so it receives `EmailEditorRef`

--- a/apps/web/src/components/sections/editor.tsx
+++ b/apps/web/src/components/sections/editor.tsx
@@ -59,8 +59,8 @@ export const EditorHomepage = () => {
         <EmailEditor
           content={INITIAL_CONTENT}
           className="flex-1 overflow-auto px-6 w-full [&>div]:w-full [&_div]:outline-none"
-          onReady={async (ref) => {
-            const html = await ref.getEmailHTML();
+          onReady={async (editor) => {
+            const html = await editor.getEmailHTML();
             setHtml(html);
           }}
           onUpdate={async (editor) => {

--- a/apps/web/src/components/sections/editor.tsx
+++ b/apps/web/src/components/sections/editor.tsx
@@ -60,7 +60,9 @@ export const EditorHomepage = () => {
         <EmailEditor
           content={INITIAL_CONTENT}
           className="flex-1 overflow-auto px-6 w-full [&>div]:w-full [&_div]:outline-none"
-          onReady={async (editor) => {
+          onReady={async (ref) => {
+            const editor = ref.editor;
+            if (!editor) return;
             const { html } = await composeReactEmail({ editor });
             setHtml(html);
           }}

--- a/apps/web/src/components/sections/editor.tsx
+++ b/apps/web/src/components/sections/editor.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { EmailEditor } from '@react-email/editor';
-import { composeReactEmail } from '@react-email/editor/core';
 import { ArrowRightIcon, SendHorizonal, X } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -61,9 +60,7 @@ export const EditorHomepage = () => {
           content={INITIAL_CONTENT}
           className="flex-1 overflow-auto px-6 w-full [&>div]:w-full [&_div]:outline-none"
           onReady={async (ref) => {
-            const editor = ref.editor;
-            if (!editor) return;
-            const { html } = await composeReactEmail({ editor });
+            const html = await ref.getEmailHTML();
             setHtml(html);
           }}
           onUpdate={async (editor) => {

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -34,7 +34,7 @@ export interface EmailEditorRef {
 export interface EmailEditorProps {
   content?: Content;
   onUpdate?: (ref: EmailEditorRef) => void;
-  onReady?: (ref: EmailEditorRef, editorContainer: HTMLDivElement) => void;
+  onReady?: (ref: EmailEditorRef) => void;
   theme?: 'basic' | 'minimal';
   editable?: boolean;
   placeholder?: string;
@@ -101,19 +101,13 @@ function RefBridge({
 function EmailEditorReadyBridge({
   onReadyRef,
 }: {
-  onReadyRef: React.RefObject<
-    ((ref: EmailEditorRef, editorContainer: HTMLDivElement) => void) | undefined
-  >;
+  onReadyRef: React.RefObject<((ref: EmailEditorRef) => void) | undefined>;
 }) {
   const { editor } = useCurrentEditor();
 
   useLayoutEffect(() => {
     if (!editor) return;
-
-    const wrapper = editor.view.dom.parentElement;
-    if (!wrapper || !(wrapper instanceof HTMLDivElement)) return;
-
-    onReadyRef.current?.(buildRef(editor), wrapper);
+    onReadyRef.current?.(buildRef(editor));
   }, [editor, onReadyRef]);
 
   return null;

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -13,6 +13,7 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import { createPasteHandler } from '../core/create-paste-handler';
 import { composeReactEmail } from '../core/serializer/compose-react-email';
@@ -29,12 +30,13 @@ export interface EmailEditorRef {
   getEmailText: () => Promise<string>;
   getJSON: () => JSONContent;
   editor: Editor | null;
+  editorContainer: HTMLDivElement | null;
 }
 
 export interface EmailEditorProps {
   content?: Content;
   onUpdate?: (ref: EmailEditorRef) => void;
-  onReady?: (editor: Editor, editorContainer: HTMLDivElement) => void;
+  onReady?: (ref: EmailEditorRef) => void;
   theme?: 'basic' | 'minimal';
   editable?: boolean;
   placeholder?: string;
@@ -48,7 +50,10 @@ export interface EmailEditorProps {
   children?: ReactNode;
 }
 
-function buildRef(editor: Editor | null): EmailEditorRef {
+function buildRef(
+  editor: Editor | null,
+  editorContainer: HTMLDivElement | null = null,
+): EmailEditorRef {
   return {
     getEmail: async () => {
       if (!editor) return { html: '', text: '' };
@@ -66,19 +71,25 @@ function buildRef(editor: Editor | null): EmailEditorRef {
     },
     getJSON: () => editor?.getJSON() ?? { type: 'doc', content: [] },
     editor,
+    editorContainer,
   };
 }
 
 function RefBridge({
   editorRef,
   onUpdateRef,
+  editorContainer,
 }: {
   editorRef: Ref<EmailEditorRef>;
   onUpdateRef: React.RefObject<((ref: EmailEditorRef) => void) | undefined>;
+  editorContainer: HTMLDivElement | null;
 }) {
   const { editor } = useCurrentEditor();
 
-  const emailEditorRef = useMemo(() => buildRef(editor), [editor]);
+  const emailEditorRef = useMemo(
+    () => buildRef(editor, editorContainer),
+    [editor, editorContainer],
+  );
 
   useImperativeHandle(editorRef, () => emailEditorRef, [emailEditorRef]);
 
@@ -100,23 +111,29 @@ function RefBridge({
 
 function EmailEditorReadyBridge({
   onReadyRef,
+  onEditorContainer,
 }: {
-  onReadyRef: React.RefObject<
-    ((editor: Editor, editorContainer: HTMLDivElement) => void) | undefined
-  >;
+  onReadyRef: React.RefObject<((ref: EmailEditorRef) => void) | undefined>;
+  onEditorContainer: (el: HTMLDivElement | null) => void;
 }) {
   const { editor } = useCurrentEditor();
 
   useLayoutEffect(() => {
     if (!editor) return;
-    const onReady = onReadyRef.current;
-    if (!onReady) return;
 
     const wrapper = editor.view.dom.parentElement;
-    if (!wrapper || !(wrapper instanceof HTMLDivElement)) return;
+    if (!wrapper || !(wrapper instanceof HTMLDivElement)) {
+      onEditorContainer(null);
+      return;
+    }
 
-    onReady(editor, wrapper);
-  }, [editor, onReadyRef]);
+    onEditorContainer(wrapper);
+    onReadyRef.current?.(buildRef(editor, wrapper));
+
+    return () => {
+      onEditorContainer(null);
+    };
+  }, [editor, onReadyRef, onEditorContainer]);
 
   return null;
 }
@@ -143,6 +160,10 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
 
     const onReadyRef = useRef(onReady);
     onReadyRef.current = onReady;
+
+    const [editorContainer, setEditorContainer] = useState<HTMLDivElement | null>(
+      null,
+    );
 
     const imageExtension = useMemo(() => {
       if (!onUploadImage) return null;
@@ -179,8 +200,15 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
         editorProps={editorProps}
         editorContainerProps={{ className }}
       >
-        <RefBridge editorRef={ref} onUpdateRef={onUpdateRef} />
-        <EmailEditorReadyBridge onReadyRef={onReadyRef} />
+        <RefBridge
+          editorRef={ref}
+          onUpdateRef={onUpdateRef}
+          editorContainer={editorContainer}
+        />
+        <EmailEditorReadyBridge
+          onReadyRef={onReadyRef}
+          onEditorContainer={setEditorContainer}
+        />
         <BubbleMenu
           hideWhenActiveNodes={bubbleMenu?.hideWhenActiveNodes ?? ['button']}
           hideWhenActiveMarks={bubbleMenu?.hideWhenActiveMarks ?? ['link']}

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -10,6 +10,7 @@ import {
   type Ref,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
 } from 'react';
@@ -33,7 +34,7 @@ export interface EmailEditorRef {
 export interface EmailEditorProps {
   content?: Content;
   onUpdate?: (ref: EmailEditorRef) => void;
-  onReady?: (editor: Editor) => void;
+  onReady?: (editor: Editor, editorContainer: HTMLDivElement) => void;
   theme?: 'basic' | 'minimal';
   editable?: boolean;
   placeholder?: string;
@@ -97,6 +98,29 @@ function RefBridge({
   return null;
 }
 
+function EmailEditorReadyBridge({
+  onReadyRef,
+}: {
+  onReadyRef: React.RefObject<
+    ((editor: Editor, editorContainer: HTMLDivElement) => void) | undefined
+  >;
+}) {
+  const { editor } = useCurrentEditor();
+
+  useLayoutEffect(() => {
+    if (!editor) return;
+    const onReady = onReadyRef.current;
+    if (!onReady) return;
+
+    const wrapper = editor.view.dom.parentElement;
+    if (!wrapper || !(wrapper instanceof HTMLDivElement)) return;
+
+    onReady(editor, wrapper);
+  }, [editor, onReadyRef]);
+
+  return null;
+}
+
 export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
   (
     {
@@ -116,6 +140,9 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
   ) => {
     const onUpdateRef = useRef(onUpdate);
     onUpdateRef.current = onUpdate;
+
+    const onReadyRef = useRef(onReady);
+    onReadyRef.current = onReady;
 
     const imageExtension = useMemo(() => {
       if (!onUploadImage) return null;
@@ -151,9 +178,9 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
         immediatelyRender={false}
         editorProps={editorProps}
         editorContainerProps={{ className }}
-        onCreate={({ editor }) => onReady?.(editor)}
       >
         <RefBridge editorRef={ref} onUpdateRef={onUpdateRef} />
+        <EmailEditorReadyBridge onReadyRef={onReadyRef} />
         <BubbleMenu
           hideWhenActiveNodes={bubbleMenu?.hideWhenActiveNodes ?? ['button']}
           hideWhenActiveMarks={bubbleMenu?.hideWhenActiveMarks ?? ['link']}

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -13,7 +13,6 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
-  useState,
 } from 'react';
 import { createPasteHandler } from '../core/create-paste-handler';
 import { composeReactEmail } from '../core/serializer/compose-react-email';
@@ -30,13 +29,12 @@ export interface EmailEditorRef {
   getEmailText: () => Promise<string>;
   getJSON: () => JSONContent;
   editor: Editor | null;
-  editorContainer: HTMLDivElement | null;
 }
 
 export interface EmailEditorProps {
   content?: Content;
   onUpdate?: (ref: EmailEditorRef) => void;
-  onReady?: (ref: EmailEditorRef) => void;
+  onReady?: (ref: EmailEditorRef, editorContainer: HTMLDivElement) => void;
   theme?: 'basic' | 'minimal';
   editable?: boolean;
   placeholder?: string;
@@ -50,10 +48,7 @@ export interface EmailEditorProps {
   children?: ReactNode;
 }
 
-function buildRef(
-  editor: Editor | null,
-  editorContainer: HTMLDivElement | null = null,
-): EmailEditorRef {
+function buildRef(editor: Editor | null): EmailEditorRef {
   return {
     getEmail: async () => {
       if (!editor) return { html: '', text: '' };
@@ -71,25 +66,19 @@ function buildRef(
     },
     getJSON: () => editor?.getJSON() ?? { type: 'doc', content: [] },
     editor,
-    editorContainer,
   };
 }
 
 function RefBridge({
   editorRef,
   onUpdateRef,
-  editorContainer,
 }: {
   editorRef: Ref<EmailEditorRef>;
   onUpdateRef: React.RefObject<((ref: EmailEditorRef) => void) | undefined>;
-  editorContainer: HTMLDivElement | null;
 }) {
   const { editor } = useCurrentEditor();
 
-  const emailEditorRef = useMemo(
-    () => buildRef(editor, editorContainer),
-    [editor, editorContainer],
-  );
+  const emailEditorRef = useMemo(() => buildRef(editor), [editor]);
 
   useImperativeHandle(editorRef, () => emailEditorRef, [emailEditorRef]);
 
@@ -111,10 +100,10 @@ function RefBridge({
 
 function EmailEditorReadyBridge({
   onReadyRef,
-  onEditorContainer,
 }: {
-  onReadyRef: React.RefObject<((ref: EmailEditorRef) => void) | undefined>;
-  onEditorContainer: (el: HTMLDivElement | null) => void;
+  onReadyRef: React.RefObject<
+    ((ref: EmailEditorRef, editorContainer: HTMLDivElement) => void) | undefined
+  >;
 }) {
   const { editor } = useCurrentEditor();
 
@@ -122,18 +111,10 @@ function EmailEditorReadyBridge({
     if (!editor) return;
 
     const wrapper = editor.view.dom.parentElement;
-    if (!wrapper || !(wrapper instanceof HTMLDivElement)) {
-      onEditorContainer(null);
-      return;
-    }
+    if (!wrapper || !(wrapper instanceof HTMLDivElement)) return;
 
-    onEditorContainer(wrapper);
-    onReadyRef.current?.(buildRef(editor, wrapper));
-
-    return () => {
-      onEditorContainer(null);
-    };
-  }, [editor, onReadyRef, onEditorContainer]);
+    onReadyRef.current?.(buildRef(editor), wrapper);
+  }, [editor, onReadyRef]);
 
   return null;
 }
@@ -160,10 +141,6 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
 
     const onReadyRef = useRef(onReady);
     onReadyRef.current = onReady;
-
-    const [editorContainer, setEditorContainer] = useState<HTMLDivElement | null>(
-      null,
-    );
 
     const imageExtension = useMemo(() => {
       if (!onUploadImage) return null;
@@ -200,15 +177,8 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
         editorProps={editorProps}
         editorContainerProps={{ className }}
       >
-        <RefBridge
-          editorRef={ref}
-          onUpdateRef={onUpdateRef}
-          editorContainer={editorContainer}
-        />
-        <EmailEditorReadyBridge
-          onReadyRef={onReadyRef}
-          onEditorContainer={setEditorContainer}
-        />
+        <RefBridge editorRef={ref} onUpdateRef={onUpdateRef} />
+        <EmailEditorReadyBridge onReadyRef={onReadyRef} />
         <BubbleMenu
           hideWhenActiveNodes={bubbleMenu?.hideWhenActiveNodes ?? ['button']}
           hideWhenActiveMarks={bubbleMenu?.hideWhenActiveMarks ?? ['link']}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`EmailEditor` now exposes `onReady` with the same shape as `onUpdate`.

## Implementation

- `onReady` now receives only `EmailEditorRef`.
- The homepage example now uses `editor.getEmailHTML()` directly and uses the same callback parameter name in both `onReady` and `onUpdate`.
- No `editorContainer` field or extra wrapper argument remains in the public API.
- Added a patch changeset for `@react-email/editor`.

## API

```ts
onUpdate?: (ref: EmailEditorRef) => void;
onReady?: (ref: EmailEditorRef) => void;
```

`onReady` still fires after the editor is available, but the API is now fully aligned with `onUpdate`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c9d148b-bcc5-4e99-9f85-c60ea32f1e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c9d148b-bcc5-4e99-9f85-c60ea32f1e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`EmailEditor` `onReady` now fires after mount and takes the same `EmailEditorRef` as `onUpdate`. The homepage example now calls `editor.getEmailHTML()` and uses the same param name; patch changeset added for `@react-email/editor`.

- **New Features**
  - Updated signature: `onReady(ref: EmailEditorRef)`.
  - Added `EmailEditorReadyBridge` with `useLayoutEffect`; removed `onCreate` to prevent early firing.

<sup>Written for commit b9fd257a94e77b040294e38f064861a99d24cb82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

