### PR TITLE
chore(ci): restore blacksmith runners

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -6,7 +6,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   bump:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     container:
       image: node:22
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   pin-dependencies-check:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -7,7 +7,7 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   preview-release:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/pull-request-title-check.yml
+++ b/.github/workflows/pull-request-title-check.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 jobs:
   pull-request-title-check:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     steps:


### PR DESCRIPTION
## Summary

- Reverts CI workflows from `ubuntu-latest` back to Blacksmith runners, matching the config before #3224
- 2vcpu for: bump, lint, pin-dependencies-check, preview-release, pull-request-title-check, tests
- 4vcpu for: e2e
- `release.yml` and `sync-skills.yml` intentionally left on `ubuntu-latest`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore CI workflows to Blacksmith runners to match the previous setup. Standard jobs use `blacksmith-2vcpu-ubuntu-2204`, e2e uses `blacksmith-4vcpu-ubuntu-2204`, and `release.yml`/`sync-skills.yml` remain on `ubuntu-latest`.

<sup>Written for commit 32aaae92d6560ecedf79af20621cda5f005b0816. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

