### PR TITLE
chore: update year in README from 2025 to 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It reduces the pain of coding responsive emails with dark mode support. It also 
 
 ## Why
 
-We believe that email is an extremely important medium for people to communicate. However, we need to stop developing emails like 2010, and rethink how email can be done in 2025 and beyond. Email development needs a revamp. A renovation. Modernized for the way we build web apps today.
+We believe that email is an extremely important medium for people to communicate. However, we need to stop developing emails like 2010, and rethink how email can be done in 2026 and beyond. Email development needs a revamp. A renovation. Modernized for the way we build web apps today.
 
 ## Install
 


### PR DESCRIPTION
bump year to 2026

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update README to reference 2026 instead of 2025 to keep the messaging current. Replaced "2025 and beyond" with "2026 and beyond" in the Why section.

<sup>Written for commit f08d7a33a079308b1bea542f21dc53c3261d7dc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

