### PR TITLE
chore(docs): updating extensions list 

### DIFF
--- a/apps/docs/editor/advanced/extensions.mdx
+++ b/apps/docs/editor/advanced/extensions.mdx
@@ -176,7 +176,6 @@ const extensions = [Body, Paragraph, Heading, Bold, Italic, Link];
 
   | Extension | Description |
   |-----------|-------------|
-  | `Placeholder` | Placeholder text when content is empty |
   | `TrailingNode` | Keeps a trailing empty block inside the target node |
   | `PreservedStyle` | Preserves formatting when unlinking |
   | `GlobalContent` | Stores metadata for serialization (CSS, etc.) |

--- a/apps/docs/editor/api-reference/extensions-list.mdx
+++ b/apps/docs/editor/api-reference/extensions-list.mdx
@@ -343,18 +343,6 @@ Adds CSS class name support to nodes.
 
 <Accordion title="Utility">
 
-### Placeholder
-
-Shows placeholder text when the editor is empty.
-
-<ResponseField name="placeholder" type="string | ((node) => string)">
-  Placeholder text or function returning placeholder text.
-</ResponseField>
-
-<ResponseField name="includeChildren" type="boolean" default="true">
-  Whether to show placeholders in child nodes.
-</ResponseField>
-
 ---
 
 ### TrailingNode


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the `Placeholder` extension from the docs to reflect current support. Cleans up the advanced extensions table and removes its config fields (`placeholder`, `includeChildren`) from the API reference list.

<sup>Written for commit 5c4f2a91d4093b1d180e2a39ba5aee7aed6eea3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

