### PR TITLE
feat(editor): add EditorProvider with ref support

### DIFF
--- a/packages/editor/src/editor-provider/editor-provider.tsx
+++ b/packages/editor/src/editor-provider/editor-provider.tsx
@@ -3,7 +3,7 @@ import {
   type EditorProviderProps as TiptapEditorProviderProps,
 } from '@tiptap/react';
 import { forwardRef, useRef } from 'react';
-import { ReadyBridge, RefBridge, type EmailEditorRef } from './ref-bridge';
+import { type EmailEditorRef, ReadyBridge, RefBridge } from './ref-bridge';
 
 export type EditorProviderProps = TiptapEditorProviderProps & {
   /**

--- a/packages/editor/src/editor-provider/editor-provider.tsx
+++ b/packages/editor/src/editor-provider/editor-provider.tsx
@@ -1,0 +1,36 @@
+import {
+  EditorProvider as TiptapEditorProvider,
+  type EditorProviderProps as TiptapEditorProviderProps,
+} from '@tiptap/react';
+import { forwardRef, useRef } from 'react';
+import { ReadyBridge, RefBridge, type EmailEditorRef } from './ref-bridge';
+
+export type EditorProviderProps = TiptapEditorProviderProps & {
+  /**
+   * Called once when the editor has finished initializing,
+   * with an `EmailEditorRef` for email export and JSON access.
+   */
+  onReady?: (ref: EmailEditorRef) => void;
+};
+
+/**
+ * A drop-in replacement for tiptap's `EditorProvider` that supports a `ref`
+ * exposing `EmailEditorRef` methods (`getEmail`, `getEmailHTML`, `getEmailText`,
+ * `getJSON`, and `editor`).
+ */
+export const EditorProvider = forwardRef<EmailEditorRef, EditorProviderProps>(
+  ({ children, onReady, ...editorOptions }, ref) => {
+    const onReadyRef = useRef(onReady);
+    onReadyRef.current = onReady;
+
+    return (
+      <TiptapEditorProvider {...editorOptions}>
+        <RefBridge editorRef={ref} />
+        <ReadyBridge onReadyRef={onReadyRef} />
+        {children}
+      </TiptapEditorProvider>
+    );
+  },
+);
+
+EditorProvider.displayName = 'EditorProvider';

--- a/packages/editor/src/editor-provider/index.ts
+++ b/packages/editor/src/editor-provider/index.ts
@@ -1,0 +1,2 @@
+export { EditorProvider, type EditorProviderProps } from './editor-provider';
+export { type EmailEditorRef } from './ref-bridge';

--- a/packages/editor/src/editor-provider/index.ts
+++ b/packages/editor/src/editor-provider/index.ts
@@ -1,2 +1,2 @@
 export { EditorProvider, type EditorProviderProps } from './editor-provider';
-export { type EmailEditorRef } from './ref-bridge';
+export type { EmailEditorRef } from './ref-bridge';

--- a/packages/editor/src/editor-provider/ref-bridge.tsx
+++ b/packages/editor/src/editor-provider/ref-bridge.tsx
@@ -1,0 +1,85 @@
+import type { Editor, JSONContent } from '@tiptap/core';
+import { useCurrentEditor } from '@tiptap/react';
+import {
+  type Ref,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+} from 'react';
+import { composeReactEmail } from '../core/serializer/compose-react-email';
+
+export interface EmailEditorRef {
+  getEmail: () => Promise<{ html: string; text: string }>;
+  getEmailHTML: () => Promise<string>;
+  getEmailText: () => Promise<string>;
+  getJSON: () => JSONContent;
+  editor: Editor | null;
+}
+
+export function buildRef(editor: Editor | null): EmailEditorRef {
+  return {
+    getEmail: async () => {
+      if (!editor) return { html: '', text: '' };
+      return composeReactEmail({ editor });
+    },
+    getEmailHTML: async () => {
+      if (!editor) return '';
+      const result = await composeReactEmail({ editor });
+      return result.html;
+    },
+    getEmailText: async () => {
+      if (!editor) return '';
+      const result = await composeReactEmail({ editor });
+      return result.text;
+    },
+    getJSON: () => editor?.getJSON() ?? { type: 'doc', content: [] },
+    editor,
+  };
+}
+
+export function RefBridge({
+  editorRef,
+  onUpdateRef,
+}: {
+  editorRef: Ref<EmailEditorRef>;
+  onUpdateRef?: React.RefObject<
+    ((ref: EmailEditorRef) => void) | undefined
+  >;
+}) {
+  const { editor } = useCurrentEditor();
+
+  const emailEditorRef = useMemo(() => buildRef(editor), [editor]);
+
+  useImperativeHandle(editorRef, () => emailEditorRef, [emailEditorRef]);
+
+  useEffect(() => {
+    if (!editor || !onUpdateRef) return;
+
+    const handler = () => {
+      onUpdateRef.current?.(emailEditorRef);
+    };
+
+    editor.on('update', handler);
+    return () => {
+      editor.off('update', handler);
+    };
+  }, [editor, emailEditorRef, onUpdateRef]);
+
+  return null;
+}
+
+export function ReadyBridge({
+  onReadyRef,
+}: {
+  onReadyRef: React.RefObject<((ref: EmailEditorRef) => void) | undefined>;
+}) {
+  const { editor } = useCurrentEditor();
+
+  useLayoutEffect(() => {
+    if (!editor) return;
+    onReadyRef.current?.(buildRef(editor));
+  }, [editor, onReadyRef]);
+
+  return null;
+}

--- a/packages/editor/src/editor-provider/ref-bridge.tsx
+++ b/packages/editor/src/editor-provider/ref-bridge.tsx
@@ -43,9 +43,7 @@ export function RefBridge({
   onUpdateRef,
 }: {
   editorRef: Ref<EmailEditorRef>;
-  onUpdateRef?: React.RefObject<
-    ((ref: EmailEditorRef) => void) | undefined
-  >;
+  onUpdateRef?: React.RefObject<((ref: EmailEditorRef) => void) | undefined>;
 }) {
   const { editor } = useCurrentEditor();
 

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -1,19 +1,11 @@
 import type { Content, Extensions } from '@tiptap/core';
-import {
-  EditorProvider,
-  type UseEditorOptions,
-} from '@tiptap/react';
-import {
-  forwardRef,
-  type ReactNode,
-  useMemo,
-  useRef,
-} from 'react';
+import { EditorProvider, type UseEditorOptions } from '@tiptap/react';
+import { forwardRef, type ReactNode, useMemo, useRef } from 'react';
 import { createPasteHandler } from '../core/create-paste-handler';
 import {
+  type EmailEditorRef,
   ReadyBridge,
   RefBridge,
-  type EmailEditorRef,
 } from '../editor-provider/ref-bridge';
 import { StarterKit } from '../extensions';
 import { EmailTheming } from '../plugins/email-theming/extension';

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -1,21 +1,20 @@
-import type { Content, Editor, Extensions, JSONContent } from '@tiptap/core';
+import type { Content, Extensions } from '@tiptap/core';
 import {
   EditorProvider,
   type UseEditorOptions,
-  useCurrentEditor,
 } from '@tiptap/react';
 import {
   forwardRef,
   type ReactNode,
-  type Ref,
-  useEffect,
-  useImperativeHandle,
-  useLayoutEffect,
   useMemo,
   useRef,
 } from 'react';
 import { createPasteHandler } from '../core/create-paste-handler';
-import { composeReactEmail } from '../core/serializer/compose-react-email';
+import {
+  ReadyBridge,
+  RefBridge,
+  type EmailEditorRef,
+} from '../editor-provider/ref-bridge';
 import { StarterKit } from '../extensions';
 import { EmailTheming } from '../plugins/email-theming/extension';
 import type { EditorThemeInput } from '../plugins/email-theming/types';
@@ -25,13 +24,7 @@ import { SlashCommandRoot } from '../ui/slash-command/root';
 import '../ui/themes/default.css';
 import { Placeholder } from '@tiptap/extension-placeholder';
 
-export interface EmailEditorRef {
-  getEmail: () => Promise<{ html: string; text: string }>;
-  getEmailHTML: () => Promise<string>;
-  getEmailText: () => Promise<string>;
-  getJSON: () => JSONContent;
-  editor: Editor | null;
-}
+export type { EmailEditorRef } from '../editor-provider/ref-bridge';
 
 export interface EmailEditorProps {
   content?: Content;
@@ -48,71 +41,6 @@ export interface EmailEditorProps {
   onUploadImage?: (file: File) => Promise<{ url: string }>;
   className?: string;
   children?: ReactNode;
-}
-
-function buildRef(editor: Editor | null): EmailEditorRef {
-  return {
-    getEmail: async () => {
-      if (!editor) return { html: '', text: '' };
-      return composeReactEmail({ editor });
-    },
-    getEmailHTML: async () => {
-      if (!editor) return '';
-      const result = await composeReactEmail({ editor });
-      return result.html;
-    },
-    getEmailText: async () => {
-      if (!editor) return '';
-      const result = await composeReactEmail({ editor });
-      return result.text;
-    },
-    getJSON: () => editor?.getJSON() ?? { type: 'doc', content: [] },
-    editor,
-  };
-}
-
-function RefBridge({
-  editorRef,
-  onUpdateRef,
-}: {
-  editorRef: Ref<EmailEditorRef>;
-  onUpdateRef: React.RefObject<((ref: EmailEditorRef) => void) | undefined>;
-}) {
-  const { editor } = useCurrentEditor();
-
-  const emailEditorRef = useMemo(() => buildRef(editor), [editor]);
-
-  useImperativeHandle(editorRef, () => emailEditorRef, [emailEditorRef]);
-
-  useEffect(() => {
-    if (!editor) return;
-
-    const handler = () => {
-      onUpdateRef.current?.(emailEditorRef);
-    };
-
-    editor.on('update', handler);
-    return () => {
-      editor.off('update', handler);
-    };
-  }, [editor, emailEditorRef, onUpdateRef]);
-
-  return null;
-}
-
-function EmailEditorReadyBridge({
-  onReadyRef,
-}: {
-  onReadyRef: React.RefObject<((ref: EmailEditorRef) => void) | undefined>;
-}) {
-  const { editor } = useCurrentEditor();
-
-  useLayoutEffect(() => {
-    if (!editor) return;
-    onReadyRef.current?.(buildRef(editor));
-  }, [editor, onReadyRef]);
-
-  return null;
 }
 
 export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
@@ -186,7 +114,7 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
         editorContainerProps={{ className }}
       >
         <RefBridge editorRef={ref} onUpdateRef={onUpdateRef} />
-        <EmailEditorReadyBridge onReadyRef={onReadyRef} />
+        <ReadyBridge onReadyRef={onReadyRef} />
         <BubbleMenu
           hideWhenActiveNodes={bubbleMenu?.hideWhenActiveNodes ?? ['button']}
           hideWhenActiveMarks={bubbleMenu?.hideWhenActiveMarks ?? ['link']}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,10 +1,9 @@
 export {
+  EditorProvider,
+  type EditorProviderProps,
+} from './editor-provider';
+export {
   EmailEditor,
   type EmailEditorProps,
   type EmailEditorRef,
 } from './email-editor';
-
-export {
-  EditorProvider,
-  type EditorProviderProps,
-} from './editor-provider';

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -3,3 +3,8 @@ export {
   type EmailEditorProps,
   type EmailEditorRef,
 } from './email-editor';
+
+export {
+  EditorProvider,
+  type EditorProviderProps,
+} from './editor-provider';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `EditorProvider` component from `@tiptap/react` doesn't support a `ref` exposing `EmailEditorRef` methods — unlike the batteries-included `EmailEditor` component. This PR adds a custom `EditorProvider` wrapper that is a drop-in replacement for tiptap's `EditorProvider` with `ref` forwarding support.

## What changed

- **New `EditorProvider` component** (`packages/editor/src/editor-provider/editor-provider.tsx`): wraps tiptap's `EditorProvider` and adds `forwardRef` support, exposing `EmailEditorRef` methods (`getEmail`, `getEmailHTML`, `getEmailText`, `getJSON`, and `editor`). Also supports an `onReady` callback.

- **Shared ref utilities** (`packages/editor/src/editor-provider/ref-bridge.tsx`): extracted `buildRef`, `RefBridge`, and `ReadyBridge` from `EmailEditor` into a shared module so both `EditorProvider` and `EmailEditor` reuse the same ref logic.

- **Refactored `EmailEditor`** to import from the shared ref utilities instead of defining its own copies.

- **New exports** from `@react-email/editor`: `EditorProvider`, `EditorProviderProps`.

## Usage

```tsx
import { EditorProvider, type EmailEditorRef } from '@react-email/editor';
import { StarterKit } from '@react-email/editor/extensions';
import { BubbleMenu } from '@react-email/editor/ui';
import { useRef } from 'react';

const extensions = [StarterKit];

export function MyEditor() {
  const editorRef = useRef<EmailEditorRef>(null);

  const handleExport = async () => {
    if (!editorRef.current) return;
    const html = await editorRef.current.getEmailHTML();
    console.log(html);
  };

  return (
    <>
      <EditorProvider
        ref={editorRef}
        extensions={extensions}
        content="<p>Hello world</p>"
        immediatelyRender={false}
      >
        <BubbleMenu />
      </EditorProvider>
      <button onClick={handleExport}>Export</button>
    </>
  );
}
```
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0A9HFCVA13/p1776418960201169?thread_ts=1776418960.201169&cid=C0A9HFCVA13)

<div><a href="https://cursor.com/agents/bc-a29f0674-4dbb-54a5-b1e4-8f552d3b6cc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a29f0674-4dbb-54a5-b1e4-8f552d3b6cc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new `EditorProvider` that wraps `@tiptap/react`’s provider and forwards a `ref` exposing `EmailEditorRef` methods. This gives the composable provider the same export and editor access as `EmailEditor`, plus an `onReady` callback.

- **New Features**
  - Added `EditorProvider` (drop-in for `@tiptap/react`’s) with `ref` support for `EmailEditorRef` (`getEmail`, `getEmailHTML`, `getEmailText`, `getJSON`, `editor`) and `onReady`.
  - Exported `EditorProvider` and `EditorProviderProps` from `@react-email/editor`.

- **Refactors**
  - Moved `buildRef`, `RefBridge`, and `ReadyBridge` to `editor-provider/ref-bridge.tsx`.
  - Updated `EmailEditor` to reuse the shared ref utilities and removed duplicates.
  - Resolved Biome lint/format issues.

<sup>Written for commit 00d92f39c2399f38258eea6da5fee7224ef59ebb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

