### PR TITLE
feat(ci): build depot snapshot for all runs

### DIFF
--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -1,0 +1,40 @@
+name: Build CI image
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 0"
+  push:
+    branches:
+      - canary
+    paths:
+      - "pnpm-lock.yaml"
+      - ".github/workflows/build-ci-image.yml"
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: depot-ubuntu-22.04-8
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: /opt/playwright
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          fetch-depth: 1
+      - name: Install Node 22
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+      - name: pnpm setup
+        uses: pnpm/action-setup@738f428026a1f5a72398de22aeed83d859c4a660
+      - name: Warm pnpm store
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers with system deps
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Snapshot and push image
+        uses: depot/snapshot-action@b11edd94cf3edbcab102fc45e695c2967953e177
+        with:
+          image: ${{ vars.DEPOT_ORG_ID }}.registry.depot.dev/react-email-ci:latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,17 +13,14 @@ permissions:
   pull-requests: read
 jobs:
   e2e:
-    runs-on: depot-ubuntu-22.04-8
-    container:
-      image: node:22
+    runs-on:
+      size: 8x16
+      image: ${{ vars.DEPOT_ORG_ID }}.registry.depot.dev/react-email-ci:latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 1
-      - run: git config --global --add safe.directory $GITHUB_WORKSPACE
-      - name: pnpm setup
-        uses: pnpm/action-setup@738f428026a1f5a72398de22aeed83d859c4a660
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,16 +13,14 @@ permissions:
   pull-requests: read
 jobs:
   lint:
-    runs-on: depot-ubuntu-22.04-2
-    container:
-      image: node:22-slim
+    runs-on:
+      size: 2x8
+      image: ${{ vars.DEPOT_ORG_ID }}.registry.depot.dev/react-email-ci:latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 1
-      - name: pnpm setup
-        uses: pnpm/action-setup@738f428026a1f5a72398de22aeed83d859c4a660
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run Lint

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -13,16 +13,14 @@ permissions:
   pull-requests: read
 jobs:
   pin-dependencies-check:
-    runs-on: depot-ubuntu-22.04-2
-    container:
-      image: node:22-slim
+    runs-on:
+      size: 2x8
+      image: ${{ vars.DEPOT_ORG_ID }}.registry.depot.dev/react-email-ci:latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 1
-      - name: pnpm setup
-        uses: pnpm/action-setup@738f428026a1f5a72398de22aeed83d859c4a660
       - name: Install root dependencies only
         run: pnpm install --frozen-lockfile --filter . --ignore-scripts
       - name: Check for pinned dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,22 +8,21 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-permissions: 
+permissions:
   contents: read
   pull-requests: read
 jobs:
   tests:
-    runs-on: depot-ubuntu-22.04-8
-    container:
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
+    runs-on:
+      size: 8x16
+      image: ${{ vars.DEPOT_ORG_ID }}.registry.depot.dev/react-email-ci:latest
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: /opt/playwright
     steps:
       - name: Checkout Repo
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 1
-      - run: git config --global --add safe.directory $GITHUB_WORKSPACE
-      - name: pnpm setup
-        uses: pnpm/action-setup@738f428026a1f5a72398de22aeed83d859c4a660
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run Build
@@ -36,7 +35,6 @@ jobs:
       - name: Run Tests
         run: pnpm test
         env:
-          PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
           SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
           SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardizes CI on a prebuilt Depot image with Node 22, warmed `pnpm` store, and `Playwright` browsers to speed up runs and reduce flakiness. Adds an automated workflow to build and push this image on schedule and on `canary`.

- **New Features**
  - Add `.github/workflows/build-ci-image.yml` to build and push a Depot snapshot image on `canary`, weekly, and on demand.
  - Image includes Node 22, warmed `pnpm` store, and `Playwright` Chromium with system deps at `/opt/playwright`.
  - Uses `depot/snapshot-action` to publish `${{ vars.DEPOT_ORG_ID }}.registry.depot.dev/react-email-ci:latest`.

- **Refactors**
  - Switch `tests`, `e2e`, `lint`, and `pin-dependencies-check` to Depot runners with `image: .../react-email-ci:latest` (`8x16` or `2x8`).
  - Remove per-job containers and `pnpm/action-setup`; rely on the prebuilt image.
  - Set `PLAYWRIGHT_BROWSERS_PATH=/opt/playwright` for tests.

<sup>Written for commit 7294808e86866a5b25cc284c05086d7b14192e72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

