### PR TITLE
fix(web): editor text color when the browser's in light mode

### DIFF
--- a/apps/web/src/app/editor/example-shell.tsx
+++ b/apps/web/src/app/editor/example-shell.tsx
@@ -25,7 +25,7 @@ export function ExampleShell({
           <p className="text-sm text-slate-11 mb-4">{description}</p>
         </>
       )}
-      <div className="example-shell-content focus-visible:outline-none border border-slate-4 rounded-xl p-4 flex-1 min-h-[350px] flex flex-col grow">
+      <div className="example-shell-content dark focus-visible:outline-none border border-slate-4 rounded-xl p-4 flex-1 min-h-[350px] flex flex-col grow">
         {children}
       </div>
     </div>


### PR DESCRIPTION
production:
<img width="1625" height="874" alt="image" src="https://github.com/user-attachments/assets/4337703c-0187-4354-b77d-35d2e0831a52" />

in this pull request:
<img width="1625" height="874" alt="image" src="https://github.com/user-attachments/assets/81e7c702-8eef-4e04-bc8d-90fe48cd0d30" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreadable editor text in light-mode browsers by forcing dark theme inside the editor preview container. Ensures consistent contrast and readability.

- **Bug Fixes**
  - Add `dark` class to `.example-shell-content` to apply dark styles regardless of system theme.

<sup>Written for commit b8afc8517769de6f36adb5a320d839cfd683d416. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

