### PR TITLE
fix: turbo's playground caching

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -31,6 +31,13 @@
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
+    "playground#build": {
+      "dependsOn": [
+        "^build",
+        "^postbuild"
+      ],
+      "outputs": [".react-email/**", "!.react-email/.next/cache/**"]
+    },
     "demo#build": {
       "dependsOn": [
         "^build",

--- a/turbo.json
+++ b/turbo.json
@@ -32,10 +32,7 @@
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "playground#build": {
-      "dependsOn": [
-        "^build",
-        "^postbuild"
-      ],
+      "dependsOn": ["^build", "^postbuild"],
       "outputs": [".react-email/**", "!.react-email/.next/cache/**"]
     },
     "demo#build": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Turbo caching for the playground with a new `playground#build` pipeline. It caches `.react-email/**`, ignores `.react-email/.next/cache/**`, and depends on `^build` and `^postbuild` to avoid stale artifacts and speed up builds.

<sup>Written for commit a5f68ef4466f18441edefdaed1822143688fe350. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

