### PR TITLE
feat(docs): api reference for EmailEditor, and show it in getting started

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -160,6 +160,7 @@
           {
             "group": "API Reference",
             "pages": [
+              "editor/api-reference/email-editor",
               "editor/api-reference/compose-react-email",
               "editor/api-reference/email-node",
               "editor/api-reference/email-mark",

--- a/apps/docs/editor/api-reference/email-editor.mdx
+++ b/apps/docs/editor/api-reference/email-editor.mdx
@@ -1,0 +1,210 @@
+---
+title: "EmailEditor"
+sidebarTitle: "EmailEditor"
+description: "Standalone editor component with built-in menus, slash commands, and export helpers."
+icon: "window"
+---
+
+`EmailEditor` is the highest-level way to embed the React Email editor. It wraps
+Tiptap's `EditorProvider`, mounts the default editor UI, and exposes a ref API
+for exporting HTML, plain text, and JSON.
+
+Use it when you want a batteries-included editor. If you need full control over
+the provider, overlays, or extension list, compose the editor from the lower-level
+APIs instead.
+
+<Tip>
+  `EmailEditor` automatically imports `@react-email/editor/themes/default.css`,
+  so the default bubble menus, slash command menu, and theme styles work without
+  a separate CSS import.
+
+  See [styling](/editor/features/styling) for details on customizing the editor's appearance.
+</Tip>
+
+## Import
+
+```tsx
+import { EmailEditor, type EmailEditorRef } from '@react-email/editor';
+```
+
+## Signature
+
+```tsx
+const EmailEditor: React.ForwardRefExoticComponent<
+  EmailEditorProps & React.RefAttributes<EmailEditorRef>
+>;
+```
+
+## Default behavior
+
+When rendered without a custom `extensions` prop, `EmailEditor` configures:
+
+- [`StarterKit`](/editor/api-reference/extensions-list)
+- `Placeholder`
+- [`EmailTheming`](/editor/api-reference/theming-api)
+- The default text `BubbleMenu`
+- [`BubbleMenu.LinkDefault`](/editor/api-reference/ui/bubble-menu#bubblemenu-linkdefault)
+- [`BubbleMenu.ButtonDefault`](/editor/api-reference/ui/bubble-menu#bubblemenu-buttondefault)
+- [`BubbleMenu.ImageDefault`](/editor/api-reference/ui/bubble-menu#bubblemenu-imagedefault)
+- The [built-in slash command menu](/editor/api-reference/ui/slash-command#default-commands)
+
+If `onUploadImage` is provided, the image upload extension is appended
+automatically.
+
+## Props
+
+<ResponseField name="content" type="Content">
+  Initial editor content. Accepts TipTap JSON or an HTML string.
+</ResponseField>
+
+<ResponseField name="onUpdate" type="(ref: EmailEditorRef) => void">
+  Called on every content update. The callback receives the same helper object
+  exposed through the component ref.
+</ResponseField>
+
+<ResponseField name="onReady" type="(ref: EmailEditorRef) => void">
+  Called once after the editor instance is mounted and ready.
+</ResponseField>
+
+<ResponseField name="theme" type="EditorThemeInput" default="'basic'">
+  Built-in theme preset or custom theme object used by the default
+  `EmailTheming` extension.
+</ResponseField>
+
+<ResponseField name="editable" type="boolean" default="true">
+  Toggles read-only mode for the editor content.
+</ResponseField>
+
+<ResponseField name="placeholder" type="string">
+  Overrides the default placeholder text. When omitted, paragraphs show
+  `Press '/' for commands`.
+</ResponseField>
+
+<ResponseField
+  name="bubbleMenu"
+  type="{ hideWhenActiveNodes?: string[]; hideWhenActiveMarks?: string[] }"
+>
+  Configures when the default text bubble menu should stay hidden.
+</ResponseField>
+
+<ResponseField name="extensions" type="Extensions">
+  Replaces the default extensions array. Use this when you want more control
+  over the editor schema or plugin list.
+</ResponseField>
+
+<ResponseField
+  name="onUploadImage"
+  type="(file: File) => Promise<{ url: string }>"
+>
+  Enables image upload for paste, drop, and image insertion flows. Resolve with
+  the final hosted image URL.
+</ResponseField>
+
+<ResponseField name="className" type="string">
+  Applied to the underlying editor container element.
+</ResponseField>
+
+<ResponseField name="children" type="ReactNode">
+  Additional UI rendered inside the internal `EditorProvider`. Children render
+  as siblings of the editor content area, which makes layouts like split-pane
+  editors and inspector sidebars work naturally.
+</ResponseField>
+
+### bubbleMenu options
+
+<ResponseField name="hideWhenActiveNodes" type="string[]" default="['button']">
+  Prevents the default text bubble menu from appearing when one of these node
+  types is active.
+</ResponseField>
+
+<ResponseField name="hideWhenActiveMarks" type="string[]" default="['link']">
+  Prevents the default text bubble menu from appearing when one of these mark
+  types is active.
+</ResponseField>
+
+## Ref API
+
+```tsx
+interface EmailEditorRef {
+  getEmail(): Promise<{ html: string; text: string }>;
+  getEmailHTML(): Promise<string>;
+  getEmailText(): Promise<string>;
+  getJSON(): JSONContent;
+  editor: Editor | null;
+}
+```
+
+<ResponseField
+  name="getEmail"
+  type="() => Promise<{ html: string; text: string }>"
+>
+  Serializes the current document to email-ready HTML and plain text in one
+  call.
+</ResponseField>
+
+<ResponseField name="getEmailHTML" type="() => Promise<string>">
+  Returns only the HTML export.
+</ResponseField>
+
+<ResponseField name="getEmailText" type="() => Promise<string>">
+  Returns only the plain text export.
+</ResponseField>
+
+<ResponseField name="getJSON" type="() => JSONContent">
+  Returns the current TipTap JSON document.
+</ResponseField>
+
+<ResponseField name="editor" type="Editor | null">
+  The underlying TipTap editor instance. `null` until the editor is ready.
+</ResponseField>
+
+<Note>
+  Before the editor is ready, the export methods resolve to empty output and
+  `getJSON()` returns an empty document with `type: 'doc'` and an empty
+  `content` array.
+</Note>
+
+## Example
+
+```tsx
+import { EmailEditor, type EmailEditorRef } from '@react-email/editor';
+import { useRef, useState } from 'react';
+
+export function MyEditor() {
+  const editorRef = useRef<EmailEditorRef>(null);
+  const [html, setHtml] = useState('');
+
+  const handleExport = async () => {
+    if (!editorRef.current) return;
+    setHtml(await editorRef.current.getEmailHTML());
+  };
+
+  return (
+    <div>
+      <EmailEditor
+        ref={editorRef}
+        content="<h1>Welcome</h1><p>Edit this email.</p>"
+        theme="basic"
+        onReady={(ref) => {
+          console.log(ref.getJSON());
+        }}
+        onUpdate={(ref) => {
+          console.log(ref.editor?.isEmpty);
+        }}
+      />
+
+      <button onClick={handleExport}>Export HTML</button>
+
+      {html && <textarea readOnly value={html} rows={12} />}
+    </div>
+  );
+}
+```
+
+## See also
+
+- [Getting Started](/editor/getting-started)
+- [BubbleMenu](/editor/api-reference/ui/bubble-menu)
+- [Inspector](/editor/api-reference/ui/inspector)
+- [composeReactEmail](/editor/api-reference/compose-react-email)
+- [Theming API](/editor/api-reference/theming-api)

--- a/apps/docs/editor/getting-started.mdx
+++ b/apps/docs/editor/getting-started.mdx
@@ -20,32 +20,88 @@ Install the editor and its peer dependencies:
 
 <EditorInstall />
 
-## Import CSS
+## Quick start
 
-The quickest way to get started is to import the bundled default theme:
+The recommended way to start is with the standalone `EmailEditor` component. It
+gives you a working editor with the default bubble menus, slash commands,
+theming, and export helpers already wired up:
 
 ```tsx
-import '@react-email/editor/themes/default.css';
+import { EmailEditor } from '@react-email/editor';
+
+const content = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'This is the simplest way to use the editor. Try selecting text to see the bubble menu, or type "/" for slash commands.',
+        },
+      ],
+    },
+  ],
+};
+
+export function MyEditor() {
+  return <EmailEditor content={content} />;
+}
 ```
 
-This single import includes the default color theme and the built-in UI styles for bubble menus,
-slash commands, and the inspector.
+See the [API Reference](/editor/api-reference/email-editor) for details.
 
 <Tip>
-  If you want to import only the pieces you use, skip the bundled theme and import the individual
-  CSS files instead:
-
-  ```tsx
-  import '@react-email/editor/styles/bubble-menu.css';
-  import '@react-email/editor/styles/slash-command.css';
-  import '@react-email/editor/styles/inspector.css';
-  ```
+  Start here unless you need full control over the extension list, provider
+  layout, or UI composition, in which case see [Lower Level Setup](#lower-level-setup).
 </Tip>
 
-## Minimal editor
+## Content format
 
-The simplest setup uses `StarterKit` with `EditorProvider`—no UI overlays, just a content-editable area
-with all core extensions (paragraphs, headings, lists, tables, code blocks, and more):
+The editor accepts content in two formats:
+
+**TipTap JSON** — A structured document tree:
+
+```json
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "paragraph",
+      "content": [
+        { "type": "text", "text": "Hello world" }
+      ]
+    }
+  ]
+}
+```
+
+**HTML string** — Parsed automatically into the editor's document model:
+
+```tsx
+const content = `
+  <h1>Welcome</h1>
+  <p>This is a <a href="https://react.email">link</a>.</p>
+`;
+
+<EmailEditor content={content} />
+```
+
+## Lower-level setup
+
+If you need more control, drop down to Tiptap's `EditorProvider` and compose the
+editor yourself. This is the lower-level path: you choose the extensions, add
+UI overlays manually, and import any CSS you need.
+
+Common building blocks on this path are [`StarterKit`](/editor/api-reference/extensions-list),
+[`BubbleMenu`](/editor/api-reference/ui/bubble-menu),
+[`SlashCommand`](/editor/api-reference/ui/slash-command),
+[`EmailTheming`](/editor/api-reference/theming-api),
+[`composeReactEmail`](/editor/api-reference/compose-react-email), and the
+[`useEditor`](/editor/api-reference/use-editor) hook.
+
+The simplest manual setup uses `StarterKit` with `EditorProvider` and no UI
+overlays:
 
 ```tsx
 import { StarterKit } from '@react-email/editor/extensions';
@@ -73,7 +129,29 @@ export function MyEditor() {
 }
 ```
 
-## Adding a bubble menu
+### Import CSS
+
+When you use the lower-level UI components directly, import the bundled theme:
+
+```tsx
+import '@react-email/editor/themes/default.css';
+```
+
+This single import includes the default color theme and the built-in UI styles
+for bubble menus, slash commands, and the inspector.
+
+<Tip>
+  If you want to import only the pieces you use, skip the bundled theme and
+  import the individual CSS files instead:
+
+  ```tsx
+  import '@react-email/editor/styles/bubble-menu.css';
+  import '@react-email/editor/styles/slash-command.css';
+  import '@react-email/editor/styles/inspector.css';
+  ```
+</Tip>
+
+### Adding a bubble menu
 
 To add a floating formatting toolbar that appears when you select text, add `BubbleMenu`
 as a child of `EditorProvider`:
@@ -111,38 +189,8 @@ export function MyEditor() {
 }
 ```
 
-Select text in the editor to see the formatting toolbar with bold, italic, underline, alignment, and more.
-
-## Content format
-
-The editor accepts content in two formats:
-
-**TipTap JSON** — A structured document tree:
-
-```json
-{
-  "type": "doc",
-  "content": [
-    {
-      "type": "paragraph",
-      "content": [
-        { "type": "text", "text": "Hello world" }
-      ]
-    }
-  ]
-}
-```
-
-**HTML string** — Parsed automatically into the editor's document model:
-
-```tsx
-const content = `
-  <h1>Welcome</h1>
-  <p>This is a <a href="https://react.email">link</a>.</p>
-`;
-
-<EditorProvider extensions={extensions} content={content} />
-```
+Select text in the editor to see the formatting toolbar with bold, italic,
+underline, alignment, and more.
 
 ## Examples
 

--- a/apps/docs/editor/getting-started.mdx
+++ b/apps/docs/editor/getting-started.mdx
@@ -29,20 +29,13 @@ theming, and export helpers already wired up:
 ```tsx
 import { EmailEditor } from '@react-email/editor';
 
-const content = {
-  type: 'doc',
-  content: [
-    {
-      type: 'paragraph',
-      content: [
-        {
-          type: 'text',
-          text: 'This is the simplest way to use the editor. Try selecting text to see the bubble menu, or type "/" for slash commands.',
-        },
-      ],
-    },
-  ],
-};
+const content = `
+  <h1>Welcome</h1>
+  <p>
+    This is the simplest way to use the editor. Try selecting text to see the
+    bubble menu, or type "/" for slash commands.
+  </p>
+`;
 
 export function MyEditor() {
   return <EmailEditor content={content} />;
@@ -60,6 +53,17 @@ See the [API Reference](/editor/api-reference/email-editor) for details.
 
 The editor accepts content in two formats:
 
+**HTML string** — Parsed automatically into the editor's document model:
+
+```tsx
+const content = `
+  <h1>Welcome</h1>
+  <p>This is a <a href="https://react.email">link</a>.</p>
+`;
+
+<EmailEditor content={content} />
+```
+
 **TipTap JSON** — A structured document tree:
 
 ```json
@@ -74,17 +78,6 @@ The editor accepts content in two formats:
     }
   ]
 }
-```
-
-**HTML string** — Parsed automatically into the editor's document model:
-
-```tsx
-const content = `
-  <h1>Welcome</h1>
-  <p>This is a <a href="https://react.email">link</a>.</p>
-`;
-
-<EmailEditor content={content} />
 ```
 
 ## Lower-level setup
@@ -109,20 +102,10 @@ import { EditorProvider } from '@tiptap/react';
 
 const extensions = [StarterKit];
 
-const content = {
-  type: 'doc',
-  content: [
-    {
-      type: 'paragraph',
-      content: [
-        {
-          type: 'text',
-          text: 'Start typing or edit this text.',
-        },
-      ],
-    },
-  ],
-};
+const content = `
+  <h1>Welcome</h1>
+  <p>Start typing or edit this text.</p>
+`;
 
 export function MyEditor() {
   return <EditorProvider extensions={extensions} content={content} />;
@@ -164,21 +147,12 @@ import '@react-email/editor/themes/default.css';
 
 const extensions = [StarterKit];
 
-const content = {
-  type: 'doc',
-  content: [
-    {
-      type: 'paragraph',
-      content: [
-        { type: 'text', text: 'Select this text to see the bubble menu. Try ' },
-        { type: 'text', marks: [{ type: 'bold' }], text: 'bold' },
-        { type: 'text', text: ', ' },
-        { type: 'text', marks: [{ type: 'italic' }], text: 'italic' },
-        { type: 'text', text: ', and other formatting options.' },
-      ],
-    },
-  ],
-};
+const content = `
+  <p>
+    Select this text to see the bubble menu. Try <strong>bold</strong>,
+    <em>italic</em>, and other formatting options.
+  </p>
+`;
 
 export function MyEditor() {
   return (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an API reference for `EmailEditor` and makes it the default Getting Started path for a faster setup with built-in menus, slash commands, theming, and export helpers.

- **New Features**
  - Added `/editor/api-reference/email-editor` with import, defaults, props, ref API, and example.
  - Updated sidebar (`apps/docs/docs.json`) to include the new API page.
  - Reworked Getting Started: begins with `EmailEditor` quick start, moves lower-level setup/CSS guidance below, clarifies HTML vs JSON content, and updates examples to use HTML.

<sup>Written for commit 3d1f1759d832867e86f3fc0078530581019c0f44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

