### PR TITLE
fix(editor): clip slash command scrollbar to rounded corners

### DIFF
--- a/.changeset/slash-command-scrollbar-clip.md
+++ b/.changeset/slash-command-scrollbar-clip.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+fix slash command scrollbar extending past rounded corners

--- a/apps/docs/editor/features/styling.mdx
+++ b/apps/docs/editor/features/styling.mdx
@@ -215,6 +215,9 @@ and custom commands.
 /* Command palette container */
 [data-re-slash-command] { }
 
+/* Scrollable viewport inside the container */
+[data-re-slash-command-scroll] { }
+
 /* Individual command item */
 [data-re-slash-command-item] { }
 

--- a/packages/editor/src/ui/slash-command/command-list.tsx
+++ b/packages/editor/src/ui/slash-command/command-list.tsx
@@ -82,15 +82,17 @@ export function CommandList({
 
   if (isFiltering) {
     return (
-      <div data-re-slash-command="" ref={containerRef}>
-        {items.map((item, index) => (
-          <CommandItem
-            item={item}
-            key={item.title}
-            onSelect={() => onSelect(index)}
-            selected={index === selectedIndex}
-          />
-        ))}
+      <div data-re-slash-command="">
+        <div data-re-slash-command-scroll="" ref={containerRef}>
+          {items.map((item, index) => (
+            <CommandItem
+              item={item}
+              key={item.title}
+              onSelect={() => onSelect(index)}
+              selected={index === selectedIndex}
+            />
+          ))}
+        </div>
       </div>
     );
   }
@@ -99,23 +101,25 @@ export function CommandList({
   let flatIndex = 0;
 
   return (
-    <div data-re-slash-command="" ref={containerRef}>
-      {groups.map((group) => (
-        <div key={group.category}>
-          <div data-re-slash-command-category="">{group.category}</div>
-          {group.items.map((item) => {
-            const currentIndex = flatIndex++;
-            return (
-              <CommandItem
-                item={item}
-                key={item.title}
-                onSelect={() => onSelect(currentIndex)}
-                selected={currentIndex === selectedIndex}
-              />
-            );
-          })}
-        </div>
-      ))}
+    <div data-re-slash-command="">
+      <div data-re-slash-command-scroll="" ref={containerRef}>
+        {groups.map((group) => (
+          <div key={group.category}>
+            <div data-re-slash-command-category="">{group.category}</div>
+            {group.items.map((item) => {
+              const currentIndex = flatIndex++;
+              return (
+                <CommandItem
+                  item={item}
+                  key={item.title}
+                  onSelect={() => onSelect(currentIndex)}
+                  selected={currentIndex === selectedIndex}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/packages/editor/src/ui/slash-command/slash-command.css
+++ b/packages/editor/src/ui/slash-command/slash-command.css
@@ -5,8 +5,16 @@
 
 [data-re-slash-command] {
   max-height: 330px;
-  overflow-y: auto;
   width: 256px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+[data-re-slash-command-scroll] {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
   padding: 0.25rem;
 }
 


### PR DESCRIPTION
## Summary

- slash command menu scrollbar was drawn in a rectangular gutter that extended past the container's rounded corners on macOS
- split the container: outer `[data-re-slash-command]` keeps `border-radius` + `overflow: hidden`, inner `[data-re-slash-command-scroll]` owns `overflow-y: auto` + padding so its scrollbar is clipped by the outer
- `containerRef` moved onto the inner element so `updateScrollView`'s `scrollTop` still targets the scrolling node
- documented the new selector in styling.mdx

## Test plan

- [ ] `pnpm dev` in `apps/web`, type `/` in the editor — scrollbar stays inside the rounded corners
- [ ] arrow-key past the visible area — selected item auto-scrolls into view
- [ ] filter to zero results (`/zzz`) — empty state renders correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clips the slash command menu scrollbar inside the rounded container by introducing a dedicated inner scroll viewport. Fixes the overflow seen on macOS while preserving auto-scroll of the selected item.

- **Bug Fixes**
  - Inner `data-re-slash-command-scroll` handles scrolling/padding; outer `data-re-slash-command` keeps border radius and `overflow: hidden` to clip the gutter.
  - Moved `containerRef` to the scrolling element so `updateScrollView` targets the right node.
  - CSS updated to a flex column layout with `min-height: 0` for reliable scrolling.
  - Documented the new selector in styling docs and added a patch changeset for `@react-email/editor`.

<sup>Written for commit 36cd03363e470fc90bc4213a39377306e826f005. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

