### PR TITLE
feat(react-email): auto-detect package manager for email build

### DIFF
--- a/.changeset/fuzzy-kangaroos-dream.md
+++ b/.changeset/fuzzy-kangaroos-dream.md
@@ -1,0 +1,5 @@
+---
+"react-email": minor
+---
+
+auto-detect the package manager for `email build`

--- a/apps/docs/cli.mdx
+++ b/apps/docs/cli.mdx
@@ -144,8 +144,9 @@ Copies the preview app for onto `.react-email` and builds it.
 <ResponseField name="--dir" type="string" default="emails">
   Change the directory of your email templates.
 </ResponseField>
-<ResponseField name="--packageManager" type="string" default="npm">
-  Package manager to use on the installation of `.react-email`.
+<ResponseField name="--packageManager" type="string">
+  Package manager to use on the installation of `.react-email`. If omitted, it
+  will be detected from the project automatically.
 </ResponseField>
 
 ## `email start`

--- a/packages/react-email/src/cli/commands/build.ts
+++ b/packages/react-email/src/cli/commands/build.ts
@@ -3,7 +3,12 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getPackages } from '@manypkg/get-packages';
 import logSymbols from 'log-symbols';
-import { installDependencies, type PackageManagerName, runScript } from 'nypm';
+import {
+  detectPackageManager,
+  installDependencies,
+  type PackageManagerName,
+  runScript,
+} from 'nypm';
 import ora from 'ora';
 import {
   type EmailsDirectory,
@@ -14,7 +19,7 @@ import { registerSpinnerAutostopping } from '../utils/register-spinner-autostopp
 
 interface Args {
   dir: string;
-  packageManager: PackageManagerName;
+  packageManager?: PackageManagerName;
 }
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -176,6 +181,8 @@ export const build = async ({
 }: Args) => {
   try {
     const usersProjectLocation = process.cwd();
+    const resolvedPackageManager =
+      packageManager ?? (await detectPackageManager(usersProjectLocation));
     const previewServerLocation = await getUiLocation();
 
     const spinner = ora({
@@ -246,7 +253,7 @@ export const build = async ({
       await installDependencies({
         cwd: builtPreviewAppPath,
         silent: true,
-        packageManager,
+        packageManager: resolvedPackageManager,
       });
     }
 
@@ -256,7 +263,7 @@ export const build = async ({
     });
 
     await runScript('build', {
-      packageManager,
+      packageManager: resolvedPackageManager,
       cwd: builtPreviewAppPath,
     });
   } catch (error) {

--- a/packages/react-email/src/cli/commands/testing/build.spec.ts
+++ b/packages/react-email/src/cli/commands/testing/build.spec.ts
@@ -1,0 +1,184 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getPackages } from '@manypkg/get-packages';
+import { detectPackageManager, installDependencies, runScript } from 'nypm';
+import { getUiLocation } from '../../utils/get-ui-location.js';
+import { registerSpinnerAutostopping } from '../../utils/register-spinner-autostopping.js';
+import { build } from '../build.js';
+
+vi.mock('@manypkg/get-packages', () => ({
+  getPackages: vi.fn(),
+}));
+
+vi.mock('log-symbols', () => ({
+  default: {
+    success: 'success',
+  },
+}));
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => ({
+    start() {
+      return this;
+    },
+    stopAndPersist() {},
+    text: '',
+  })),
+}));
+
+vi.mock('nypm', () => ({
+  detectPackageManager: vi.fn(),
+  installDependencies: vi.fn(),
+  runScript: vi.fn(),
+}));
+
+vi.mock('../utils/get-ui-location.js', () => ({
+  getUiLocation: vi.fn(),
+}));
+
+vi.mock('../utils/register-spinner-autostopping.js', () => ({
+  registerSpinnerAutostopping: vi.fn(),
+}));
+
+const mockedDetectPackageManager = vi.mocked(detectPackageManager);
+const mockedGetPackages = vi.mocked(getPackages);
+const mockedGetUiLocation = vi.mocked(getUiLocation);
+const mockedInstallDependencies = vi.mocked(installDependencies);
+const mockedRunScript = vi.mocked(runScript);
+const mockedRegisterSpinnerAutostopping = vi.mocked(
+  registerSpinnerAutostopping,
+);
+
+const createFixture = async () => {
+  const root = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'react-email-build-'),
+  );
+  const emailsDir = path.join(root, 'emails');
+  const previewDir = path.join(root, 'preview');
+
+  await fs.promises.mkdir(path.join(emailsDir, 'static'), {
+    recursive: true,
+  });
+  await fs.promises.writeFile(
+    path.join(emailsDir, 'welcome.tsx'),
+    `export default function Welcome() {
+  return null;
+}
+`,
+    'utf8',
+  );
+
+  await fs.promises.mkdir(path.join(previewDir, 'src/app/preview/[...slug]'), {
+    recursive: true,
+  });
+  await fs.promises.writeFile(
+    path.join(previewDir, 'package.json'),
+    JSON.stringify({
+      name: 'ui',
+      scripts: {
+        build: 'next build',
+        start: 'next start',
+        postbuild: 'echo postbuild',
+      },
+      dependencies: {},
+      devDependencies: {},
+    }),
+    'utf8',
+  );
+  await fs.promises.writeFile(
+    path.join(previewDir, 'src/app/layout.tsx'),
+    `export const dynamic = 'force-dynamic';
+
+export default function Layout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}
+`,
+    'utf8',
+  );
+  await fs.promises.writeFile(
+    path.join(previewDir, 'src/app/preview/[...slug]/page.tsx'),
+    `export const dynamic = 'force-dynamic';
+
+export default function Page() {
+  return null;
+}
+`,
+    'utf8',
+  );
+
+  return { root, emailsDir, previewDir };
+};
+
+describe('build()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('auto-detects the package manager when none is provided', async () => {
+    const fixture = await createFixture();
+    const previousCwd = process.cwd();
+
+    try {
+      process.chdir(fixture.root);
+      const projectLocation = process.cwd();
+
+      mockedGetPackages.mockResolvedValue({
+        rootDir: projectLocation,
+      } as never);
+      mockedGetUiLocation.mockResolvedValue(fixture.previewDir);
+      mockedDetectPackageManager.mockResolvedValue({
+        name: 'pnpm',
+        command: 'pnpm',
+      } as never);
+
+      await build({ dir: 'emails' });
+
+      expect(mockedDetectPackageManager).toHaveBeenCalledWith(projectLocation);
+      expect(mockedRunScript).toHaveBeenCalledWith('build', {
+        cwd: path.join(projectLocation, '.react-email'),
+        packageManager: {
+          name: 'pnpm',
+          command: 'pnpm',
+        },
+      });
+      expect(mockedInstallDependencies).not.toHaveBeenCalled();
+      expect(mockedRegisterSpinnerAutostopping).toHaveBeenCalled();
+    } finally {
+      process.chdir(previousCwd);
+      await fs.promises.rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the explicit package manager when provided', async () => {
+    const fixture = await createFixture();
+    const previousCwd = process.cwd();
+
+    try {
+      process.chdir(fixture.root);
+      const projectLocation = process.cwd();
+
+      mockedGetPackages.mockResolvedValue({
+        rootDir: projectLocation,
+      } as never);
+      mockedGetUiLocation.mockResolvedValue(fixture.previewDir);
+
+      await build({ dir: 'emails', packageManager: 'yarn' });
+
+      expect(mockedDetectPackageManager).not.toHaveBeenCalled();
+      expect(mockedRunScript).toHaveBeenCalledWith('build', {
+        cwd: path.join(projectLocation, '.react-email'),
+        packageManager: 'yarn',
+      });
+      expect(mockedInstallDependencies).not.toHaveBeenCalled();
+      expect(mockedRegisterSpinnerAutostopping).toHaveBeenCalled();
+    } finally {
+      process.chdir(previousCwd);
+      await fs.promises.rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/react-email/src/cli/commands/testing/build.spec.ts
+++ b/packages/react-email/src/cli/commands/testing/build.spec.ts
@@ -3,8 +3,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { getPackages } from '@manypkg/get-packages';
 import { detectPackageManager, installDependencies, runScript } from 'nypm';
-import { getUiLocation } from '../../utils/get-ui-location.js';
-import { registerSpinnerAutostopping } from '../../utils/register-spinner-autostopping.js';
+import * as getUiLocationModule from '../../utils/get-ui-location.js';
+import * as registerSpinnerAutostoppingModule from '../../utils/register-spinner-autostopping.js';
 import { build } from '../build.js';
 
 vi.mock('@manypkg/get-packages', () => ({
@@ -33,21 +33,17 @@ vi.mock('nypm', () => ({
   runScript: vi.fn(),
 }));
 
-vi.mock('../utils/get-ui-location.js', () => ({
-  getUiLocation: vi.fn(),
-}));
-
-vi.mock('../utils/register-spinner-autostopping.js', () => ({
-  registerSpinnerAutostopping: vi.fn(),
-}));
-
 const mockedDetectPackageManager = vi.mocked(detectPackageManager);
 const mockedGetPackages = vi.mocked(getPackages);
-const mockedGetUiLocation = vi.mocked(getUiLocation);
+const mockedGetUiLocation = vi.spyOn(
+  getUiLocationModule,
+  'getUiLocation',
+);
 const mockedInstallDependencies = vi.mocked(installDependencies);
 const mockedRunScript = vi.mocked(runScript);
-const mockedRegisterSpinnerAutostopping = vi.mocked(
-  registerSpinnerAutostopping,
+const mockedRegisterSpinnerAutostopping = vi.spyOn(
+  registerSpinnerAutostoppingModule,
+  'registerSpinnerAutostopping',
 );
 
 const createFixture = async () => {

--- a/packages/react-email/src/cli/commands/testing/build.spec.ts
+++ b/packages/react-email/src/cli/commands/testing/build.spec.ts
@@ -35,10 +35,7 @@ vi.mock('nypm', () => ({
 
 const mockedDetectPackageManager = vi.mocked(detectPackageManager);
 const mockedGetPackages = vi.mocked(getPackages);
-const mockedGetUiLocation = vi.spyOn(
-  getUiLocationModule,
-  'getUiLocation',
-);
+const mockedGetUiLocation = vi.spyOn(getUiLocationModule, 'getUiLocation');
 const mockedInstallDependencies = vi.mocked(installDependencies);
 const mockedRunScript = vi.mocked(runScript);
 const mockedRegisterSpinnerAutostopping = vi.spyOn(

--- a/packages/react-email/src/cli/index.ts
+++ b/packages/react-email/src/cli/index.ts
@@ -60,11 +60,7 @@ if (!hasRequiredFlags) {
       'Directory with your email templates',
       './emails',
     )
-    .option(
-      '-p --packageManager <name>',
-      'Package name to use on installation on `.react-email`',
-      'npm',
-    )
+    .option('-p --packageManager <name>', 'Package manager to use')
     .action(build);
 
   program


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Auto-detects the package manager for the `react-email` build command, so builds use your project's tool without needing `--packageManager`. The flag is now optional; explicit values still override detection.

- **New Features**
  - Detects the package manager via `nypm` from the project root and uses it for build (and installs when needed).
  - `--packageManager` is now optional (no default). Updated CLI help/docs and tests, and added a changeset for release.

<sup>Written for commit 25aeaa5cac7b2cab08893032ac0b203024c7048e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



