### PR TITLE
chore(docs): update changelog with new 6.0

### DIFF
--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -10,14 +10,16 @@ icon: "list-check"
 
 **React Email 6.0.0**
 
-- all components (previously in `@react-email/components` or individual packages like `@react-email/button`) and rendering utilities (previously in `@react-email/render`) are now exported directly from `react-email`, unifying the install and import experience into a single package
+- All components and rendering utilities unified into the `react-email` package, so `@react-email/components` and individual component packages are no longer needed
 - replace deprecated `url.parse()` with WHATWG URL API in the preview dev server
 - Updated dependencies
     - @react-email/render@2.0.7
 
+See [the migration guide](/getting-started/updating-react-email)
+
 **UI 6.0.0**
 
-- rename `@react-email/preview-server` to `@react-email/ui`
+- Renamed from `@react-email/preview-server` to `@react-email/ui`, same code under a new name
 - copy toolbar insights for AI
 - remove extra margin from sending button
 
@@ -27,24 +29,7 @@ icon: "list-check"
 
 **Editor 1.0.0**
 
-- avoid injecting undefined css values
-- add `getEmailHTML()` and `getEmailText()` to `EmailEditorRef`, remove `getHTML()`, rename `onChange` to `onUpdate`
-- add placeholder style
-- add `onUploadImage` prop to `EmailEditor` and merge image paste/drop handlers into a single plugin
-- don't add an extra focus scope provider if there's already one above `Inspector.Root`
-- add trailing nodes for columns and sections
-- new `ThemeConfig` API for custom theming
-- add `children` prop to `EmailEditor` for composing UI like the Inspector sidebar inside the editor context
-- render Table as a native `<table>` instead of `Section` to fix invalid `<tr>` inside `<td>` nesting in email output
-- align `EmailEditor`'s `onReady` callback with `onUpdate` so it receives `EmailEditorRef`
-- `InspectorBreadcrumbSegment.node` is now always a `FocusedNode`; exports `getNodeMeta` for custom breadcrumb label/icon mapping
-- collapse `SlashCommand.Root` into `SlashCommand` and stop exporting internal `CommandList`/`CommandListProps`
-- remove placeholder from starter kit, keep it in standalone editor
-- improved default for inspector
-- fix color pickers closing and not letting drag happen in root node
-- remove line height from default inbox styles
-- Updated dependencies
-    - react-email@6.0.0
+- Launch!
 
 **Create Email 1.2.4**
 

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -29,7 +29,16 @@ See [the migration guide](/getting-started/updating-react-email)
 
 **Editor 1.0.0**
 
-- Launch!
+- Launch! An embeddable visual editor for composing React Email templates, built on top of [TipTap](https://tiptap.dev/) and [ProseMirror](https://prosemirror.net/)
+- Rich text editing — paragraphs, headings, lists, code blocks, tables, and more
+- Bubble menus — floating formatting toolbars that appear on text selection
+- Slash commands — insert content blocks by typing `/`
+- Multi-column layouts — two, three, and four-column email layouts
+- Email theming — built-in themes with customizable CSS properties
+- HTML export — convert editor content to email-ready HTML and plain text
+- Custom extensions — create your own email-compatible nodes and marks
+
+See [the documentation](/editor/overview)
 
 **Create Email 1.2.4**
 

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -6,6 +6,50 @@ description: "New features, bug fixes, and improvements made to each package."
 icon: "list-check"
 ---
 
+## April 16, 2026
+
+**React Email 6.0.0**
+
+- all components (previously in `@react-email/components` or individual packages like `@react-email/button`) and rendering utilities (previously in `@react-email/render`) are now exported directly from `react-email`, unifying the install and import experience into a single package
+- replace deprecated `url.parse()` with WHATWG URL API in the preview dev server
+- Updated dependencies
+    - @react-email/render@2.0.7
+
+**UI 6.0.0**
+
+- rename `@react-email/preview-server` to `@react-email/ui`
+- copy toolbar insights for AI
+- remove extra margin from sending button
+
+**Render 2.0.7**
+
+- fix export map ordering between convex and node
+
+**Editor 1.0.0**
+
+- avoid injecting undefined css values
+- add `getEmailHTML()` and `getEmailText()` to `EmailEditorRef`, remove `getHTML()`, rename `onChange` to `onUpdate`
+- add placeholder style
+- add `onUploadImage` prop to `EmailEditor` and merge image paste/drop handlers into a single plugin
+- don't add an extra focus scope provider if there's already one above `Inspector.Root`
+- add trailing nodes for columns and sections
+- new `ThemeConfig` API for custom theming
+- add `children` prop to `EmailEditor` for composing UI like the Inspector sidebar inside the editor context
+- render Table as a native `<table>` instead of `Section` to fix invalid `<tr>` inside `<td>` nesting in email output
+- align `EmailEditor`'s `onReady` callback with `onUpdate` so it receives `EmailEditorRef`
+- `InspectorBreadcrumbSegment.node` is now always a `FocusedNode`; exports `getNodeMeta` for custom breadcrumb label/icon mapping
+- collapse `SlashCommand.Root` into `SlashCommand` and stop exporting internal `CommandList`/`CommandListProps`
+- remove placeholder from starter kit, keep it in standalone editor
+- improved default for inspector
+- fix color pickers closing and not letting drag happen in root node
+- remove line height from default inbox styles
+- Updated dependencies
+    - react-email@6.0.0
+
+**Create Email 1.2.4**
+
+- use the new `@react-email/ui`
+
 ## April 9, 2026
 
 **Render 2.0.6**


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update docs changelog with the April 16, 2026 releases. Adds entries for `react-email` 6.0.0 (package unification and preview server URL API update), `@react-email/ui` 6.0.0 (renamed from `@react-email/preview-server`), `@react-email/render` 2.0.7 (export map fix), `@react-email/editor` 1.0.0 launch, and Create Email 1.2.4 adopting `@react-email/ui`, with links to the migration guide and editor docs.

<sup>Written for commit dbd4e2262777c936b4d960059b999f8bc732c509. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

