### PR TITLE
chore(ci): move back to github actions

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -6,7 +6,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   bump:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: ubuntu-latest
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -6,7 +6,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   bump:
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-22.04-32
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   e2e:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: ubuntu-latest
     container:
       image: node:22
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   e2e:
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: depot-ubuntu-22.04-32
     container:
       image: node:22
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   lint:
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-22.04-32
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   lint:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: ubuntu-latest
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   pin-dependencies-check:
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-22.04-32
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   pin-dependencies-check:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: ubuntu-latest
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -7,7 +7,7 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   preview-release:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: ubuntu-latest
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -7,7 +7,7 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   preview-release:
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: depot-ubuntu-22.04-32
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/pull-request-title-check.yml
+++ b/.github/workflows/pull-request-title-check.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 jobs:
   pull-request-title-check:
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-22.04-32
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/pull-request-title-check.yml
+++ b/.github/workflows/pull-request-title-check.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 jobs:
   pull-request-title-check:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: ubuntu-latest
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
-    # npm trusted publishing (OIDC) is only supported on GitHub-hosted `ubuntu-latest` runners.
     runs-on: ubuntu-latest
     permissions: 
       id-token: write

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-22.04-32
     steps:
       - name: Trigger sync on resend-skills
         env:

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: ubuntu-latest
     steps:
       - name: Trigger sync on resend-skills
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   tests:
-    runs-on: depot-ubuntu-22.04-32
+    runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   tests:
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: depot-ubuntu-22.04-32
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     steps:


### PR DESCRIPTION
depot seems to be having an incident and it's blocking pull requets

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move CI back to GitHub Actions runners to restore reliability during the Depot outage and unblock PRs. All workflows now run on `ubuntu-latest`; no job logic or steps were changed.

<sup>Written for commit b78baf7e61eaa11bb0d00e7a2c4017ad49cc47a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

