### PR TITLE
chore(ci): use a github app's token to create bump pull request

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Checkout Repo
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -13,10 +13,17 @@ jobs:
     container:
       image: node:22
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 1
+          token: ${{ steps.app-token.outputs.token }}
       - run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: pnpm setup
         uses: pnpm/action-setup@738f428026a1f5a72398de22aeed83d859c4a660
@@ -28,4 +35,4 @@ jobs:
           version: pnpm run version
           title: "chore(root): version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the bump workflow to use a GitHub App token so version bump PRs are opened by the app with the right permissions and can trigger workflows. Adds permission guardrails.

- **Refactors**
  - Generate a GitHub App token with `actions/create-github-app-token` using `BOT_APP_ID` and `BOT_APP_PRIVATE_KEY`, scoped to `contents` and `pull-requests` write.
  - Use the app token for `actions/checkout` and as `GITHUB_TOKEN` when creating the changeset PR.

<sup>Written for commit d2d75f264b2d626f610d943019f1bc0cc113555d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

