### PR TITLE
fix(render): remove nul bytes when using React 18 

### DIFF
--- a/.changeset/bumpy-pens-mate.md
+++ b/.changeset/bumpy-pens-mate.md
@@ -1,0 +1,5 @@
+---
+"@react-email/render": patch
+---
+
+Strip nul bytes from React 18 `renderToPipeableStream` output to prevent emails with multi-byte characters from being truncated.

--- a/packages/render/src/node/render.tsx
+++ b/packages/render/src/node/render.tsx
@@ -50,7 +50,7 @@ export const render = async (node: React.ReactNode, options?: Options) => {
         </ErrorBoundary>,
         {
           async onAllReady() {
-            html = await readStream(stream);
+            html = await readStream(stream).then(stripNulBytes);
             resolve();
           },
           onError(error) {
@@ -77,3 +77,7 @@ export const render = async (node: React.ReactNode, options?: Options) => {
 
   return document;
 };
+
+// Workaround for https://github.com/facebook/react/pull/26228
+// (fixed in React 19, not backported to 18)
+const stripNulBytes = (s: string) => s.replaceAll('\0', '');

--- a/packages/render/src/node/render.tsx
+++ b/packages/render/src/node/render.tsx
@@ -50,7 +50,11 @@ export const render = async (node: React.ReactNode, options?: Options) => {
         </ErrorBoundary>,
         {
           async onAllReady() {
-            html = await readStream(stream).then(stripNulBytes);
+            html = await readStream(stream).then((s: string) => {
+              // Workaround for https://github.com/facebook/react/pull/26228
+              // (fixed in React 19, not backported to 18)
+              return s.replaceAll('\0', '');
+            });
             resolve();
           },
           onError(error) {
@@ -77,7 +81,3 @@ export const render = async (node: React.ReactNode, options?: Options) => {
 
   return document;
 };
-
-// Workaround for https://github.com/facebook/react/pull/26228
-// (fixed in React 19, not backported to 18)
-const stripNulBytes = (s: string) => s.replaceAll('\0', '');


### PR DESCRIPTION
## Workaround for React 18 `renderToPipeableStream` nul-byte bug

### The bug
React 18's server renderer encodes HTML into a reusable 2048-byte `Uint8Array` using `TextEncoder.encodeInto()`. When a multi-byte UTF-8 character (e.g. an em-dash —, 3 bytes) would straddle the end of the buffer, `encodeInto` stops early rather than splitting the character in half, leaving a few trailing bytes of the buffer unwritten.

The bug is that React flushes the entire 2048-byte buffer instead of just the portion that was actually written, so those uninitialised trailing bytes (\0) leak into the output stream.

The result is HTML that contains stray nul bytes near internal 2KB boundaries. Most browsers shrug these off, but many email clients interpret them as end-of-file and silently truncate the email at the first nul byte.

Trigger conditions are narrow but absolutely reachable in real emails:
* A <Suspense> boundary (forces Fizz to take the buffered path).
* Enough content to fill roughly 2KB (typical for styled email templates).
* A multi-byte UTF-8 character (em-dash, en-dash, emoji 💀, curly quotes, etc.) landing at the buffer boundary.

### The fix in React

Facebook fixed this upstream in [facebook/react#26228](https://github.com/facebook/react/pull/26228) by slicing the buffer to the number of bytes actually written before flushing.

The fix shipped in React 19 and was deliberately not backported to the 18.x line.

### The fix in React Email

Since `@react-email/render` still supports React 18, we need to work around the bug by stripping nul bytes from the HTML after `renderToPipeableStream` finishes:

```javascript
html = await readStream(stream).then(stripNulBytes);
```

This is scoped to the `renderToPipeableStream` code path (React 18 in Node). The `renderToReadableStream` path untouched since it's unaffected by the bug. Nul bytes have no legitimate place in HTML output, so stripping them unconditionally is safe.

### References

Upstream fix: https://github.com/facebook/react/pull/26228
Affected: react-dom@18.0.0 - 18.3.1
Fixed in: react-dom@19.0.0+

### Fixes

* #1561
* #1785
* #1915

Among others I'm sure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stray NUL bytes from React 18 server rendering (`renderToPipeableStream`) to prevent email truncation in Outlook and similar clients. We now strip `\0` in `onAllReady` during streaming (workaround until React 19); shipping as a patch to `@react-email/render`.

<sup>Written for commit 4d8b953bcde44e095cb9faffa9bbf942bca029ab. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3406?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

