### PR TITLE
chore: exit canary

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "canary",
   "initialVersions": {
     "demo": "0.0.0",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Exit canary pre-release mode to resume normal releases. Updated `.changeset/pre.json` to set `mode` from `pre` to `exit`.

<sup>Written for commit 3b1efd82edebcb74a22827e008913f81761892b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

