### PR TITLE
fix: keep "Editor" highlighted in topbar on editor subpages

### DIFF
--- a/apps/web/src/components/menu.tsx
+++ b/apps/web/src/components/menu.tsx
@@ -17,6 +17,11 @@ const GITHUB_URL = 'https://github.com/resend/react-email';
 
 function MenuItem({ children, className, href, onClick }: MenuItemProps) {
   const pathname = usePathname();
+  const normalizedPathname = pathname?.replace(/\/$/, '') ?? '';
+  const normalizedHref = href.replace(/\/$/, '');
+  const isActive =
+    normalizedPathname === normalizedHref ||
+    normalizedPathname.startsWith(`${normalizedHref}/`);
 
   return (
     <TabButton
@@ -24,7 +29,7 @@ function MenuItem({ children, className, href, onClick }: MenuItemProps) {
       className={className}
       onClick={onClick}
       tabIndex={0}
-      data-active={pathname?.replace(/\/$/, '') === href.replace(/\/$/, '')}
+      data-active={isActive}
     >
       <SmartLink href={href}>{children}</SmartLink>
     </TabButton>

--- a/apps/web/src/components/menu.tsx
+++ b/apps/web/src/components/menu.tsx
@@ -19,9 +19,12 @@ function MenuItem({ children, className, href, onClick }: MenuItemProps) {
   const pathname = usePathname();
   const normalizedPathname = pathname?.replace(/\/$/, '') ?? '';
   const normalizedHref = href.replace(/\/$/, '');
+  const sectionHref = normalizedHref.startsWith('/')
+    ? `/${normalizedHref.split('/')[1] ?? ''}`
+    : normalizedHref;
   const isActive =
-    normalizedPathname === normalizedHref ||
-    normalizedPathname.startsWith(`${normalizedHref}/`);
+    normalizedPathname === sectionHref ||
+    normalizedPathname.startsWith(`${sectionHref}/`);
 
   return (
     <TabButton


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The "Editor" item in the topbar navigation was losing its active/highlighted state when navigating to subpages under `/editor` (e.g. `/editor/examples/standalone-editor`) or to `/editor` itself.

### Root cause

The `MenuItem` component in `apps/web/src/components/menu.tsx` used strict equality (`===`) to compare the current pathname against the menu item's `href`. Since the Editor item points to `/editor/examples`, any path like `/editor` or `/editor/examples/<slug>` would not match, and the highlight would disappear.

### Fix

Replaced the strict equality check with section-based prefix matching. The first path segment is extracted from the menu item's `href` (e.g. `/editor` from `/editor/examples`) and used for matching. A menu item is now considered active if the current pathname either:
- Equals the top-level section path exactly (e.g. `/editor`), **or**
- Starts with the section path followed by `/` (e.g. `/editor/examples`, `/editor/examples/standalone-editor`)

This ensures the "Editor" tab stays highlighted on `/editor`, `/editor/examples`, and all deeper editor subpages. The same correct behavior applies to all other topbar items (Components, Templates, Docs).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0A9HFCVA13/p1776359707519859?thread_ts=1776359707.519859&cid=C0A9HFCVA13)

<div><a href="https://cursor.com/agents/bc-f7f8a237-6feb-5048-97dd-173de6e69f39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7f8a237-6feb-5048-97dd-173de6e69f39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the topbar menu active on section pages and subpages. The "Editor" tab now stays highlighted on `/editor`, `/editor/examples`, and any nested routes; same logic applies to other tabs.

- **Bug Fixes**
  - Updated `MenuItem` in `apps/web/src/components/menu.tsx` to extract the top-level section from `href` and use prefix matching on a normalized pathname: active if it equals the section (e.g., `/editor`) or starts with it (`/editor/...`).

<sup>Written for commit 70d6a1000bd2895a8987da82426bf58d0023a92f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

