### PR TITLE
chore(docs): image upload api reference, some other updates

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -166,6 +166,7 @@
               "editor/api-reference/email-mark",
               "editor/api-reference/extensions-list",
               "editor/api-reference/theming-api",
+              "editor/api-reference/image-upload-api",
               {
                 "group": "UI Components",
                 "icon": "window",

--- a/apps/docs/editor/api-reference/email-editor.mdx
+++ b/apps/docs/editor/api-reference/email-editor.mdx
@@ -48,8 +48,8 @@ When rendered without a custom `extensions` prop, `EmailEditor` configures:
 - [`BubbleMenu.ImageDefault`](/editor/api-reference/ui/bubble-menu#bubblemenu-imagedefault)
 - The [built-in slash command menu](/editor/api-reference/ui/slash-command#default-commands)
 
-If `onUploadImage` is provided, the image upload extension is appended
-automatically.
+If [`onUploadImage`](#onuploadimage) is provided, the image upload extension is
+appended automatically.
 
 ## Props
 
@@ -97,7 +97,9 @@ automatically.
   type="(file: File) => Promise<{ url: string }>"
 >
   Enables image upload for paste, drop, and image insertion flows. Resolve with
-  the final hosted image URL.
+  the final hosted image URL. See [Image Upload](/editor/features/image-upload)
+  for setup patterns and [Image Upload API](/editor/api-reference/image-upload-api)
+  for the lower-level hook, commands, and types.
 </ResponseField>
 
 <ResponseField name="className" type="string">
@@ -208,3 +210,4 @@ export function MyEditor() {
 - [Inspector](/editor/api-reference/ui/inspector)
 - [composeReactEmail](/editor/api-reference/compose-react-email)
 - [Theming API](/editor/api-reference/theming-api)
+- [Image Upload API](/editor/api-reference/image-upload-api)

--- a/apps/docs/editor/api-reference/image-upload-api.mdx
+++ b/apps/docs/editor/api-reference/image-upload-api.mdx
@@ -1,0 +1,168 @@
+---
+title: "Image Upload API"
+sidebarTitle: "Image Upload API"
+description: "Hook, types, slash command, and editor commands for image uploads."
+icon: "image"
+---
+
+## `useEditorImage`
+
+The `useEditorImage` hook from `@react-email/editor/plugins` creates the image
+extension used for paste, drop, file-picker, and slash-command uploads.
+
+```tsx
+import { StarterKit } from '@react-email/editor/extensions';
+import { useEditorImage } from '@react-email/editor/plugins';
+
+const imageExtension = useEditorImage({
+  uploadImage: async (file) => {
+    const url = await uploadToStorage(file);
+    return { url };
+  },
+});
+
+const extensions = [StarterKit, imageExtension];
+```
+
+It returns a configured `image` extension that:
+
+- adds the `image` node to the editor schema
+- handles image paste and drop events
+- adds `editor.commands.uploadImage()`
+- adds `editor.commands.setImage(...)`
+
+<ResponseField name="options" type="UseEditorImageOptions" required>
+  Configuration for the upload flow.
+</ResponseField>
+
+## Types
+
+### `UseEditorImageOptions`
+
+```tsx
+interface UseEditorImageOptions {
+  uploadImage: (file: File) => Promise<UploadImageResult>;
+}
+```
+
+<ResponseField
+  name="uploadImage"
+  type="(file: File) => Promise<UploadImageResult>"
+  required
+>
+  Called after a user pastes, drops, or selects an image file. Resolve with the
+  final hosted image URL.
+</ResponseField>
+
+---
+
+### `UploadImageResult`
+
+```tsx
+interface UploadImageResult {
+  url: string;
+}
+```
+
+<ResponseField name="url" type="string" required>
+  The final image URL written back to the image node after upload completes.
+</ResponseField>
+
+## `imageSlashCommand`
+
+`imageSlashCommand` is a ready-made slash command item that triggers
+`editor.commands.uploadImage()` after removing the typed slash-command range.
+
+```tsx
+import { imageSlashCommand } from '@react-email/editor/plugins';
+import { defaultSlashCommands, SlashCommand } from '@react-email/editor/ui';
+
+<SlashCommand.Root items={[...defaultSlashCommands, imageSlashCommand]} />
+```
+
+The command appears as **Image** in the slash menu and is categorized under
+`Layout`.
+
+## Editor commands
+
+Registering `useEditorImage()` adds two commands to `editor.commands`.
+
+### `uploadImage`
+
+Opens a native file picker with `accept="image/*"` and runs the configured
+upload flow:
+
+```tsx
+editor.commands.uploadImage();
+```
+
+Use this when you want to trigger uploads from your own toolbar buttons or
+custom UI.
+
+---
+
+### `setImage`
+
+Inserts an image node directly:
+
+```tsx
+editor.commands.setImage({
+  src: 'https://example.com/hero.png',
+  alt: 'Hero image',
+  width: '600',
+  height: '320',
+  alignment: 'center',
+  href: 'https://react.email',
+});
+```
+
+<ResponseField name="src" type="string" required>
+  Image source URL.
+</ResponseField>
+
+<ResponseField name="alt" type="string">
+  Alternate text for the image.
+</ResponseField>
+
+<ResponseField name="width" type="string" default="'auto'">
+  Rendered image width.
+</ResponseField>
+
+<ResponseField name="height" type="string" default="'auto'">
+  Rendered image height.
+</ResponseField>
+
+<ResponseField
+  name="alignment"
+  type="'left' | 'center' | 'right'"
+  default="'center'"
+>
+  Alignment metadata used by the image UI and serializer.
+</ResponseField>
+
+<ResponseField name="href" type="string | null" default="null">
+  Optional link URL. When present, the image is wrapped in a link on export.
+</ResponseField>
+
+## Upload behavior
+
+All upload entry points share the same behavior:
+
+1. A temporary blob URL is inserted immediately so the image appears in the editor.
+2. Your `uploadImage(file)` handler runs.
+3. On success, the blob URL is replaced with the returned `url`.
+4. On failure, the temporary image node is removed and the error is logged.
+
+## `EmailEditor` integration
+
+If you're using [`EmailEditor`](/editor/api-reference/email-editor), you can
+enable the same behavior without calling `useEditorImage()` directly:
+
+```tsx
+<EmailEditor
+  onUploadImage={async (file) => ({ url: await uploadToStorage(file) })}
+/>
+```
+
+See [Image Upload](/editor/features/image-upload) for setup patterns and
+end-to-end examples.

--- a/apps/docs/editor/features/image-upload.mdx
+++ b/apps/docs/editor/features/image-upload.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Image Upload"
 sidebarTitle: "Image Upload"
-description: "Upload images via paste, drop, or slash command with the useEditorImage plugin."
+description: "Upload images via paste, drop, or slash command with the image upload plugin."
 icon: "image"
 ---
 
 ## Quick start
 
-Add the image extension with `useEditorImage`, register `imageSlashCommand`,
-and render `BubbleMenu.ImageDefault` for inline editing.
+Import `useEditorImage`, add the returned extension to your editor, register
+`imageSlashCommand`, and render `BubbleMenu.ImageDefault` for inline editing.
 
 ```tsx
 import { StarterKit } from '@react-email/editor/extensions';
@@ -42,10 +42,28 @@ export function MyEditor() {
 `uploadImage` receives a `File` and must resolve with `{ url }`. The returned
 URL is written to the image node once the promise resolves.
 
-## One-line setup
+See [Image Upload API](/editor/api-reference/image-upload-api) for the hook,
+types, slash command, and editor commands exposed by this plugin.
 
-`EmailEditor` wraps the same extension behind a single prop — use this when
-you don't need direct access to the extension or slash command list.
+## How image upload works
+
+The image upload plugin combines an `image` node extension with a ProseMirror
+file-handler plugin:
+
+- `useEditorImage({ uploadImage })` creates the extension and keeps the latest
+  upload handler wired in.
+- Paste and drop events are intercepted when the first file is an image.
+- `editor.commands.uploadImage()` opens a file picker for `image/*`.
+- All entry points run the same upload flow: insert a temporary blob URL,
+  await `uploadImage(file)`, then swap the node to the final hosted URL.
+
+If `uploadImage` throws, the temporary image node is removed and the error is
+logged, which keeps failed uploads from lingering in the document.
+
+## Using `EmailEditor`
+
+`EmailEditor` wraps the same extension behind a single prop. Use this when you
+don't need direct access to the extension or slash command list:
 
 ```tsx
 import { EmailEditor } from '@react-email/editor';
@@ -59,7 +77,10 @@ export function MyEditor() {
 }
 ```
 
-## Combining with the text bubble menu
+When `onUploadImage` is present, `EmailEditor` enables the same upload flow for
+paste, drop, and image insertion.
+
+## Bubble menus and slash commands
 
 When pairing `BubbleMenu.ImageDefault` with the default `BubbleMenu`, pass
 `hideWhenActiveNodes={['image']}` so the text menu steps aside when an image
@@ -72,6 +93,13 @@ is focused.
 </EditorProvider>
 ```
 
+To expose image uploads from `/`, add `imageSlashCommand` to the slash command
+items:
+
+```tsx
+<SlashCommand.Root items={[...defaultSlashCommands, imageSlashCommand]} />
+```
+
 ## Upload triggers
 
 Once the extension is registered, three input paths upload automatically:
@@ -82,6 +110,27 @@ Once the extension is registered, three input paths upload automatically:
 
 All three run the same flow: a temporary blob URL renders while `uploadImage`
 runs, and the node swaps to the resolved URL on success.
+
+## Programmatic insertion
+
+The extension adds two editor commands:
+
+```tsx
+editor.commands.uploadImage();
+
+editor.commands.setImage({
+  src: 'https://example.com/hero.png',
+  alt: 'Hero image',
+  alignment: 'center',
+});
+```
+
+`uploadImage()` opens a file picker and runs the upload flow. `setImage()`
+inserts an image node directly, which is useful when you already have a URL.
+
+Available `setImage` attributes: `src`, `alt`, `width`, `height`,
+`alignment` (`'left' | 'center' | 'right'`), and `href` (wraps the image in a
+link on export).
 
 ## Error handling
 
@@ -100,27 +149,6 @@ const uploadImage = useCallback(async (file: File) => {
   }
 }, []);
 ```
-
-## Inserting programmatically
-
-The extension adds two commands to the editor:
-
-```tsx
-editor.commands.uploadImage();
-
-editor.commands.setImage({
-  src: 'https://example.com/hero.png',
-  alt: 'Hero image',
-  alignment: 'center',
-});
-```
-
-`uploadImage()` opens a file picker and runs the upload flow. `setImage()`
-inserts a node directly — useful when you already have a URL.
-
-Available `setImage` attributes: `src`, `alt`, `width`, `height`, `alignment`
-(`'left' | 'center' | 'right'`), and `href` (wraps the image in a link on
-export).
 
 ## Examples
 

--- a/apps/docs/editor/overview.mdx
+++ b/apps/docs/editor/overview.mdx
@@ -28,7 +28,7 @@ The editor is organized into five entry points:
 | `@react-email/editor/core` | `composeReactEmail` serialization, event bus, types |
 | `@react-email/editor/extensions` | `StarterKit` and 35+ email-aware extensions |
 | `@react-email/editor/ui` | Bubble menus, slash commands |
-| `@react-email/editor/plugins` | Email theming plugin |
+| `@react-email/editor/plugins` | Email theming and image upload plugins |
 | `@react-email/editor/utils` | Attribute helpers, style utilities |
 
 <Info>
@@ -50,6 +50,9 @@ The editor is organized into five entry points:
   </Card>
   <Card title="Email Theming" icon="palette" href="/editor/features/theming">
     Apply visual themes to your email output.
+  </Card>
+  <Card title="Image Upload" icon="image" href="/editor/features/image-upload">
+    Upload images via paste, drop, or slash command.
   </Card>
   <Card title="Styling" icon="paintbrush" href="/editor/features/styling">
     Customize the editor's appearance with CSS.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a dedicated Image Upload API reference and updates related docs to explain `useEditorImage`, editor commands, and `EmailEditor` integration. Navigation and overview now surface the feature.

- **New Features**
  - New API page: Image Upload API (`/editor/api-reference/image-upload-api`) covering `useEditorImage`, `imageSlashCommand`, and `editor.commands.uploadImage`/`setImage`.
  - Expanded feature guide with upload flow, programmatic insertion, bubble menus, slash command setup, and error handling; adds `EmailEditor` usage.
  - `EmailEditor` API ref now links to Image Upload docs and clarifies `onUploadImage`.
  - Sidebar updated to include the new API page; overview highlights Image Upload and notes `@react-email/editor/plugins` includes image upload.

<sup>Written for commit 510bc6228c6bc0da4c4fefc9ccf9e54765283480. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

