### PR TITLE
fix(tailwind): collapse empty-fallback var() refs in inline styles

### DIFF
--- a/.changeset/tasty-cows-invent.md
+++ b/.changeset/tasty-cows-invent.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+collapse empty-fallback var() refs in inline styles

--- a/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.spec.ts
@@ -41,10 +41,34 @@ describe('makeInlineStylesFor()', async () => {
       ),
     ).toMatchInlineSnapshot(`
       {
-        "backgroundColor": " #3490dc",
+        "backgroundColor": "#3490dc",
         "borderRadius": "0.25rem",
-        "color": " #fff",
+        "color": "#fff",
         "padding": "0.5rem 1rem",
+      }
+    `);
+  });
+
+  it('strips Tailwind v4 variant-stacking var() refs with empty fallbacks', () => {
+    // Tailwind v4 compiles `tabular-nums` to a font-variant-numeric value
+    // where every optional variant slot is represented by an unresolved
+    // var(--tw-..., ) with an empty fallback. Email clients do not support
+    // CSS custom properties reliably, so these must collapse at inline time
+    // (per CSS spec, an empty fallback resolves to empty string).
+    const tailwindStyles = parse(`
+      .tabular-nums {
+        font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) tabular-nums var(--tw-numeric-fraction,);
+      }
+    `) as StyleSheet;
+
+    expect(
+      makeInlineStylesFor(
+        tailwindStyles.children.toArray(),
+        getCustomProperties(tailwindStyles),
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "fontVariantNumeric": "tabular-nums",
       }
     `);
   });

--- a/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.spec.ts
@@ -72,4 +72,30 @@ describe('makeInlineStylesFor()', async () => {
       }
     `);
   });
+
+  it('preserves user-authored empty-fallback var() refs (non --tw- prefix)', () => {
+    // The collapse is scoped to Tailwind's --tw-* variant-stacking idiom.
+    // A user-authored var(--my-color,) with an empty fallback must pass
+    // through unchanged even though it syntactically matches the idiom --
+    // the user opted into that semantic and the render target may define
+    // --my-color at a higher scope.
+    const userStyles = parse(`
+      .thing {
+        color: var(--my-color,);
+        background: var(--brand,) var(--tw-custom,);
+      }
+    `) as StyleSheet;
+
+    expect(
+      makeInlineStylesFor(
+        userStyles.children.toArray(),
+        getCustomProperties(userStyles),
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "background": "var(--brand,)",
+        "color": "var(--my-color,)",
+      }
+    `);
+  });
 });

--- a/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.spec.ts
@@ -98,4 +98,27 @@ describe('makeInlineStylesFor()', async () => {
       }
     `);
   });
+
+  it('collapses outer --tw-* var() that becomes empty after inner --tw-* var() collapses', () => {
+    // Regression test for cubic-dev-ai P2 review on PR #3359:
+    // pre-order traversal misses outer var(--tw-X, var(--tw-Y,)) because the
+    // outer's fallback only becomes empty AFTER the inner collapses. Post-order
+    // traversal fixes this.
+    const tailwindStyles = parse(`
+      .nested {
+        font-variant-numeric: var(--tw-outer, var(--tw-inner,)) tabular-nums;
+      }
+    `) as StyleSheet;
+
+    expect(
+      makeInlineStylesFor(
+        tailwindStyles.children.toArray(),
+        getCustomProperties(tailwindStyles),
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "fontVariantNumeric": "tabular-nums",
+      }
+    `);
+  });
 });

--- a/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.ts
@@ -59,9 +59,23 @@ export function makeInlineStylesFor(
         if (declaration.property.startsWith('--')) {
           return;
         }
+        // Tailwind v4 emits variant-stacking idioms like
+        //   font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) tabular-nums var(--tw-numeric-fraction,)
+        // where each var() has an empty fallback so missing variants collapse to nothing.
+        // The walker above replaces var() calls with an initialValue when one is defined,
+        // but Tailwind deliberately leaves these variant vars undefined until used, so they
+        // stay in the output here and produce unresolvable custom properties in email HTML
+        // (no email client supports CSS custom properties reliably). Per the CSS spec
+        // (https://www.w3.org/TR/css-variables-1/#using-variables) an empty fallback means
+        // "use empty string if the variable is undefined", which is exactly what we want at
+        // inline-style time.
+        const rawValue = generate(declaration.value);
+        const cleanedValue = rawValue
+          .replace(/var\(\s*--[\w-]+\s*,\s*\)/g, ' ')
+          .replace(/\s+/g, ' ')
+          .trim();
         styles[getReactProperty(declaration.property)] =
-          generate(declaration.value) +
-          (declaration.important ? '!important' : '');
+          cleanedValue + (declaration.important ? '!important' : '');
       },
     });
   }

--- a/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.ts
@@ -69,9 +69,12 @@ export function makeInlineStylesFor(
         // (https://www.w3.org/TR/css-variables-1/#using-variables) an empty fallback means
         // "use empty string if the variable is undefined", which is exactly what we want at
         // inline-style time.
+        //
+        // Scoped to the `--tw-` prefix so any user-authored empty-fallback var() refs
+        // (even ones used inside tailwind utilities) are left untouched.
         const rawValue = generate(declaration.value);
         const cleanedValue = rawValue
-          .replace(/var\(\s*--[\w-]+\s*,\s*\)/g, ' ')
+          .replace(/var\(\s*--tw-[\w-]+\s*,\s*\)/g, ' ')
           .replace(/\s+/g, ' ')
           .trim();
         styles[getReactProperty(declaration.property)] =

--- a/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.ts
@@ -74,7 +74,7 @@ export function makeInlineStylesFor(
         // (even ones used inside tailwind utilities) are left untouched.
         walk(declaration.value, {
           visit: 'Function',
-          enter(func, funcItem, funcList) {
+          leave(func, funcItem, funcList) {
             if (func.name !== 'var') {
               return;
             }
@@ -101,7 +101,21 @@ export function makeInlineStylesFor(
                 return;
               }
 
-              if (generate(child).trim().length > 0) {
+              let childValue = generate(child).trim();
+              if (child.type === 'Raw') {
+                const emptyTailwindVarPattern = /var\(--tw-[^,()]+,\s*\)/g;
+                let nextChildValue = childValue
+                  .replace(emptyTailwindVarPattern, '')
+                  .trim();
+                while (nextChildValue !== childValue) {
+                  childValue = nextChildValue;
+                  nextChildValue = childValue
+                    .replace(emptyTailwindVarPattern, '')
+                    .trim();
+                }
+              }
+
+              if (childValue.length > 0) {
                 hasFallbackContent = true;
               }
             });

--- a/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.ts
@@ -104,15 +104,9 @@ export function makeInlineStylesFor(
               let childValue = generate(child).trim();
               if (child.type === 'Raw') {
                 const emptyTailwindVarPattern = /var\(--tw-[^,()]+,\s*\)/g;
-                let nextChildValue = childValue
-                  .replace(emptyTailwindVarPattern, '')
+                childValue = childValue
+                  .replaceAll(emptyTailwindVarPattern, '')
                   .trim();
-                while (nextChildValue !== childValue) {
-                  childValue = nextChildValue;
-                  nextChildValue = childValue
-                    .replace(emptyTailwindVarPattern, '')
-                    .trim();
-                }
               }
 
               if (childValue.length > 0) {

--- a/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.ts
@@ -72,13 +72,51 @@ export function makeInlineStylesFor(
         //
         // Scoped to the `--tw-` prefix so any user-authored empty-fallback var() refs
         // (even ones used inside tailwind utilities) are left untouched.
-        const rawValue = generate(declaration.value);
-        const cleanedValue = rawValue
-          .replace(/var\(\s*--tw-[\w-]+\s*,\s*\)/g, ' ')
-          .replace(/\s+/g, ' ')
-          .trim();
+        walk(declaration.value, {
+          visit: 'Function',
+          enter(func, funcItem, funcList) {
+            if (func.name !== 'var') {
+              return;
+            }
+
+            let variableName: string | undefined;
+            walk(func, {
+              visit: 'Identifier',
+              enter(identifier) {
+                variableName = identifier.name;
+                return this.break;
+              },
+            });
+            if (!variableName?.startsWith('--tw-')) {
+              return;
+            }
+
+            let sawComma = false;
+            let hasFallbackContent = false;
+            func.children.forEach((child) => {
+              if (!sawComma) {
+                if (child.type === 'Operator' && child.value === ',') {
+                  sawComma = true;
+                }
+                return;
+              }
+
+              if (generate(child).trim().length > 0) {
+                hasFallbackContent = true;
+              }
+            });
+
+            if (!sawComma || hasFallbackContent) {
+              return;
+            }
+
+            funcList.remove(funcItem);
+          },
+        });
+
         styles[getReactProperty(declaration.property)] =
-          cleanedValue + (declaration.important ? '!important' : '');
+          generate(declaration.value).trim() +
+          (declaration.important ? '!important' : '');
       },
     });
   }


### PR DESCRIPTION
Closes #2898

## Repro

With the `Tailwind` component and a `tabular-nums` className:

```tsx
<Tailwind><p className="tabular-nums">1234</p></Tailwind>
```

Rendered output (before this PR):

```html
<p style="font-variant-numeric:var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) tabular-nums var(--tw-numeric-fraction,)">1234</p>
```

No email client reliably evaluates CSS custom properties, so most inboxes drop the entire `font-variant-numeric` declaration and the user never sees tabular figures.

## Root cause

Tailwind v4 compiles every `font-variant-numeric` utility into a variant-stacking chain. Each optional slot is an unresolved `var(--tw-<name>,)` with an empty fallback, so when a variant isn't in use it collapses to nothing per the CSS Custom Properties spec: "If the declared property does not have a value, substitute the fallback value" -- empty fallback = empty string.

`makeInlineStylesFor` already tries to substitute variables, but only when the custom property has an `initialValue` registered on `:root`. Tailwind v4 deliberately leaves these variant vars undefined, so the walker leaves the `var()` calls in place, and the `generate()` call writes them to the inline style object as-is.

## Fix

After `generate(declaration.value)`, strip any leftover `var(--name,)` calls with empty fallbacks and collapse the leftover whitespace before committing the style to the output map. Diff: +7 lines of logic + rationale comment in `make-inline-styles-for.ts`.

Scoped regex: only matches `var(` + `--...` + `,` + `)` (empty fallback). Non-empty fallbacks and `var(--foo)` without a fallback are untouched, so this doesn't change existing resolution paths.

## Rendered output (after)

```html
<p style="font-variant-numeric:tabular-nums">1234</p>
```

## Tests

- New `strips Tailwind v4 variant-stacking var() refs with empty fallbacks` test in `make-inline-styles-for.spec.ts` covering the exact output Tailwind v4 emits for `tabular-nums`.
- Re-snapshotted `does basic local variable resolution`: the previously retained leading space (`" #3490dc"`) was an accidental artifact of `generate()` - the new whitespace collapse makes the output `"#3490dc"` without the leading space. Functionally identical for React's inline style map.
- All 87 `packages/react-email/src/components/tailwind/` tests pass locally.

## Scope

- One function touched. Does not affect `resolveAllCssVariables` (which already has its own fallback handling at `resolve-all-css-variables.ts:192`).
- Does not fix the same class of bug for other Tailwind multi-var properties (`transform`, `filter`, `backdrop-filter`) - those still have the same pattern but only `font-variant-numeric` is in the issue. Follow-up welcome; regex is class-agnostic so it may Just Work for those if exercised.

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes empty-fallback `var()` refs from Tailwind v4 variant-stacking in inline styles (e.g., `tabular-nums`) so `font-variant-numeric` works in emails. Scoped to `--tw-*` vars, trims whitespace, and handles nested `var()` chains.

- **Bug Fixes**
  - Uses a `css-tree` AST post-order walk to delete `var(--tw-*,)` (including nested cases) with a targeted Raw-fallback scrubber; preserves `!important`, non-empty fallbacks, and non-`--tw-*` vars.
  - Adds tests for Tailwind v4 `tabular-nums`, nested `var(--tw-outer, var(--tw-inner,))`, and preserving user-authored `var(--my-color,)`/`var(--brand,)`; updates one whitespace snapshot.

<sup>Written for commit 62adf48ed02d9425a84b5625bc3fcb4d62abbdcc. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3359?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

