### PR TITLE
feat(docs): document image bubble menu form and unlink

### DIFF
--- a/apps/docs/editor/api-reference/ui/bubble-menu.mdx
+++ b/apps/docs/editor/api-reference/ui/bubble-menu.mdx
@@ -69,8 +69,8 @@ Image editing menu that appears when clicking an image.
 <BubbleMenu.ImageDefault />
 ```
 
-<ResponseField name="excludeItems" type="('edit-link')[]" default="[]">
-  Actions to hide.
+<ResponseField name="excludeItems" type="('edit-link' | 'unlink')[]" default="[]">
+  Actions to hide from the toolbar.
 </ResponseField>
 
 <ResponseField name="placement" type="'top' | 'bottom'" default="'top'">
@@ -83,6 +83,18 @@ Image editing menu that appears when clicking an image.
 
 <ResponseField name="onHide" type="() => void">
   Called when the bubble menu is hidden.
+</ResponseField>
+
+<ResponseField name="validateUrl" type="(value: string) => string | null">
+  Custom URL validator. Return the valid URL string or `null`.
+</ResponseField>
+
+<ResponseField name="onLinkApply" type="(href: string) => void">
+  Called after a link is applied to the image.
+</ResponseField>
+
+<ResponseField name="onLinkRemove" type="() => void">
+  Called after a link is removed from the image.
 </ResponseField>
 
 ---
@@ -216,6 +228,8 @@ Factory for common `trigger` functions:
 | -- | -- |
 | `BubbleMenu.ImageToolbar` | Wrapper -- hides when editing mode is active |
 | `BubbleMenu.ImageEditLink` | Button that enters editing mode |
+| `BubbleMenu.ImageUnlink` | Removes the link wrapping the image |
+| `BubbleMenu.ImageForm` | Inline form for editing the image's link |
 
 ---
 

--- a/apps/docs/editor/features/styling.mdx
+++ b/apps/docs/editor/features/styling.mdx
@@ -198,12 +198,19 @@ The menu that appears when clicking an image
 /* Container */
 [data-re-img-bm] { }
 
-/* Toolbar */
+/* Toolbar with action buttons */
 [data-re-img-bm-toolbar] { }
 
 /* Action buttons */
 [data-re-img-bm-item] { }
 [data-re-img-bm-item][data-item="edit-link"] { }
+[data-re-img-bm-item][data-item="unlink"] { }
+
+/* Edit form */
+[data-re-img-bm-form] { }
+[data-re-img-bm-input] { }
+[data-re-img-bm-apply] { }
+[data-re-img-bm-unlink] { }
 ```
 
 ### Slash command


### PR DESCRIPTION
## Summary
Documents the new image bubble menu surface shipped in #3371:

- `BubbleMenu.ImageDefault` props: wider `excludeItems` (`'edit-link' | 'unlink'`) and new `validateUrl` / `onLinkApply` / `onLinkRemove`
- Image compound components: `BubbleMenu.ImageUnlink` and `BubbleMenu.ImageForm`
- Image bubble menu CSS hooks: `data-item="unlink"` selector plus `form` / `input` / `apply` / `unlink`

Depends on #3371 — merge that first so the docs match shipped code.

## Test plan
- [ ] Run the docs locally and verify the BubbleMenu API reference page renders the new props and compound rows
- [ ] Verify the Styling page shows the expanded image bubble menu CSS block

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the image bubble menu link editing features: link form, unlink action, and related API and styling hooks. Clarifies `BubbleMenu.ImageDefault` props and adds new image components.

- **New Features**
  - Expanded `BubbleMenu.ImageDefault` `excludeItems` to include `'unlink'`; added `validateUrl`, `onLinkApply`, `onLinkRemove`.
  - Added `BubbleMenu.ImageUnlink` and `BubbleMenu.ImageForm` to the image menu docs.
  - Added styling selectors for the image menu: `[data-re-img-bm-item][data-item="unlink"]`, `[data-re-img-bm-form]`, `[data-re-img-bm-input]`, `[data-re-img-bm-apply]`, `[data-re-img-bm-unlink]`.

<sup>Written for commit 1215d16f4d12af7611fb2a50a84817a867408a96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

