### PR TITLE
fix(editor): emit theme link styles in renderHTML

### DIFF
--- a/.changeset/theme-aware-link-mark.md
+++ b/.changeset/theme-aware-link-mark.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Emit active EmailTheming link styles in the Link mark's `renderHTML` so plain links carry inline color + underline in exported HTML. User inline styles still take precedence via the CSS cascade. `RESET_MINIMAL.link` now also ships `#0670DB` + underline.

--- a/packages/editor/src/extensions/link.spec.ts
+++ b/packages/editor/src/extensions/link.spec.ts
@@ -1,0 +1,128 @@
+import { Editor } from '@tiptap/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EmailTheming } from '../plugins/email-theming/extension';
+import { StarterKit } from './index';
+
+vi.mock('@tiptap/react', () => ({
+  ReactNodeViewRenderer: () => () => null,
+  useEditorState: vi.fn(),
+}));
+
+vi.mock('tippy.js', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('@/env', () => ({
+  env: new Proxy(
+    {},
+    {
+      get: () => '',
+    },
+  ),
+}));
+
+function docWithLink(style?: string) {
+  const attrs: Record<string, unknown> = { href: 'https://resend.com' };
+  if (style !== undefined) {
+    attrs.style = style;
+  }
+  return {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'text',
+            marks: [{ type: 'link', attrs }],
+            text: 'click',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function createEditor(theme: 'basic' | 'minimal', content = docWithLink()) {
+  return new Editor({
+    extensions: [StarterKit, EmailTheming.configure({ theme })],
+    content,
+  });
+}
+
+function findLinkMark(editor: Editor) {
+  const walk = (nodes: unknown[]): Record<string, unknown> | undefined => {
+    for (const n of nodes) {
+      const node = n as Record<string, unknown>;
+      const marks = node.marks as Array<Record<string, unknown>> | undefined;
+      const linkMark = marks?.find((m) => m.type === 'link');
+      if (linkMark) return linkMark;
+      const children = node.content as unknown[] | undefined;
+      if (children) {
+        const found = walk(children);
+        if (found) return found;
+      }
+    }
+    return undefined;
+  };
+  return walk((editor.getJSON().content ?? []) as unknown[]);
+}
+
+const COLOR_RE = /color:\s*#0670DB/i;
+const UNDERLINE_RE = /text-decoration:\s*underline/i;
+
+describe('Link mark theming', () => {
+  let editor: Editor;
+
+  afterEach(() => {
+    editor?.destroy();
+    document.head
+      .querySelectorAll('style[id^="tiptap-theme-"]')
+      .forEach((node) => node.remove());
+  });
+
+  it('emits theme-resolved color and text-decoration on plain links (basic)', () => {
+    editor = createEditor('basic');
+    const html = editor.getHTML();
+    expect(html).toMatch(COLOR_RE);
+    expect(html).toMatch(UNDERLINE_RE);
+  });
+
+  it('emits theme-resolved color and text-decoration on plain links (minimal)', () => {
+    editor = createEditor('minimal');
+    const html = editor.getHTML();
+    expect(html).toMatch(COLOR_RE);
+    expect(html).toMatch(UNDERLINE_RE);
+  });
+
+  it('preserves class="node-link" in the rendered output', () => {
+    editor = createEditor('basic');
+    expect(editor.getHTML()).toContain('class="node-link"');
+  });
+
+  it('lets user-specified color win over the theme color', () => {
+    editor = createEditor('basic', docWithLink('color: red'));
+    const html = editor.getHTML();
+    expect(html).toMatch(/color:\s*red/i);
+    expect(html).not.toMatch(COLOR_RE);
+    expect(html).toMatch(UNDERLINE_RE);
+  });
+
+  it('keeps mark.attrs.style empty for plain links (inspector contract)', () => {
+    editor = createEditor('basic');
+    const mark = findLinkMark(editor);
+    expect(mark?.type).toBe('link');
+    expect((mark?.attrs as Record<string, unknown>).style).toBe('');
+  });
+
+  it('round-trips a plain <a href> through setContent+getHTML with themed style', () => {
+    editor = createEditor('basic');
+    editor.commands.setContent(
+      '<p><a href="https://resend.com">click</a></p>',
+      { emitUpdate: true },
+    );
+    const html = editor.getHTML();
+    expect(html).toMatch(COLOR_RE);
+    expect(html).toMatch(UNDERLINE_RE);
+  });
+});

--- a/packages/editor/src/extensions/link.spec.ts
+++ b/packages/editor/src/extensions/link.spec.ts
@@ -78,7 +78,9 @@ describe('Link mark theming', () => {
     editor?.destroy();
     document.head
       .querySelectorAll('style[id^="tiptap-theme-"]')
-      .forEach((node) => node.remove());
+      .forEach((node) => {
+        node.remove();
+      });
   });
 
   it('emits theme-resolved color and text-decoration on plain links (basic)', () => {

--- a/packages/editor/src/extensions/link.tsx
+++ b/packages/editor/src/extensions/link.tsx
@@ -1,5 +1,5 @@
-import { mergeAttributes } from '@tiptap/core';
 import type { Editor } from '@tiptap/core';
+import { mergeAttributes } from '@tiptap/core';
 import type { LinkOptions as TipTapLinkOptions } from '@tiptap/extension-link';
 import TiptapLink from '@tiptap/extension-link';
 import { Link as ReactEmailLink } from 'react-email';

--- a/packages/editor/src/extensions/link.tsx
+++ b/packages/editor/src/extensions/link.tsx
@@ -1,3 +1,5 @@
+import { mergeAttributes } from '@tiptap/core';
+import type { Editor } from '@tiptap/core';
 import type { LinkOptions as TipTapLinkOptions } from '@tiptap/extension-link';
 import TiptapLink from '@tiptap/extension-link';
 import { Link as ReactEmailLink } from 'react-email';
@@ -6,8 +8,23 @@ export type LinkOptions = TipTapLinkOptions;
 
 import { editorEventBus } from '../core';
 import { EmailMark } from '../core/serializer/email-mark';
-import { inlineCssToJs } from '../utils/styles';
+import {
+  getEmailTheming,
+  getMergedCssJs,
+  getResolvedNodeStyles,
+} from '../plugins/email-theming/extension';
+import { inlineCssToJs, jsToInlineCss } from '../utils/styles';
 import { processStylesForUnlink } from './preserved-style';
+
+function resolveThemedLinkStyle(editor: Editor): string {
+  const theming = getEmailTheming(editor);
+  const resolved = getResolvedNodeStyles(
+    { type: 'link', attrs: {} },
+    0,
+    getMergedCssJs(theming.theme, theming.styles),
+  );
+  return jsToInlineCss(resolved).replace(/;$/, '');
+}
 
 export const Link: EmailMark<TipTapLinkOptions, any> = EmailMark.from(
   TiptapLink,
@@ -82,6 +99,21 @@ export const Link: EmailMark<TipTapLinkOptions, any> = EmailMark.from(
         parseHTML: (element) => element.getAttribute('ses:no-track'),
       },
     };
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const userStyle = ((HTMLAttributes.style as string | undefined) ?? '')
+      .trim()
+      .replace(/;$/, '');
+    const themed = this.editor ? resolveThemedLinkStyle(this.editor) : '';
+    const mergedStyle = [themed, userStyle].filter(Boolean).join('; ');
+    return [
+      'a',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        style: mergedStyle || null,
+      }),
+      0,
+    ];
   },
 
   addCommands() {

--- a/packages/editor/src/plugins/email-theming/extension.tsx
+++ b/packages/editor/src/plugins/email-theming/extension.tsx
@@ -174,7 +174,7 @@ function resolveThemeConfig(config: EditorThemeInput): {
   return { baseTheme, panels };
 }
 
-function getEmailTheming(editor: Editor) {
+export function getEmailTheming(editor: Editor) {
   const theme = getEmailTheme(editor);
   const normalizedStyles =
     normalizeThemePanelStyles(theme, getEmailStyles(editor)) ??

--- a/packages/editor/src/plugins/email-theming/themes.ts
+++ b/packages/editor/src/plugins/email-theming/themes.ts
@@ -729,6 +729,7 @@ const RESET_MINIMAL: ResetTheme = {
   nestedList: RESET_BASIC.nestedList,
   listItem: RESET_BASIC.listItem,
   listParagraph: RESET_BASIC.listParagraph,
+  link: { color: '#0670DB', textDecoration: 'underline' },
 };
 
 export const RESET_THEMES: Record<EditorTheme, ResetTheme> = {

--- a/packages/editor/src/plugins/email-theming/themes.ts
+++ b/packages/editor/src/plugins/email-theming/themes.ts
@@ -677,7 +677,7 @@ const RESET_BASIC: ResetTheme = {
     fontFamily:
       "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif",
   },
-  link: { textDecoration: 'underline' },
+  link: { color: '#0670DB', textDecoration: 'underline' },
   footer: {
     fontSize: '0.8em',
   },
@@ -729,7 +729,7 @@ const RESET_MINIMAL: ResetTheme = {
   nestedList: RESET_BASIC.nestedList,
   listItem: RESET_BASIC.listItem,
   listParagraph: RESET_BASIC.listParagraph,
-  link: { color: '#0670DB', textDecoration: 'underline' },
+  link: RESET_BASIC.link,
 };
 
 export const RESET_THEMES: Record<EditorTheme, ResetTheme> = {


### PR DESCRIPTION
## Summary

- Link mark renderHTML merges EmailTheming link styles into the emitted `<a style="...">`. User inline styles still win via CSS cascade (appended last).
- Exports `getEmailTheming` so the Link extension can resolve the active theme at render time.
- `RESET_MINIMAL.link` now carries `color: #0670DB` + `text-decoration: underline` so both themes ship a default link color.
- No hardcoded colors in link.tsx; all defaults come from `getResolvedNodeStyles` against the active theme.

Unblocks dropping the DOMParser workaround in the dashboard's `generate-json-content.ts` (resend/resend#10044).


### Bug happening

https://github.com/user-attachments/assets/16daba0c-2a5d-42f1-83e2-642632845cff

### After this fix

https://github.com/user-attachments/assets/f16e01c0-46fa-48b9-8225-ed6bf06fc640

## Test plan

- [x] New `packages/editor/src/extensions/link.spec.ts` (6 cases): basic + minimal themes emit themed style, `class="node-link"` preserved, user color wins over theme, `mark.attrs.style` stays empty for plain links (inspector contract), plain `<a>` setContent round-trip produces themed output.
- [x] `pnpm vitest run --project unit` — 434 passed, 1 skipped, no snapshot regressions.
- [x] `pnpm build` clean.
- [ ] Manual: dashboard Visual -> HTML -> Visual, add link in Visual mode, confirm blue + underline in editor view and in exported HTML.
- [ ] Manual: switch theme to minimal, confirm link still themed.
- [ ] Manual: set custom link color via inspector, confirm custom color wins in both editor and export.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make link rendering theme-aware by injecting EmailTheming styles into the `<a>` tag during HTML export. Links render blue and underlined by default, and user inline styles still win.

- **Bug Fixes**
  - Merge theme `link` styles into `<a style>` in `renderHTML`; user inline styles are appended last to win.
  - Move default link styles to `RESET_BASIC` (`color: #0670DB`, `text-decoration: underline`); `RESET_MINIMAL` references them for consistency.
  - Resolve defaults via `getResolvedNodeStyles`; no hardcoded colors in the link extension.
  - Fixes link styling loss on Visual ↔ HTML round‑trips; enables removing the DOMParser workaround in the dashboard.

- **Dependencies**
  - Add changeset for a patch release of `@react-email/editor`.

<sup>Written for commit 9af91a9d41ec67d35f7f19d2a6e7326f89c1b528. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

