### PR TITLE
chore(ci): bring depot back

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -6,7 +6,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   bump:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-2
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-8
     container:
       image: node:22
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   pin-dependencies-check:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -7,7 +7,7 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   preview-release:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-8
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/pull-request-title-check.yml
+++ b/.github/workflows/pull-request-title-check.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 jobs:
   pull-request-title-check:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:22-slim
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
+    # npm trusted publishing (OIDC) is only supported on GitHub-hosted `ubuntu-latest` runners.
     runs-on: ubuntu-latest
     permissions: 
       id-token: write

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-2
     steps:
       - name: Trigger sync on resend-skills
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-8
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     steps:


### PR DESCRIPTION
This reverts commit a8fca817ae531a555cb3ff93a62cacf8a7a9a494.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch most CI workflows to Depot runners to improve throughput and reduce queue times.

- **Refactors**
  - Use `depot-ubuntu-22.04-2` for lightweight jobs: lint, bump, pin-dependencies-check, PR title check, sync-skills.
  - Use `depot-ubuntu-22.04-8` for heavier jobs: tests, e2e, preview-release.
  - Keep `release` on `ubuntu-latest` because npm trusted publishing (OIDC) requires GitHub-hosted runners.

<sup>Written for commit c7a010aac383997c0199cf1e146b1f04d14a9d4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

