### PR TITLE
chore(deps): group routine Renovate update PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,49 @@
   "rebaseWhen": "never",
   "vulnerabilityAlerts": {
     "groupName": "security updates"
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Group routine non-major dev-only updates to reduce PR noise.",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "dev dependency updates"
+    },
+    {
+      "description": "Keep React ecosystem updates together.",
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom",
+        "next",
+        "@next/*"
+      ],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "react ecosystem updates"
+    },
+    {
+      "description": "Keep build, test, and release tooling together.",
+      "matchPackageNames": [
+        "@biomejs/**",
+        "@changesets/**",
+        "rollup",
+        "tsdown",
+        "@tsdown/**",
+        "tsx",
+        "turbo",
+        "typescript",
+        "vite",
+        "vitest"
+      ],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "tooling updates"
+    },
+    {
+      "description": "Keep GitHub integration libraries together.",
+      "matchPackageNames": ["@actions/**", "@octokit/**"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "github integration updates"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- group routine non-major Renovate updates into reviewable buckets instead of one broad dependency PR
- keep security advisories isolated under `vulnerabilityAlerts` so they can still be reviewed and merged independently
- document each Renovate field used in this config so the grouping strategy is easy to verify against Renovate's docs

## Test plan
- [x] Validate `renovate.json` parses with `python -m json.tool renovate.json`
- [ ] Let Renovate run against this branch and confirm PR grouping behavior matches the configured rules

## Renovate docs references
- `$schema`: https://docs.renovatebot.com/renovate-schema.json
- `extends`: https://docs.renovatebot.com/configuration-options/#extends
- `ignorePaths`: https://docs.renovatebot.com/configuration-options/#ignorepaths
- `rebaseWhen`: https://docs.renovatebot.com/configuration-options/#rebasewhen
- `vulnerabilityAlerts`: https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
- `packageRules`: https://docs.renovatebot.com/configuration-options/#packagerules
- `description`: https://docs.renovatebot.com/configuration-options/#description
- `matchDepTypes`: https://docs.renovatebot.com/configuration-options/#matchdeptypes
- `matchUpdateTypes`: https://docs.renovatebot.com/configuration-options/#matchupdatetypes
- `matchPackageNames`: https://docs.renovatebot.com/configuration-options/#matchpackagenames
- `groupName`: https://docs.renovatebot.com/configuration-options/#groupname


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups routine non‑major Renovate updates into focused PRs to cut noise and speed reviews. Security advisories stay isolated under `vulnerabilityAlerts` as `security updates`.

- **Dependencies**
  - Group dev-only `minor`/`patch`/`pin`/`digest` updates as "dev dependency updates".
  - Group React ecosystem: `react`, `react-dom`, `@types/react`, `@types/react-dom`, `next`, `@next/*`.
  - Group tooling: `@biomejs/**`, `@changesets/**`, `rollup`, `tsdown`, `@tsdown/**`, `tsx`, `turbo`, `typescript`, `vite`, `vitest`.
  - Group GitHub integrations: `@actions/**`, `@octokit/**`.

<sup>Written for commit 1bb0aac7ca5fc48660a239ffd8431717eb782a76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

