### PR TITLE
chore(editor): manually bump to 1.0

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/editor",
-  "version": "0.0.0-canary.51",
+  "version": "1.0.0-canary.51",
   "description": "A rich text editor for editing and building email templates",
   "sideEffects": [
     "**/*.css"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `@react-email/editor` to 1.0.0-canary.51 to start the v1 prerelease stream and align installs with `^1` ranges. No code changes.

<sup>Written for commit 1d0dbd42e5f27ca085d393de85bcff9e42df3bc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

