### PR TITLE
fix(ui): detect hsl()/hsla() as Outlook-incompatible CSS

### DIFF
--- a/.changeset/lovely-papers-tell.md
+++ b/.changeset/lovely-papers-tell.md
@@ -2,4 +2,4 @@
 "@react-email/ui": minor
 ---
 
-hsl/hsla compatibility detection
+add hsl/hsla compatibility detection

--- a/.changeset/lovely-papers-tell.md
+++ b/.changeset/lovely-papers-tell.md
@@ -1,0 +1,5 @@
+---
+"@react-email/ui": minor
+---
+
+hsl/hsla compatibility detection

--- a/packages/ui/src/actions/email-validation/check-compatibility.spec.ts
+++ b/packages/ui/src/actions/email-validation/check-compatibility.spec.ts
@@ -1,0 +1,54 @@
+import {
+  type CompatibilityCheckingResult,
+  checkCompatibility,
+} from './check-compatibility';
+
+const collect = async (reactCode: string) => {
+  const results: CompatibilityCheckingResult[] = [];
+  const stream = await checkCompatibility(reactCode, '');
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (value) results.push(value);
+    if (done) break;
+  }
+  return results;
+};
+
+const findHslResult = (results: CompatibilityCheckingResult[]) =>
+  results.find((result) => result.entry.slug === 'css-hsl-hsla');
+
+describe('checkCompatibility() — hsl()/hsla() detection', () => {
+  it('flags background-color: hsl(...) as Outlook-incompatible', async () => {
+    const results = await collect(
+      "<Section style={{ backgroundColor: 'hsl(200, 50%, 50%)' }} />",
+    );
+    const hslResult = findHslResult(results);
+    expect(hslResult).toBeDefined();
+    expect(hslResult?.status).toBe('error');
+    expect(hslResult?.statsPerEmailClient.outlook?.status).toBe('error');
+  });
+
+  it('flags color: hsla(...) as Outlook-incompatible', async () => {
+    const results = await collect(
+      "<Section style={{ color: 'hsla(120, 100%, 50%, 0.5)' }} />",
+    );
+    const hslResult = findHslResult(results);
+    expect(hslResult).toBeDefined();
+    expect(hslResult?.status).toBe('error');
+  });
+
+  it('tolerates whitespace variations in hsl() arguments', async () => {
+    const results = await collect(
+      "<Section style={{ backgroundColor: 'hsl( 200 , 50% , 50% )' }} />",
+    );
+    expect(findHslResult(results)).toBeDefined();
+  });
+
+  it('does not flag hex or rgb() colors', async () => {
+    const results = await collect(
+      "<Section style={{ color: '#ff0000', backgroundColor: 'rgb(255, 0, 0)' }} />",
+    );
+    expect(findHslResult(results)).toBeUndefined();
+  });
+});

--- a/packages/ui/src/actions/email-validation/check-compatibility.spec.ts
+++ b/packages/ui/src/actions/email-validation/check-compatibility.spec.ts
@@ -27,6 +27,10 @@ describe('checkCompatibility() — hsl()/hsla() detection', () => {
     expect(hslResult).toBeDefined();
     expect(hslResult?.status).toBe('error');
     expect(hslResult?.statsPerEmailClient.outlook?.status).toBe('error');
+    expect(hslResult?.entry.source).toBe('react-email');
+    expect(hslResult?.entry.url).toBe(
+      'https://github.com/resend/react-email/issues/2947',
+    );
   });
 
   it('flags color: hsla(...) as Outlook-incompatible', async () => {

--- a/packages/ui/src/actions/email-validation/check-compatibility.ts
+++ b/packages/ui/src/actions/email-validation/check-compatibility.ts
@@ -24,6 +24,7 @@ import { getElementAttributes } from '../../utils/caniemail/get-element-attribut
 import { getElementNames } from '../../utils/caniemail/get-element-names';
 import { snakeToCamel } from '../../utils/snake-to-camel';
 import { supportEntries } from './caniemail-data';
+import { customSupportEntries } from './custom-support-entries';
 
 export interface CompatibilityCheckingResult {
   location: SourceLocation;
@@ -146,7 +147,7 @@ export const checkCompatibility = async (
   );
   const readableStream = new ReadableStream<CompatibilityCheckingResult>({
     async start(controller) {
-      for (const entry of supportEntries) {
+      for (const entry of [...supportEntries, ...customSupportEntries]) {
         const compatibilityStats = getCompatibilityStatsForEntry(
           entry,
           relevantEmailClients,

--- a/packages/ui/src/actions/email-validation/check-compatibility.ts
+++ b/packages/ui/src/actions/email-validation/check-compatibility.ts
@@ -24,7 +24,7 @@ import { getElementAttributes } from '../../utils/caniemail/get-element-attribut
 import { getElementNames } from '../../utils/caniemail/get-element-names';
 import { snakeToCamel } from '../../utils/snake-to-camel';
 import { supportEntries } from './caniemail-data';
-import { customSupportEntries } from './custom-support-entries';
+import { reactEmailSupportEntries } from './custom-support-entries';
 
 export interface CompatibilityCheckingResult {
   location: SourceLocation;
@@ -159,7 +159,7 @@ export const checkCompatibility = async (
   );
   const readableStream = new ReadableStream<CompatibilityCheckingResult>({
     async start(controller) {
-      for (const entry of [...supportEntries, ...customSupportEntries]) {
+      for (const entry of [...supportEntries, ...reactEmailSupportEntries]) {
         const compatibilityStats = getCompatibilityStatsForEntry(
           entry,
           relevantEmailClients,

--- a/packages/ui/src/actions/email-validation/check-compatibility.ts
+++ b/packages/ui/src/actions/email-validation/check-compatibility.ts
@@ -72,7 +72,7 @@ export type Platform =
 
 export type SupportEntryCategory = 'html' | 'css' | 'image' | 'others';
 
-export interface SupportEntry {
+interface SupportEntryBase {
   slug: string;
   title: string;
   description: string | null;
@@ -110,6 +110,18 @@ export interface SupportEntry {
   notes: string | null;
   notes_by_num: Record<number, string> | null;
 }
+
+export type SupportEntry =
+  | (SupportEntryBase & {
+      /**
+       * Caniemail entries are generated and predate this discriminator, so the
+       * missing value is treated as `caniemail`.
+       */
+      source?: 'caniemail';
+    })
+  | (SupportEntryBase & {
+      source: 'react-email';
+    });
 
 const relevantEmailClients: EmailClient[] = [
   'gmail',

--- a/packages/ui/src/actions/email-validation/custom-support-entries.ts
+++ b/packages/ui/src/actions/email-validation/custom-support-entries.ts
@@ -1,0 +1,40 @@
+import type { SupportEntry } from './check-compatibility';
+
+/**
+ * Manually curated compatibility entries that aren't covered by caniemail's
+ * dataset. These get merged with `supportEntries` at runtime, so regenerating
+ * `caniemail-data.ts` via `pnpm caniemail:fetch` won't wipe them.
+ */
+export const customSupportEntries: SupportEntry[] = [
+  // https://github.com/resend/react-email/issues/2947
+  // Outlook (Windows versions using Word's MS rendering engine) silently
+  // strips `hsl()`/`hsla()` color functions. Caniemail.com doesn't ship an
+  // entry for this, so we curate one here so the checker can flag it.
+  {
+    slug: 'css-hsl-hsla',
+    title: 'hsl(), hsla()',
+    description:
+      'HSL and HSLA color functions. Outlook on Windows silently drops these declarations, so hex or rgb() is safer for broad email client support.',
+    url: 'https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl',
+    category: 'css',
+    tags: [],
+    keywords: 'color,hsl,hsla',
+    last_test_date: '2026-04-19',
+    test_url:
+      'https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl',
+    test_results_url: null,
+    stats: {
+      outlook: {
+        windows: [
+          { '2007': 'n' },
+          { '2010': 'n' },
+          { '2013': 'n' },
+          { '2016': 'n' },
+          { '2019': 'n' },
+        ],
+      },
+    },
+    notes: null,
+    notes_by_num: null,
+  },
+];

--- a/packages/ui/src/actions/email-validation/custom-support-entries.ts
+++ b/packages/ui/src/actions/email-validation/custom-support-entries.ts
@@ -5,7 +5,10 @@ import type { SupportEntry } from './check-compatibility';
  * dataset. These get merged with `supportEntries` at runtime, so regenerating
  * `caniemail-data.ts` via `pnpm caniemail:fetch` won't wipe them.
  */
-export const customSupportEntries: SupportEntry[] = [
+export const customSupportEntries: Extract<
+  SupportEntry,
+  { source: 'react-email' }
+>[] = [
   // https://github.com/resend/react-email/issues/2947
   // Outlook (Windows versions using Word's MS rendering engine) silently
   // strips `hsl()`/`hsla()` color functions. Caniemail.com doesn't ship an
@@ -15,13 +18,13 @@ export const customSupportEntries: SupportEntry[] = [
     title: 'hsl(), hsla()',
     description:
       'HSL and HSLA color functions. Outlook on Windows silently drops these declarations, so hex or rgb() is safer for broad email client support.',
-    url: 'https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl',
+    source: 'react-email',
+    url: 'https://github.com/resend/react-email/issues/2947',
     category: 'css',
     tags: [],
     keywords: 'color,hsl,hsla',
     last_test_date: '2026-04-19',
-    test_url:
-      'https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl',
+    test_url: 'https://github.com/resend/react-email/issues/2947',
     test_results_url: null,
     stats: {
       outlook: {

--- a/packages/ui/src/actions/email-validation/custom-support-entries.ts
+++ b/packages/ui/src/actions/email-validation/custom-support-entries.ts
@@ -5,7 +5,7 @@ import type { SupportEntry } from './check-compatibility';
  * dataset. These get merged with `supportEntries` at runtime, so regenerating
  * `caniemail-data.ts` via `pnpm caniemail:fetch` won't wipe them.
  */
-export const customSupportEntries: Extract<
+export const reactEmailSupportEntries: Extract<
   SupportEntry,
   { source: 'react-email' }
 >[] = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,7 +273,7 @@ importers:
     dependencies:
       mintlify:
         specifier: 4.2.521
-        version: 4.2.521(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@25.5.0)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 4.2.521(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@22.19.17)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -8827,9 +8827,6 @@ packages:
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
-  zod@3.24.0:
-    resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
-
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -9794,51 +9791,51 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.1(@types/node@25.5.0)':
+  '@inquirer/checkbox@4.3.1(@types/node@22.19.17)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/confirm@5.1.20(@types/node@25.5.0)':
+  '@inquirer/confirm@5.1.20(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/core@10.3.1(@types/node@25.5.0)':
+  '@inquirer/core@10.3.1(@types/node@22.19.17)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
       cli-width: 4.1.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/editor@4.2.22(@types/node@25.5.0)':
+  '@inquirer/editor@4.2.22(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/external-editor': 1.0.3(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/expand@4.0.22(@types/node@25.5.0)':
+  '@inquirer/expand@4.0.22(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
   '@inquirer/external-editor@1.0.3(@types/node@22.19.17)':
     dependencies:
@@ -9847,97 +9844,90 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.5.0)':
-    dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.0
-    optionalDependencies:
-      '@types/node': 25.5.0
-
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.0(@types/node@25.5.0)':
+  '@inquirer/input@4.3.0(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/number@3.0.22(@types/node@25.5.0)':
+  '@inquirer/number@3.0.22(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/password@4.0.22(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/prompts@7.10.0(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.1(@types/node@25.5.0)
-      '@inquirer/confirm': 5.1.20(@types/node@25.5.0)
-      '@inquirer/editor': 4.2.22(@types/node@25.5.0)
-      '@inquirer/expand': 4.0.22(@types/node@25.5.0)
-      '@inquirer/input': 4.3.0(@types/node@25.5.0)
-      '@inquirer/number': 3.0.22(@types/node@25.5.0)
-      '@inquirer/password': 4.0.22(@types/node@25.5.0)
-      '@inquirer/rawlist': 4.1.10(@types/node@25.5.0)
-      '@inquirer/search': 3.2.1(@types/node@25.5.0)
-      '@inquirer/select': 4.4.1(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/prompts@7.9.0(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.1(@types/node@25.5.0)
-      '@inquirer/confirm': 5.1.20(@types/node@25.5.0)
-      '@inquirer/editor': 4.2.22(@types/node@25.5.0)
-      '@inquirer/expand': 4.0.22(@types/node@25.5.0)
-      '@inquirer/input': 4.3.0(@types/node@25.5.0)
-      '@inquirer/number': 3.0.22(@types/node@25.5.0)
-      '@inquirer/password': 4.0.22(@types/node@25.5.0)
-      '@inquirer/rawlist': 4.1.10(@types/node@25.5.0)
-      '@inquirer/search': 3.2.1(@types/node@25.5.0)
-      '@inquirer/select': 4.4.1(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/rawlist@4.1.10(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/search@3.2.1(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/select@4.4.1(@types/node@25.5.0)':
+  '@inquirer/password@4.0.22(@types/node@22.19.17)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/prompts@7.10.0(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.1(@types/node@22.19.17)
+      '@inquirer/confirm': 5.1.20(@types/node@22.19.17)
+      '@inquirer/editor': 4.2.22(@types/node@22.19.17)
+      '@inquirer/expand': 4.0.22(@types/node@22.19.17)
+      '@inquirer/input': 4.3.0(@types/node@22.19.17)
+      '@inquirer/number': 3.0.22(@types/node@22.19.17)
+      '@inquirer/password': 4.0.22(@types/node@22.19.17)
+      '@inquirer/rawlist': 4.1.10(@types/node@22.19.17)
+      '@inquirer/search': 3.2.1(@types/node@22.19.17)
+      '@inquirer/select': 4.4.1(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/prompts@7.9.0(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.1(@types/node@22.19.17)
+      '@inquirer/confirm': 5.1.20(@types/node@22.19.17)
+      '@inquirer/editor': 4.2.22(@types/node@22.19.17)
+      '@inquirer/expand': 4.0.22(@types/node@22.19.17)
+      '@inquirer/input': 4.3.0(@types/node@22.19.17)
+      '@inquirer/number': 3.0.22(@types/node@22.19.17)
+      '@inquirer/password': 4.0.22(@types/node@22.19.17)
+      '@inquirer/rawlist': 4.1.10(@types/node@22.19.17)
+      '@inquirer/search': 3.2.1(@types/node@22.19.17)
+      '@inquirer/select': 4.4.1(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/rawlist@4.1.10(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/type@3.0.10(@types/node@25.5.0)':
+  '@inquirer/search@3.2.1(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
+
+  '@inquirer/select@4.4.1(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/type@3.0.10(@types/node@22.19.17)':
+    optionalDependencies:
+      '@types/node': 22.19.17
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -10060,9 +10050,9 @@ snapshots:
 
   '@mediapipe/tasks-vision@0.10.17': {}
 
-  '@mintlify/cli@4.0.1124(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@25.5.0)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+  '@mintlify/cli@4.0.1124(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@22.19.17)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
-      '@inquirer/prompts': 7.9.0(@types/node@25.5.0)
+      '@inquirer/prompts': 7.9.0(@types/node@22.19.17)
       '@mintlify/common': 1.0.858(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/link-rot': 3.0.1034(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/prebuild': 1.0.1000(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
@@ -10075,7 +10065,7 @@ snapshots:
       front-matter: 4.0.2
       fs-extra: 11.2.0
       ink: 6.3.0(@types/react@19.2.14)(react@19.2.4)
-      inquirer: 12.3.0(@types/node@25.5.0)
+      inquirer: 12.3.0(@types/node@22.19.17)
       js-yaml: 4.1.1
       mdast-util-mdx-jsx: 3.2.0
       open: 8.4.2
@@ -10429,7 +10419,7 @@ snapshots:
       unified: 11.0.5
       unist-util-visit: 5.0.0
       yargs: 17.7.1
-      zod: 3.24.0
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/react'
@@ -14280,12 +14270,12 @@ snapshots:
 
   inline-style-parser@0.2.4: {}
 
-  inquirer@12.3.0(@types/node@25.5.0):
+  inquirer@12.3.0(@types/node@22.19.17):
     dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/prompts': 7.10.0(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-      '@types/node': 25.5.0
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/prompts': 7.10.0(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      '@types/node': 22.19.17
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 3.0.0
@@ -15357,9 +15347,9 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
-  mintlify@4.2.521(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@25.5.0)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  mintlify@4.2.521(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@22.19.17)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
-      '@mintlify/cli': 4.0.1124(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@25.5.0)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@mintlify/cli': 4.0.1124(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@22.19.17)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/node'
@@ -18012,8 +18002,6 @@ snapshots:
       zod: 3.25.76
 
   zod@3.23.8: {}
-
-  zod@3.24.0: {}
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
Fixes #2947. Adds `hsl()` / `hsla()` to the Outlook compatibility checker.

@gabrielmfern invited this in the issue thread — here's a stab.

## Approach

The checker is data-driven off caniemail.com's dataset. caniemail has no `hsl()` entry, and `pnpm caniemail:fetch` **fully overwrites** `packages/ui/src/actions/email-validation/caniemail-data.ts`. So editing that file directly would be wiped on the next fetch.

Instead, this PR adds a hand-curated overlay at `packages/ui/src/actions/email-validation/custom-support-entries.ts` — one `SupportEntry` for `hsl(), hsla()` with Outlook Windows 2007–2019 marked `"n"` (→ `error` status via the existing stats pipeline). The overlay is spread into the checker loop at runtime:

```ts
for (const entry of [...supportEntries, ...customSupportEntries]) { ... }
```

Happy to rename (`curated-`, `manual-`, `extra-`) or restructure (e.g. merge at fetch time inside `fill-caniemail-data.mts`) if you'd prefer a different pattern — this is establishing a new precedent since no `custom-*-entries.ts` exists today.

## Known limitation (pre-existing, not introduced here)

The function matcher at `check-compatibility.ts:293` is case-sensitive: `entryFunctions.includes(functionName)`. So `HSL(...)` won't match. Same applies to the existing `oklch`/`lch`/`lab` entries today. Can fix in a follow-up if you want.

## Tests

`packages/ui/src/actions/email-validation/check-compatibility.spec.ts` — 4 new cases:

- `background-color: hsl(200, 50%, 50%)` → Outlook error
- `color: hsla(120, 100%, 50%, 0.5)` → Outlook error  
- Whitespace tolerance: `hsl( 200 , 50% , 50% )` → Outlook error
- Negative: hex / rgb values → no false-positive

```
pnpm -F @react-email/ui test
  Test Files  1 passed (1)
       Tests  4 passed (4)
# full ui suite also green: 12 files, 31 tests passed
```

Lint clean. TypeScript clean. No lockfile changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects and warns on CSS hsl()/hsla() as Outlook-incompatible in the email compatibility checker. Uses a curated overlay so the warning persists when `caniemail-data` is refreshed.

- **Bug Fixes**
  - Added manual `css-hsl-hsla` support entry (Outlook Windows 2007–2019 unsupported) and merged at runtime via `reactEmailSupportEntries`. Added tests for detection, whitespace tolerance, and no false positives for hex/rgb.
  - Introduced a `source` discriminator on support entries and tagged curated ones as `react-email` for clear identification in results.

- **Dependencies**
  - Updated `pnpm-lock.yaml`; bumped `postcss` to `8.5.10`; added changeset for `@react-email/ui` minor release.

<sup>Written for commit 717c522f7cab74d4754f96aecd4b285be7050c82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

