### PR TITLE
fix(docs): add missing `Community/` prefix to demo preview URLs

### DIFF
--- a/apps/docs/cli.mdx
+++ b/apps/docs/cli.mdx
@@ -68,7 +68,7 @@ your email template when you make changes.
         }
         ```
 
-        You can refer to our [demo emails source code](https://demo.react.email/preview/notifications/vercel-invite-user)
+        You can refer to our [demo emails source code](https://demo.react.email/preview/Community/notifications/vercel-invite-user)
         for an example of how we do this with our demo deploy on Vercel.
     </Info>
 

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -83,7 +83,7 @@ const Email = () => {
   title="Tailwind Demo"
   icon="arrow-up-right-from-square"
   iconType="duotone"
-  href="https://demo.react.email/preview/notifications/vercel-invite-user"
+  href="https://demo.react.email/preview/Community/notifications/vercel-invite-user"
 >
   See the full demo and source code.
 </Card>

--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -27,7 +27,7 @@ After cloning the [React Email repository](https://github.com/resend/react-email
       <td>
         Here you can find all of the apps related to our online presence, like:
         - this documentation (under [apps/docs](https://github.com/resend/react-email/tree/canary/apps/docs)),
-        - the demo emails we have on [demo.react.email](https://demo.react.email/preview/notifications/vercel-invite-user)
+        - the demo emails we have on [demo.react.email](https://demo.react.email/preview/Community/notifications/vercel-invite-user)
           (under [apps/demo](https://github.com/resend/react-email/tree/canary/apps/demo))
         - the Next app we have for our landing page on [react.email](https://react.email) (under [apps/web](https://github.com/resend/react-email/tree/canary/apps/web))
       </td>

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -190,7 +190,7 @@
         },
         {
           "anchor": "Templates",
-          "href": "https://demo.react.email/preview/notifications/vercel-invite-user",
+          "href": "https://demo.react.email/preview/Community/notifications/vercel-invite-user",
           "icon": "arrow-pointer"
         }
       ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The "Templates" sidebar link in the docs and several other documentation references pointed to `https://demo.react.email/preview/notifications/vercel-invite-user`, which no longer loads because the demo email templates were reorganized under a `Community/` directory.

The preview app's catch-all route resolves the URL slug to a file path under the emails directory. Since there is no `emails/notifications/` folder (only `emails/Community/notifications/`), the slug resolution fails and redirects to the homepage.

## Changes

Updated 4 files in `apps/docs` to use the correct path with the `Community/` prefix:

- **`docs.json`** — the global "Templates" anchor in the sidebar navigation
- **`components/tailwind.mdx`** — link to the full demo
- **`contributing/codebase-overview.mdx`** — link to demo.react.email
- **`cli.mdx`** — link to demo emails source code

All URLs changed from:
`/preview/notifications/vercel-invite-user` → `/preview/Community/notifications/vercel-invite-user`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0A9HFCVA13/p1776450594829329?thread_ts=1776450594.829329&cid=C0A9HFCVA13)

<div><a href="https://cursor.com/agents/bc-a80fa5d6-1c80-5d13-8086-0b92142121f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a80fa5d6-1c80-5d13-8086-0b92142121f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken demo template links in the docs by adding the missing `Community/` prefix to preview URLs, so links open the correct template instead of redirecting to the homepage. Updated four references in `apps/docs` (docs.json, cli.mdx, components/tailwind.mdx, contributing/codebase-overview.mdx) from `/preview/notifications/vercel-invite-user` to `/preview/Community/notifications/vercel-invite-user`.

<sup>Written for commit 83c5d2b232a4e42b5be767dc31dee21d064add30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

