### PR TITLE
fix: polishing examples container

### DIFF
--- a/apps/web/src/app/editor/examples/custom-theme/example.tsx
+++ b/apps/web/src/app/editor/examples/custom-theme/example.tsx
@@ -128,7 +128,10 @@ export function CustomThemeExample() {
         ))}
       </div>
       <EditorContext.Provider value={{ editor }}>
-        <EditorContent editor={editor} />
+        <EditorContent
+          className="p-4 pt-0 bg-white rounded-md"
+          editor={editor}
+        />
         <BubbleMenu />
       </EditorContext.Provider>
     </ExampleShell>

--- a/apps/web/src/app/editor/examples/email-export/example.tsx
+++ b/apps/web/src/app/editor/examples/email-export/example.tsx
@@ -85,6 +85,11 @@ export function EmailExport() {
         extensions={extensions}
         content={content}
         immediatelyRender={false}
+        editorProps={{
+          attributes: {
+            class: 'p-4 bg-white rounded-md',
+          },
+        }}
       >
         <BubbleMenu />
         <ExportPanel />

--- a/apps/web/src/app/editor/examples/email-theming/example.tsx
+++ b/apps/web/src/app/editor/examples/email-theming/example.tsx
@@ -101,10 +101,12 @@ export function EmailThemingExample() {
           </button>
         ))}
       </div>
-      <EditorContext.Provider value={{ editor }}>
-        <EditorContent editor={editor} />
-        <BubbleMenu />
-      </EditorContext.Provider>
+      <div className="p-4 bg-white rounded-md">
+        <EditorContext.Provider value={{ editor }}>
+          <EditorContent editor={editor} />
+          <BubbleMenu />
+        </EditorContext.Provider>
+      </div>
     </ExampleShell>
   );
 }

--- a/apps/web/src/app/editor/examples/example-shell.tsx
+++ b/apps/web/src/app/editor/examples/example-shell.tsx
@@ -25,7 +25,7 @@ export function ExampleShell({
           <p className="text-sm text-slate-11 mb-4">{description}</p>
         </>
       )}
-      <div className="example-shell-content focus-visible:outline-none overflow-hidden border border-slate-4 rounded-xl p-4 flex-1 min-h-[350px] flex flex-col grow">
+      <div className="example-shell-content focus-visible:outline-none border border-slate-4 rounded-xl p-4 flex-1 min-h-[350px] flex flex-col grow">
         {children}
       </div>
     </div>

--- a/apps/web/src/app/editor/examples/example-shell.tsx
+++ b/apps/web/src/app/editor/examples/example-shell.tsx
@@ -25,7 +25,7 @@ export function ExampleShell({
           <p className="text-sm text-slate-11 mb-4">{description}</p>
         </>
       )}
-      <div className="example-shell-content border border-slate-4 rounded-xl p-4 flex-1 min-h-[350px] flex flex-col grow">
+      <div className="example-shell-content focus-visible:outline-none overflow-hidden border border-slate-4 rounded-xl p-4 flex-1 min-h-[350px] flex flex-col grow">
         {children}
       </div>
     </div>

--- a/apps/web/src/app/editor/examples/example-tabbed-content.tsx
+++ b/apps/web/src/app/editor/examples/example-tabbed-content.tsx
@@ -65,7 +65,7 @@ export function ExampleTabbedContent({
       </div>
       <div className="relative h-fit w-full transition-all duration-300 ease-[cubic-bezier(.36,.66,.6,1)] transition-discrete">
         <Tabs.Content
-          className="relative m-4 mx-2 h-fit scroll-m-2 transition-colors focus:outline-hidden focus:ring-3 focus:ring-slate-8 md:mx-8"
+          className="relative m-4 mx-2 h-fit scroll-m-2 transition-colors focus:outline-hidden md:mx-8"
           value="example"
         >
           <ExamplePageContext.Provider value={true}>

--- a/apps/web/src/app/editor/examples/full-email-builder/example.tsx
+++ b/apps/web/src/app/editor/examples/full-email-builder/example.tsx
@@ -162,8 +162,12 @@ export function FullEmailBuilder() {
           className="flex overflow-hidden -mx-4 -mb-4 border-t border-(--re-border)"
           style={{ height: '32rem' }}
         >
-          <div className="flex-1 min-w-0 p-4 overflow-y-auto">
-            <EditorContent editor={editor} />
+          <div className="flex-1 min-w-0 m-4 mt-0 overflow-y-auto">
+            <EditorContent
+              className="p-4 pt-0 bg-white rounded-md"
+              editor={editor}
+            />
+
             <BubbleMenu
               hideWhenActiveNodes={['button']}
               hideWhenActiveMarks={['link']}

--- a/apps/web/src/app/editor/examples/inspector-composed/example.tsx
+++ b/apps/web/src/app/editor/examples/inspector-composed/example.tsx
@@ -31,8 +31,11 @@ export function InspectorComposed() {
     >
       <EditorContext.Provider value={{ editor }}>
         <div className="flex flex-1 min-h-0 overflow-hidden -m-4">
-          <div className="flex-1 min-w-0 p-4 overflow-y-auto">
-            <EditorContent editor={editor} />
+          <div className="flex-1 min-w-0 m-4 mt-0 overflow-y-auto">
+            <EditorContent
+              className="p-4 pt-0 bg-white rounded-md"
+              editor={editor}
+            />
           </div>
 
           <aside className="w-60 shrink-0 border-l border-(--re-border) p-4 flex flex-col gap-4 overflow-y-auto text-xs">

--- a/apps/web/src/app/editor/examples/inspector-custom/example.tsx
+++ b/apps/web/src/app/editor/examples/inspector-custom/example.tsx
@@ -31,10 +31,12 @@ export function InspectorCustom() {
     >
       <EditorContext.Provider value={{ editor }}>
         <div className="flex flex-1 min-h-0 overflow-hidden -m-4">
-          <div className="flex-1 min-w-0 p-4 overflow-y-auto">
-            <EditorContent editor={editor} />
+          <div className="flex-1 min-w-0 m-4 mt-0 overflow-y-auto">
+            <EditorContent
+              className="p-4 pt-0 bg-white rounded-md"
+              editor={editor}
+            />
           </div>
-
           <aside className="w-60 shrink-0 border-l border-(--re-border) p-4 flex flex-col gap-3 overflow-y-auto text-xs">
             <Inspector.Root>
               <Inspector.Document>

--- a/apps/web/src/app/editor/examples/inspector-defaults/example.tsx
+++ b/apps/web/src/app/editor/examples/inspector-defaults/example.tsx
@@ -32,8 +32,11 @@ export function InspectorDefaults() {
     >
       <EditorContext.Provider value={{ editor }}>
         <div className="flex flex-1 min-h-0 overflow-hidden -m-4">
-          <div className="flex-1 min-w-0 p-4 overflow-y-auto">
-            <EditorContent editor={editor} />
+          <div className="flex-1 min-w-0 m-4 overflow-y-auto">
+            <EditorContent
+              className="p-4 pt-0 bg-white rounded-md"
+              editor={editor}
+            />
           </div>
 
           <aside className="w-60 shrink-0 border-l border-(--re-border) p-4 flex flex-col gap-4 overflow-y-auto text-xs">

--- a/apps/web/src/app/editor/examples/standalone-editor-full/example.tsx
+++ b/apps/web/src/app/editor/examples/standalone-editor-full/example.tsx
@@ -69,7 +69,12 @@ export function StandaloneEditorFull() {
         </button>
       </div>
 
-      <EmailEditor ref={editorRef} content={content} theme={theme} />
+      <EmailEditor
+        className="p-4 bg-white rounded-md"
+        ref={editorRef}
+        content={content}
+        theme={theme}
+      />
 
       {output && (
         <textarea

--- a/apps/web/src/app/editor/examples/standalone-editor-inspector/example.tsx
+++ b/apps/web/src/app/editor/examples/standalone-editor-inspector/example.tsx
@@ -19,12 +19,12 @@ export function StandaloneEditorInspector() {
       description="Add an inspector sidebar alongside the standalone EmailEditor — no manual EditorProvider setup needed."
     >
       <div
-        className="flex flex-1 min-h-0 overflow-hidden -m-4 border-t border-(--re-border)"
+        className="flex flex-1 min-h-0 overflow-hidden"
         style={{ height: '32rem' }}
       >
         <EmailEditor
           content={content}
-          className="flex-1 min-w-0 overflow-y-auto p-4"
+          className="flex-1 min-w-0 overflow-y-auto mr-4 p-4 bg-white rounded-md"
         >
           <Sidebar />
         </EmailEditor>

--- a/apps/web/src/app/editor/examples/standalone-editor/example.tsx
+++ b/apps/web/src/app/editor/examples/standalone-editor/example.tsx
@@ -24,7 +24,7 @@ export function StandaloneEditor() {
       title="Standalone editor — minimal"
       description="The simplest setup — one component with everything included."
     >
-      <EmailEditor content={content} />
+      <EmailEditor className="p-4 bg-white -m-4" content={content} />
     </ExampleShell>
   );
 }

--- a/apps/web/src/components/component-view.tsx
+++ b/apps/web/src/components/component-view.tsx
@@ -56,7 +56,7 @@ const TabContent: React.FC<{
   className?: string;
 }> = ({ value, children, className = '' }) => (
   <Tabs.Content
-    className={`relative m-4 mx-2 h-fit scroll-m-2 overflow-hidden rounded-2xl border border-slate-4 transition-colors focus:outline-hidden focus:ring-3 focus:ring-slate-8 md:mx-8 ${className}`}
+    className={`relative m-4 mx-2 h-fit scroll-m-2 overflow-hidden rounded-2xl border border-slate-4 transition-colors focus:outline-hidden  md:mx-8 ${className}`}
     value={value}
   >
     {children}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the examples container and editor surfaces for consistent spacing and a cleaner look. Standardized editor padding/backgrounds/rounded corners and simplified focus/scroll behavior to avoid double rings and clipping.

- **Refactors**
  - Applied a unified editor surface to `EditorContent`/`EmailEditor` (`p-4`, `bg-white`, `rounded-md`, `pt-0` where needed); used `editorProps` or a lightweight wrapper when required.
  - Shifted padding from outer wrappers to editors and adjusted margins (`m-4`, `-m-4`, `mt-0`) to align with the shell and tabbed layouts.
  - Simplified focus styles by removing extra `focus:ring` in tabbed content and `component-view`, and added `focus-visible:outline-none` to `ExampleShell`.
  - Smoothed overflow/scroll in inspector, full builder, and standalone examples to prevent clipping.

<sup>Written for commit 4f319a94f597ead488b8981574c0c09f59e925e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

