### PR TITLE
Change year from 2025 to 2026 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It reduces the pain of coding responsive emails with dark mode support. It also 
 
 ## Why
 
-We believe that email is an extremely important medium for people to communicate. However, we need to stop developing emails like 2010, and rethink how email can be done in 2025 and beyond. Email development needs a revamp. A renovation. Modernized for the way we build web apps today.
+We believe that email is an extremely important medium for people to communicate. However, we need to stop developing emails like 2010, and rethink how email can be done in 2026 and beyond. Email development needs a revamp. A renovation. Modernized for the way we build web apps today.
 
 ## Install
 


### PR DESCRIPTION
Updated the year in the rationale for modern email development.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the README “Why” section to reference 2026 instead of 2025, keeping the rationale current.

<sup>Written for commit 45ea8b771c4526ed2421e30cffbfffaa1b44cd61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

