### PR TITLE
fix: remaining references to @react-email/components

### DIFF
--- a/apps/docs/editor/api-reference/compose-react-email.mdx
+++ b/apps/docs/editor/api-reference/compose-react-email.mdx
@@ -148,7 +148,7 @@ default — it adds theme-specific body/container styles and can inject global C
 
 ### 7. Render to HTML and plain text
 
-The React tree is rendered to an HTML string using `@react-email/components`' `render()`
+The React tree is rendered to an HTML string using `react-email`' `render()`
 function. Both the formatted HTML and a plain text version (tags stripped, text preserved)
 are produced in parallel from the final React tree.
 

--- a/apps/web/components/code-inline-with-different-colors/inline-styles.tsx
+++ b/apps/web/components/code-inline-with-different-colors/inline-styles.tsx
@@ -14,7 +14,7 @@ export const component = (
         paddingBottom: 2,
       }}
     >
-      @react-email/components
+      react-email
     </CodeInline>{' '}
     package
   </Text>

--- a/apps/web/components/code-inline-with-different-colors/tailwind.tsx
+++ b/apps/web/components/code-inline-with-different-colors/tailwind.tsx
@@ -5,7 +5,7 @@ export const component = (
   <Text className="text-center">
     Install the{' '}
     <CodeInline className="rounded-[6px] bg-green-300 px-[4px] py-[2px]">
-      @react-email/components
+      react-email
     </CodeInline>{' '}
     package
   </Text>

--- a/apps/web/components/simple-code-inline/inline-styles.tsx
+++ b/apps/web/components/simple-code-inline/inline-styles.tsx
@@ -14,7 +14,7 @@ export const component = (
         paddingBottom: 2,
       }}
     >
-      @react-email/components
+      react-email
     </CodeInline>{' '}
     package
   </Text>

--- a/apps/web/components/simple-code-inline/tailwind.tsx
+++ b/apps/web/components/simple-code-inline/tailwind.tsx
@@ -5,7 +5,7 @@ export const component = (
   <Text className="text-center">
     Install the{' '}
     <CodeInline className="rounded-[6px] bg-gray-300 px-[4px] py-[2px]">
-      @react-email/components
+      react-email
     </CodeInline>{' '}
     package
   </Text>

--- a/apps/web/src/components/component-code-view.tsx
+++ b/apps/web/src/components/component-code-view.tsx
@@ -67,7 +67,7 @@ export function ComponentCodeView({
     if (importsReactEmail.length > 0) {
       importStatements += `import { ${importsReactEmail.join(
         ', ',
-      )} } from "@react-email/components";\n`;
+      )} } from "react-email";\n`;
     }
 
     if (importsReactResponsive.length > 0) {

--- a/packages/editor/readme.md
+++ b/packages/editor/readme.md
@@ -31,13 +31,6 @@ The package exposes multiple entry points for granular imports:
 npm install @react-email/editor
 ```
 
-### Peer Dependencies
-
-- `react` (^18.0 || ^19.0)
-- `react-dom` (^18.0 || ^19.0)
-- `@react-email/components`
-- `@radix-ui/react-popover` (^1.0.0)
-
 ## Development
 
 ```bash

--- a/packages/editor/src/extensions/code-block.tsx
+++ b/packages/editor/src/extensions/code-block.tsx
@@ -141,7 +141,7 @@ export const CodeBlockPrism = EmailNode.from(
       ? `${node.attrs.language}`
       : 'javascript';
 
-    // @ts-expect-error -- @react-email/components does not export theme objects by name; dynamic access needed for user-selected themes
+    // @ts-expect-error -- react-email does not export theme objects by name; dynamic access needed for user-selected themes
     // biome-ignore lint/performance/noDynamicNamespaceImportAccess: dynamic access needed for user-selected themes
     const userTheme = ReactEmailComponents[node.attrs?.theme];
 

--- a/packages/ui/src/utils/testing/js-email-test.js
+++ b/packages/ui/src/utils/testing/js-email-test.js
@@ -1,6 +1,6 @@
 // A simple JavaScript email component
 const _React = require('react');
-const { Html, Button } = require('@react-email/components');
+const { Html, Button } = require('react-email');
 
 function Email() {
   return (

--- a/playground/README.md
+++ b/playground/README.md
@@ -2,7 +2,7 @@
 
 This is a playground for React Email made to experiment with components in realtime.
 
-It includes all components directly from source with a path alias import of `@react-email/components` and hot reloading in the `dev` script.
+It includes all components directly from source with a path alias import of `react-email` and hot reloading in the `dev` script.
 
 ## Development workflow
 
@@ -11,7 +11,7 @@ It includes all components directly from source with a path alias import of `@re
 Create a new file at `playground/emails/testing.tsx` 
 
 ```tsx emails/testing.tsx
-import { Html, Head, Body, Tailwind, Text } from '@react-email/components';
+import { Html, Head, Body, Tailwind, Text } from 'react-email';
 
 export default function Testing() {
   return <Tailwind>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced remaining references to `@react-email/components` with `react-email` across code, docs, and examples to prevent broken imports and align with the current package name.

- **Bug Fixes**
  - Updated generated imports in `ComponentCodeView` to use `react-email`.
  - Fixed docs and examples (web components and playground) to show `react-email` imports and naming.
  - Updated test utility to import from `react-email`.
  - Removed the outdated `@react-email/components` peer dependency mention from the editor README.
  - Clarified comments in the editor code to reference `react-email`.

<sup>Written for commit 67a75852a809d3f9eb1e19f0355e9b4753161fd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

