### PR TITLE
fix(editor): prevent deletion of globalContent node on select-all + delete

### DIFF
--- a/packages/editor/src/extensions/global-content.spec.ts
+++ b/packages/editor/src/extensions/global-content.spec.ts
@@ -1,0 +1,237 @@
+import type { JSONContent } from '@tiptap/core';
+import { Editor } from '@tiptap/core';
+import { TextSelection } from '@tiptap/pm/state';
+import { afterEach, describe, expect, it } from 'vitest';
+import { StarterKit } from './index';
+
+vi.mock('@/actions/ai', () => ({
+  uploadImageViaAI: vi.fn(),
+}));
+
+describe('GlobalContent Node', () => {
+  let editor: Editor | null = null;
+
+  afterEach(() => {
+    editor?.destroy();
+    editor = null;
+  });
+
+  function createEditor(content: JSONContent) {
+    editor = new Editor({
+      content,
+      extensions: [StarterKit],
+    });
+    editor.view.dispatch(editor.state.tr);
+    return editor;
+  }
+
+  it('preserves globalContent when selecting all and deleting', () => {
+    const themeData = { theme: 'basic', css: 'body { color: red; }' };
+
+    const ed = createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'globalContent',
+          attrs: { data: themeData },
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Hello world' }],
+        },
+      ],
+    });
+
+    const { state } = ed;
+    const allSelection = TextSelection.create(
+      state.doc,
+      0,
+      state.doc.content.size,
+    );
+    ed.view.dispatch(state.tr.setSelection(allSelection).deleteSelection());
+
+    const json = ed.getJSON();
+    const globalContentNodes = json.content!.filter(
+      (n) => n.type === 'globalContent',
+    );
+
+    expect(globalContentNodes).toHaveLength(1);
+    expect(globalContentNodes[0].attrs!.data).toEqual(themeData);
+  });
+
+  it('preserves globalContent data after multiple select-all + delete cycles', () => {
+    const themeData = { theme: 'minimal', styles: [{ id: 'test' }] };
+
+    const ed = createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'globalContent',
+          attrs: { data: themeData },
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'First content' }],
+        },
+      ],
+    });
+
+    for (let i = 0; i < 3; i++) {
+      const { state } = ed;
+      const allSelection = TextSelection.create(
+        state.doc,
+        0,
+        state.doc.content.size,
+      );
+      ed.view.dispatch(state.tr.setSelection(allSelection).deleteSelection());
+    }
+
+    const json = ed.getJSON();
+    const globalContentNodes = json.content!.filter(
+      (n) => n.type === 'globalContent',
+    );
+
+    expect(globalContentNodes).toHaveLength(1);
+    expect(globalContentNodes[0].attrs!.data).toEqual(themeData);
+  });
+
+  it('does not duplicate globalContent when it already exists', () => {
+    const ed = createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'globalContent',
+          attrs: { data: { theme: 'basic' } },
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+    });
+
+    ed.commands.insertContent({
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'New paragraph' }],
+    });
+
+    const json = ed.getJSON();
+    const globalContentNodes = json.content!.filter(
+      (n) => n.type === 'globalContent',
+    );
+
+    expect(globalContentNodes).toHaveLength(1);
+  });
+
+  it('restores globalContent at position 0 when deleted via replaceWith', () => {
+    const themeData = { theme: 'basic', css: '.test {}' };
+
+    const ed = createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'globalContent',
+          attrs: { data: themeData },
+        },
+        {
+          type: 'container',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'Content' }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const { state } = ed;
+    const { schema } = state;
+    const newParagraph = schema.nodes.paragraph.create(
+      null,
+      schema.text('Replaced content'),
+    );
+    const tr = state.tr.replaceWith(0, state.doc.content.size, newParagraph);
+    ed.view.dispatch(tr);
+
+    const json = ed.getJSON();
+    const globalContentNodes = json.content!.filter(
+      (n) => n.type === 'globalContent',
+    );
+
+    expect(globalContentNodes).toHaveLength(1);
+    expect(globalContentNodes[0].attrs!.data).toEqual(themeData);
+  });
+
+  it('does not restore globalContent if it was never present', () => {
+    const ed = createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'No global content here' }],
+        },
+      ],
+    });
+
+    ed.commands.clearContent();
+
+    const json = ed.getJSON();
+    const globalContentNodes = (json.content ?? []).filter(
+      (n) => n.type === 'globalContent',
+    );
+
+    expect(globalContentNodes).toHaveLength(0);
+  });
+
+  it('setGlobalContent command creates globalContent if not present', () => {
+    const ed = createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+    });
+
+    ed.commands.setGlobalContent('theme', 'basic');
+
+    const json = ed.getJSON();
+    const globalContentNodes = json.content!.filter(
+      (n) => n.type === 'globalContent',
+    );
+
+    expect(globalContentNodes).toHaveLength(1);
+    expect(globalContentNodes[0].attrs!.data.theme).toBe('basic');
+  });
+
+  it('setGlobalContent command updates existing globalContent data', () => {
+    const ed = createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'globalContent',
+          attrs: { data: { theme: 'basic' } },
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+    });
+
+    ed.commands.setGlobalContent('css', 'body { color: blue; }');
+
+    const json = ed.getJSON();
+    const globalContentNodes = json.content!.filter(
+      (n) => n.type === 'globalContent',
+    );
+
+    expect(globalContentNodes).toHaveLength(1);
+    expect(globalContentNodes[0].attrs!.data).toEqual({
+      theme: 'basic',
+      css: 'body { color: blue; }',
+    });
+  });
+});

--- a/packages/editor/src/extensions/global-content.ts
+++ b/packages/editor/src/extensions/global-content.ts
@@ -1,6 +1,7 @@
 import { type Editor, mergeAttributes, Node } from '@tiptap/core';
 import type { Node as PmNode } from '@tiptap/pm/model';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { hasCollaborationExtension } from '../utils/is-collaboration';
 
 const GLOBAL_CONTENT_NODE_TYPE = 'globalContent' as const;
 
@@ -141,20 +142,64 @@ export const GlobalContent = Node.create<GlobalContentOptions>({
 
   addProseMirrorPlugins() {
     const nodeType = this.type;
+    const isCollaborative = hasCollaborationExtension(
+      this.editor.extensionManager.extensions,
+    );
 
     return [
       new Plugin({
         key: new PluginKey('globalContentProtector'),
 
-        appendTransaction(transactions, oldState, newState) {
-          const docChanged = transactions.some((tr) => tr.docChanged);
-          if (!docChanged) {
+        view: isCollaborative
+          ? undefined
+          : (editorView) => {
+              let lastGlobalContentNode: PmNode | null = null;
+
+              const findAndCache = (doc: PmNode) => {
+                let found: PmNode | null = null;
+                doc.descendants((node) => {
+                  if (node.type.name === GLOBAL_CONTENT_NODE_TYPE) {
+                    found = node;
+                    return false;
+                  }
+                });
+                if (found) {
+                  lastGlobalContentNode = found;
+                }
+                return found;
+              };
+
+              findAndCache(editorView.state.doc);
+
+              return {
+                update(view) {
+                  const doc = view.state.doc;
+                  const current = findAndCache(doc);
+
+                  if (!current && lastGlobalContentNode) {
+                    const restoredNode = nodeType.create(
+                      lastGlobalContentNode.attrs,
+                    );
+                    const tr = view.state.tr;
+                    tr.insert(0, restoredNode);
+                    tr.setMeta('addToHistory', false);
+                    cachedGlobalPosition = 0;
+                    view.dispatch(tr);
+                  }
+                },
+              };
+            },
+
+        appendTransaction(_transactions, oldState, newState) {
+          if (findGlobalContentPositions(newState.doc).length > 0) {
             return null;
           }
 
-          const hasGlobalContent =
-            findGlobalContentPositions(newState.doc).length > 0;
-          if (hasGlobalContent) {
+          // Skip no-op transactions from collaboration extensions (e.g.
+          // Liveblocks stabilisation rounds) to avoid restoring the node
+          // before the real document content arrives — same guard used by
+          // the containerEnforcer plugin.
+          if (newState.doc.eq(oldState.doc)) {
             return null;
           }
 

--- a/packages/editor/src/extensions/global-content.ts
+++ b/packages/editor/src/extensions/global-content.ts
@@ -1,4 +1,6 @@
 import { type Editor, mergeAttributes, Node } from '@tiptap/core';
+import type { Node as PmNode } from '@tiptap/pm/model';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
 
 const GLOBAL_CONTENT_NODE_TYPE = 'globalContent' as const;
 
@@ -135,5 +137,48 @@ export const GlobalContent = Node.create<GlobalContentOptions>({
           return true;
         },
     };
+  },
+
+  addProseMirrorPlugins() {
+    const nodeType = this.type;
+
+    return [
+      new Plugin({
+        key: new PluginKey('globalContentProtector'),
+
+        appendTransaction(transactions, oldState, newState) {
+          const docChanged = transactions.some((tr) => tr.docChanged);
+          if (!docChanged) {
+            return null;
+          }
+
+          const hasGlobalContent =
+            findGlobalContentPositions(newState.doc).length > 0;
+          if (hasGlobalContent) {
+            return null;
+          }
+
+          let previousNode: PmNode | null = null;
+          oldState.doc.descendants((node) => {
+            if (node.type.name === GLOBAL_CONTENT_NODE_TYPE) {
+              previousNode = node;
+              return false;
+            }
+          });
+
+          if (!previousNode) {
+            return null;
+          }
+
+          const restoredNode = nodeType.create((previousNode as PmNode).attrs);
+          const tr = newState.tr;
+          tr.insert(0, restoredNode);
+          tr.setMeta('addToHistory', false);
+          cachedGlobalPosition = 0;
+
+          return tr;
+        },
+      }),
+    ];
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When users press CMD+A (select all) followed by Delete/Backspace, the entire document content is replaced — including the `globalContent` node that stores the theme configuration (styles, theme name, CSS). This causes the theme to be permanently lost from the document.

## Solution

Added a ProseMirror `globalContentProtector` plugin to the `GlobalContent` extension, closely following the patterns established by the `containerEnforcer` plugin in `container.tsx`:

1. **`appendTransaction`** — After any doc-changing transaction, checks if the `globalContent` node is still present. If it's missing but existed in the previous state, restores it at position 0 with all original attributes (theme, styles, CSS).
2. **Collaboration-aware no-op guard** — Skips `doc.eq(oldDoc)` transactions from Liveblocks stabilisation rounds to avoid premature restoration before real document content arrives (same heuristic used by `containerEnforcer`).
3. **`view`-based restoration** — In non-collaborative mode, uses the plugin's `view` hook to track the last-known `globalContent` node and restore it on update, matching how `containerEnforcer` proactively checks on view init/update.
4. The restoration transaction is marked with `addToHistory: false` so it doesn't pollute the undo stack.

## Changes

- **`packages/editor/src/extensions/global-content.ts`** — Added `addProseMirrorPlugins()` with the `globalContentProtector` plugin
- **`packages/editor/src/extensions/global-content.spec.ts`** — New test file with 7 tests covering:
  - Select-all + delete preserves globalContent with theme data
  - Multiple delete cycles preserve data
  - No duplication when globalContent already exists
  - Restoration after `replaceWith` operations
  - No false restoration when globalContent was never present
  - `setGlobalContent` command functionality
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0A9HFCVA13/p1776416355455249?thread_ts=1776416355.455249&cid=C0A9HFCVA13)

<div><a href="https://cursor.com/agents/bc-b689d78b-ec9c-56ed-9ff2-8d2f2da36816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b689d78b-ec9c-56ed-9ff2-8d2f2da36816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents loss of theme configuration by restoring the `globalContent` node if it’s removed (e.g., select-all + delete). Works in collab and non-collab sessions without polluting undo history.

- **Bug Fixes**
  - Added `globalContentProtector` to reinsert the node at pos 0 with previous attrs; uses view-based restore in non-collab mode and skips no-op `doc.eq(oldDoc)` transactions to avoid premature restores with Liveblocks.
  - Restoration uses `addToHistory: false`; tests cover select-all delete, replace operations, no duplication, and `setGlobalContent` updates.

<sup>Written for commit aba11d8b9b7243142ce4f6c35abbf110a0984a1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

