### PR TITLE
fix(editor): numeric styles getting reset after blur

### DIFF
--- a/packages/editor/src/__tests__/inspector-padding.browser.spec.tsx
+++ b/packages/editor/src/__tests__/inspector-padding.browser.spec.tsx
@@ -1,12 +1,8 @@
 import { NodeSelection } from '@tiptap/pm/state';
-import { useRef } from 'react';
+import { vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
-import { vi } from 'vitest';
-import {
-  EmailEditor,
-  type EmailEditorRef,
-} from '../email-editor/email-editor';
+import { EmailEditor, type EmailEditorRef } from '../email-editor/email-editor';
 import { Inspector } from '../ui/inspector';
 
 const CONTENT = {
@@ -31,7 +27,7 @@ const CONTENT = {
 function Harness({
   editorRef,
 }: {
-  editorRef: React.MutableRefObject<EmailEditorRef | null>;
+  editorRef: React.RefObject<EmailEditorRef | null>;
 }) {
   return (
     <EmailEditor
@@ -97,7 +93,7 @@ async function waitForPaddingInputWithValue(expected: string) {
 
 describe('inspector padding input (browser)', () => {
   it('keeps the same value after focus + blur', async () => {
-    const editorRef: React.MutableRefObject<EmailEditorRef | null> = {
+    const editorRef: React.RefObject<EmailEditorRef | null> = {
       current: null,
     };
     render(<Harness editorRef={editorRef} />);
@@ -120,7 +116,7 @@ describe('inspector padding input (browser)', () => {
   });
 
   it('keeps a newly committed value after a subsequent focus + blur', async () => {
-    const editorRef: React.MutableRefObject<EmailEditorRef | null> = {
+    const editorRef: React.RefObject<EmailEditorRef | null> = {
       current: null,
     };
     render(<Harness editorRef={editorRef} />);

--- a/packages/editor/src/__tests__/inspector-padding.browser.spec.tsx
+++ b/packages/editor/src/__tests__/inspector-padding.browser.spec.tsx
@@ -145,3 +145,90 @@ describe('inspector padding input (browser)', () => {
     expect(paddingInput.value).toBe('12');
   });
 });
+
+const HSL_CONTENT = {
+  type: 'doc',
+  content: [
+    {
+      type: 'section',
+      attrs: {
+        style: 'background-color: hsl(200, 50%, 40%);',
+      },
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Inside section' }],
+        },
+      ],
+    },
+  ],
+};
+
+function HslHarness({
+  editorRef,
+}: {
+  editorRef: React.RefObject<EmailEditorRef | null>;
+}) {
+  return (
+    <EmailEditor
+      ref={(value) => {
+        editorRef.current = value;
+      }}
+      content={HSL_CONTENT}
+    >
+      <Inspector.Root data-testid="inspector">
+        <Inspector.Node />
+      </Inspector.Root>
+    </EmailEditor>
+  );
+}
+
+async function waitForBackgroundSection() {
+  return vi.waitFor(() => {
+    const inspector = document.querySelector<HTMLElement>(
+      '[data-testid="inspector"]',
+    );
+    if (!inspector) throw new Error('Inspector not rendered yet');
+    const header = Array.from(
+      inspector.querySelectorAll<HTMLElement>(
+        '[data-re-inspector-section-header]',
+      ),
+    ).find((h) => h.textContent?.includes('Background'));
+    const section = header?.closest<HTMLElement>('[data-re-inspector-section]');
+    if (!section) throw new Error('Background section not rendered yet');
+    return section;
+  });
+}
+
+describe('inspector background color input (browser)', () => {
+  it('does not strip % from HSL color values at parse time', async () => {
+    const editorRef: React.RefObject<EmailEditorRef | null> = {
+      current: null,
+    };
+    render(<HslHarness editorRef={editorRef} />);
+
+    const editor = page.getByRole('textbox');
+    await expect.element(editor).toBeVisible();
+
+    selectSectionNode(editorRef.current);
+
+    const hexInput = await vi.waitFor(() => {
+      const bg = document.querySelector<HTMLElement>(
+        '[data-testid="inspector"]',
+      );
+      if (!bg) throw new Error('Inspector not rendered yet');
+      return waitForBackgroundSection().then((section) => {
+        const input = section.querySelector<HTMLInputElement>(
+          'input[data-re-inspector-color-hex]',
+        );
+        if (!input) throw new Error('Color hex input not rendered yet');
+        if (input.value === '') {
+          throw new Error('Color hex input not populated yet');
+        }
+        return input;
+      });
+    });
+
+    expect(hexInput.value).toBe('hsl(200, 50%, 40%)');
+  });
+});

--- a/packages/editor/src/__tests__/inspector-padding.browser.spec.tsx
+++ b/packages/editor/src/__tests__/inspector-padding.browser.spec.tsx
@@ -1,0 +1,151 @@
+import { NodeSelection } from '@tiptap/pm/state';
+import { useRef } from 'react';
+import { page, userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { vi } from 'vitest';
+import {
+  EmailEditor,
+  type EmailEditorRef,
+} from '../email-editor/email-editor';
+import { Inspector } from '../ui/inspector';
+
+const CONTENT = {
+  type: 'doc',
+  content: [
+    {
+      type: 'section',
+      attrs: {
+        style:
+          'padding-top: 44px; padding-right: 44px; padding-bottom: 44px; padding-left: 44px;',
+      },
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Inside section' }],
+        },
+      ],
+    },
+  ],
+};
+
+function Harness({
+  editorRef,
+}: {
+  editorRef: React.MutableRefObject<EmailEditorRef | null>;
+}) {
+  return (
+    <EmailEditor
+      ref={(value) => {
+        editorRef.current = value;
+      }}
+      content={CONTENT}
+    >
+      <Inspector.Root data-testid="inspector">
+        <Inspector.Node />
+      </Inspector.Root>
+    </EmailEditor>
+  );
+}
+
+function selectSectionNode(editorRef: EmailEditorRef | null) {
+  const editor = editorRef?.editor;
+  if (!editor) throw new Error('Editor not ready');
+  let sectionPos = -1;
+  editor.state.doc.descendants((node, pos) => {
+    if (sectionPos === -1 && node.type.name === 'section') {
+      sectionPos = pos;
+      return false;
+    }
+    return true;
+  });
+  if (sectionPos === -1) throw new Error('Section not found');
+  editor.view.focus();
+  const selection = NodeSelection.create(editor.state.doc, sectionPos);
+  editor.view.dispatch(editor.state.tr.setSelection(selection));
+}
+
+async function waitForSpacingSection() {
+  return vi.waitFor(() => {
+    const inspector = document.querySelector<HTMLElement>(
+      '[data-testid="inspector"]',
+    );
+    if (!inspector) throw new Error('Inspector not rendered yet');
+    const header = Array.from(
+      inspector.querySelectorAll<HTMLElement>(
+        '[data-re-inspector-section-header]',
+      ),
+    ).find((h) => h.textContent?.includes('Spacing'));
+    const section = header?.closest<HTMLElement>('[data-re-inspector-section]');
+    if (!section) throw new Error('Spacing section not rendered yet');
+    return section;
+  });
+}
+
+async function waitForPaddingInputWithValue(expected: string) {
+  return vi.waitFor(async () => {
+    const spacing = await waitForSpacingSection();
+    const input = spacing.querySelector<HTMLInputElement>(
+      'input[data-re-inspector-input]',
+    );
+    if (!input) throw new Error('Padding input not rendered yet');
+    if (input.value !== expected) {
+      throw new Error(`expected ${expected}, got ${input.value}`);
+    }
+    return input;
+  });
+}
+
+describe('inspector padding input (browser)', () => {
+  it('keeps the same value after focus + blur', async () => {
+    const editorRef: React.MutableRefObject<EmailEditorRef | null> = {
+      current: null,
+    };
+    render(<Harness editorRef={editorRef} />);
+
+    const editor = page.getByRole('textbox');
+    await expect.element(editor).toBeVisible();
+
+    selectSectionNode(editorRef.current);
+
+    const paddingInput = await waitForPaddingInputWithValue('44');
+
+    paddingInput.focus();
+    expect(document.activeElement).toBe(paddingInput);
+
+    paddingInput.blur();
+    expect(document.activeElement).not.toBe(paddingInput);
+
+    // The value must still be "44" — not reset to "0".
+    expect(paddingInput.value).toBe('44');
+  });
+
+  it('keeps a newly committed value after a subsequent focus + blur', async () => {
+    const editorRef: React.MutableRefObject<EmailEditorRef | null> = {
+      current: null,
+    };
+    render(<Harness editorRef={editorRef} />);
+
+    const editor = page.getByRole('textbox');
+    await expect.element(editor).toBeVisible();
+
+    selectSectionNode(editorRef.current);
+
+    const paddingInput = await waitForPaddingInputWithValue('44');
+
+    paddingInput.focus();
+    paddingInput.select();
+    await userEvent.keyboard('12');
+    await userEvent.keyboard('{Enter}');
+
+    await vi.waitFor(() => {
+      if (paddingInput.value !== '12') {
+        throw new Error(`expected 12, got ${paddingInput.value}`);
+      }
+    });
+
+    paddingInput.focus();
+    paddingInput.blur();
+
+    expect(paddingInput.value).toBe('12');
+  });
+});

--- a/packages/editor/src/ui/inspector/components/padding-picker.tsx
+++ b/packages/editor/src/ui/inspector/components/padding-picker.tsx
@@ -40,7 +40,6 @@ export function PaddingPicker({
   const [expanded, setExpanded] = React.useState(!allEqual);
 
   const handleChange = (key: keyof PaddingValues, newValue: number) => {
-    console.log('changing padding', key, newValue);
     onChange({
       paddingTop: value.paddingTop ?? 0,
       paddingRight: value.paddingRight ?? 0,

--- a/packages/editor/src/ui/inspector/components/padding-picker.tsx
+++ b/packages/editor/src/ui/inspector/components/padding-picker.tsx
@@ -40,6 +40,7 @@ export function PaddingPicker({
   const [expanded, setExpanded] = React.useState(!allEqual);
 
   const handleChange = (key: keyof PaddingValues, newValue: number) => {
+    console.log('changing padding', key, newValue);
     onChange({
       paddingTop: value.paddingTop ?? 0,
       paddingRight: value.paddingRight ?? 0,

--- a/packages/editor/src/ui/inspector/node.tsx
+++ b/packages/editor/src/ui/inspector/node.tsx
@@ -6,6 +6,7 @@ import {
   stylesToCss,
   useEmailTheming,
 } from '../../plugins/email-theming/extension';
+import { SUPPORTED_CSS_PROPERTIES } from '../../plugins/email-theming/themes';
 import type { KnownCssProperties } from '../../plugins/email-theming/types';
 import { inlineCssToJs } from '../../utils/styles';
 import { useDocumentColors } from './hooks/use-document-colors';
@@ -65,7 +66,7 @@ export function InspectorNode({ children }: InspectorNodeProps) {
   }
 
   const attrs = localAttr ?? focusedNode.nodeAttrs;
-  const inlineStyles = inlineCssToJs(attrs.style || '', { removeUnit: true });
+  const inlineStyles = inlineCssToJs(attrs.style || '');
 
   const css = stylesToCss(theming.styles, theming.theme);
   const themeDefaults = resolveThemeDefaults(
@@ -79,7 +80,18 @@ export function InspectorNode({ children }: InspectorNodeProps) {
     ...inlineStyles,
   };
 
-  const getStyle = (prop: KnownCssProperties) => mergedStyles[prop];
+  const getStyle = (prop: KnownCssProperties) => {
+    const value = mergedStyles[prop];
+    // Strip the trailing CSS unit only for numeric properties so that
+    // numeric inputs receive a parseable number. Non-numeric properties
+    // (colors, gradients, etc.) are returned verbatim — stripping `%`/`px`
+    // globally would corrupt values like `hsl(200, 50%, 40%)`.
+    const isNumericProperty = Boolean(SUPPORTED_CSS_PROPERTIES[prop]?.unit);
+    if (isNumericProperty && typeof value === 'string') {
+      return value.replace(/(px|%)$/, '');
+    }
+    return value;
+  };
 
   const setStyle = (prop: KnownCssProperties, value: string | number) => {
     customUpdateStyles(

--- a/packages/editor/src/ui/inspector/node.tsx
+++ b/packages/editor/src/ui/inspector/node.tsx
@@ -65,7 +65,7 @@ export function InspectorNode({ children }: InspectorNodeProps) {
   }
 
   const attrs = localAttr ?? focusedNode.nodeAttrs;
-  const inlineStyles = inlineCssToJs(attrs.style || '');
+  const inlineStyles = inlineCssToJs(attrs.style || '', { removeUnit: true });
 
   const css = stylesToCss(theming.styles, theming.theme);
   const themeDefaults = resolveThemeDefaults(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes numeric style inputs resetting on blur and avoids corrupting HSL colors in the Inspector. Padding and border values now persist across focus changes.

- **Bug Fixes**
  - Strip units only for numeric CSS properties using `SUPPORTED_CSS_PROPERTIES` in `Inspector.Node`, so inputs parse as numbers while values like `hsl(200, 50%, 40%)` remain intact.
  - Add browser tests for padding value persistence (initial and post-commit) and HSL color input; revert temporary debug code.

<sup>Written for commit 236fd802931f62bfb0a577f979436938822a783a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

