### PR TITLE
feat(editor): celspacing attribute for columns

### DIFF
--- a/.changeset/witty-trams-feel.md
+++ b/.changeset/witty-trams-feel.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": minor
+---
+
+new cellspacing attribute for columns node, remove the gap for columns from default css

--- a/apps/docs/editor/features/column-layouts.mdx
+++ b/apps/docs/editor/features/column-layouts.mdx
@@ -105,6 +105,20 @@ export function MyEditor() {
   the editor instance from child components.
 </Tip>
 
+## Column spacing
+
+Column layouts render as email-safe tables. Space between columns is stored as the
+`cellspacing` attribute on the column layout and exported as the `cellSpacing`
+prop on the underlying `Row`.
+
+Select a 2, 3, or 4 column layout in the editor and use **Column spacing** in
+the inspector to adjust the gap between columns.
+
+<Tip>
+  Column spacing controls the gap between columns. Padding on an individual
+  column controls the space inside that column.
+</Tip>
+
 ## Slash commands
 
 The default slash commands include column layouts. Type `/` and search for "columns":

--- a/apps/docs/editor/features/styling.mdx
+++ b/apps/docs/editor/features/styling.mdx
@@ -454,9 +454,9 @@ Customize how content looks inside the editor.
   border-radius: 0.25rem;
 }
 
-/* Custom column gap */
+/* Custom column gutter (matches exported Row cellSpacing via --re-columns-gap) */
 .tiptap .node-columns {
-  gap: 1rem;
+  --re-columns-gap: 1rem;
 }
 
 /* Custom button appearance in the editor */

--- a/apps/docs/editor/features/styling.mdx
+++ b/apps/docs/editor/features/styling.mdx
@@ -454,10 +454,6 @@ Customize how content looks inside the editor.
   border-radius: 0.25rem;
 }
 
-/* Custom column gutter (matches exported Row cellSpacing via --re-columns-gap) */
-.tiptap .node-columns {
-  --re-columns-gap: 1rem;
-}
 
 /* Custom button appearance in the editor */
 .tiptap .node-button {

--- a/packages/editor/src/__tests__/inspector-column-spacing.browser.spec.tsx
+++ b/packages/editor/src/__tests__/inspector-column-spacing.browser.spec.tsx
@@ -1,4 +1,4 @@
-import { NodeSelection } from '@tiptap/pm/state';
+import { NodeSelection, TextSelection } from '@tiptap/pm/state';
 import { vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
@@ -50,6 +50,22 @@ function Harness({
       content={CONTENT}
     >
       <Inspector.Root data-testid="inspector">
+        <Inspector.Breadcrumb>
+          {(segments) => (
+            <nav aria-label="Inspector breadcrumb">
+              {segments.map((segment) => (
+                <button
+                  type="button"
+                  key={`${segment.node.nodeType}-${segment.node.nodePos.pos}`}
+                  data-node-type={segment.node.nodeType}
+                  onClick={segment.focus}
+                >
+                  {segment.node.nodeType}
+                </button>
+              ))}
+            </nav>
+          )}
+        </Inspector.Breadcrumb>
         <Inspector.Node />
       </Inspector.Root>
     </EmailEditor>
@@ -73,15 +89,15 @@ function findNodePos(editorRef: EmailEditorRef | null, nodeType: string) {
   return nodePos;
 }
 
-function selectColumnsNode(editorRef: EmailEditorRef | null) {
+function selectFirstParagraphText(editorRef: EmailEditorRef | null) {
   const editor = editorRef?.editor;
   if (!editor) throw new Error('Editor not ready');
 
-  const columnsPos = findNodePos(editorRef, 'twoColumns');
+  const paragraphPos = findNodePos(editorRef, 'paragraph');
   editor.view.focus();
   editor.view.dispatch(
     editor.state.tr.setSelection(
-      NodeSelection.create(editor.state.doc, columnsPos),
+      TextSelection.create(editor.state.doc, paragraphPos + 1),
     ),
   );
 }
@@ -114,7 +130,22 @@ describe('inspector column spacing input (browser)', () => {
     const editor = page.getByRole('textbox');
     await expect.element(editor).toBeVisible();
 
-    selectColumnsNode(editorRef.current);
+    selectFirstParagraphText(editorRef.current);
+
+    const columnsBreadcrumb = await vi.waitFor(() => {
+      const button = document.querySelector<HTMLButtonElement>(
+        '[data-node-type="twoColumns"]',
+      );
+      if (!button) throw new Error('Columns breadcrumb not rendered yet');
+      return button;
+    });
+    await userEvent.click(columnsBreadcrumb);
+
+    await vi.waitFor(() => {
+      const selection = editorRef.current?.editor?.state.selection;
+      expect(selection).toBeInstanceOf(NodeSelection);
+      expect((selection as NodeSelection).node.type.name).toBe('twoColumns');
+    });
 
     const section = await waitForColumnsSection();
     const input = section.querySelector<HTMLInputElement>(
@@ -125,15 +156,17 @@ describe('inspector column spacing input (browser)', () => {
     expect(input.value).toBe('8');
 
     input.focus();
-    input.select();
-    await userEvent.keyboard('16');
-    await userEvent.keyboard('{Enter}');
+    await userEvent.keyboard('{ArrowUp}');
 
     await vi.waitFor(() => {
       const columnsPos = findNodePos(editorRef.current, 'twoColumns');
       const columnsNode =
         editorRef.current?.editor?.state.doc.nodeAt(columnsPos);
-      expect(columnsNode?.attrs.cellspacing).toBe(16);
+      expect(columnsNode?.attrs.cellspacing).toBe(9);
     });
+
+    const selection = editorRef.current?.editor?.state.selection;
+    expect(selection).toBeInstanceOf(NodeSelection);
+    expect((selection as NodeSelection).node.type.name).toBe('twoColumns');
   });
 });

--- a/packages/editor/src/__tests__/inspector-column-spacing.browser.spec.tsx
+++ b/packages/editor/src/__tests__/inspector-column-spacing.browser.spec.tsx
@@ -1,0 +1,139 @@
+import { NodeSelection } from '@tiptap/pm/state';
+import { vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { EmailEditor, type EmailEditorRef } from '../email-editor/email-editor';
+import { Inspector } from '../ui/inspector';
+
+const CONTENT = {
+  type: 'doc',
+  content: [
+    {
+      type: 'twoColumns',
+      attrs: {
+        cellspacing: 8,
+      },
+      content: [
+        {
+          type: 'columnsColumn',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'Column A' }],
+            },
+          ],
+        },
+        {
+          type: 'columnsColumn',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'Column B' }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function Harness({
+  editorRef,
+}: {
+  editorRef: React.RefObject<EmailEditorRef | null>;
+}) {
+  return (
+    <EmailEditor
+      ref={(value) => {
+        editorRef.current = value;
+      }}
+      content={CONTENT}
+    >
+      <Inspector.Root data-testid="inspector">
+        <Inspector.Node />
+      </Inspector.Root>
+    </EmailEditor>
+  );
+}
+
+function findNodePos(editorRef: EmailEditorRef | null, nodeType: string) {
+  const editor = editorRef?.editor;
+  if (!editor) throw new Error('Editor not ready');
+
+  let nodePos = -1;
+  editor.state.doc.descendants((node, pos) => {
+    if (nodePos === -1 && node.type.name === nodeType) {
+      nodePos = pos;
+      return false;
+    }
+    return true;
+  });
+
+  if (nodePos === -1) throw new Error(`${nodeType} not found`);
+  return nodePos;
+}
+
+function selectColumnsNode(editorRef: EmailEditorRef | null) {
+  const editor = editorRef?.editor;
+  if (!editor) throw new Error('Editor not ready');
+
+  const columnsPos = findNodePos(editorRef, 'twoColumns');
+  editor.view.focus();
+  editor.view.dispatch(
+    editor.state.tr.setSelection(
+      NodeSelection.create(editor.state.doc, columnsPos),
+    ),
+  );
+}
+
+async function waitForColumnsSection() {
+  return vi.waitFor(() => {
+    const inspector = document.querySelector<HTMLElement>(
+      '[data-testid="inspector"]',
+    );
+    if (!inspector) throw new Error('Inspector not rendered yet');
+
+    const header = Array.from(
+      inspector.querySelectorAll<HTMLElement>(
+        '[data-re-inspector-section-header]',
+      ),
+    ).find((h) => h.textContent?.includes('Column spacing'));
+    const section = header?.closest<HTMLElement>('[data-re-inspector-section]');
+    if (!section) throw new Error('Columns section not rendered yet');
+    return section;
+  });
+}
+
+describe('inspector column spacing input (browser)', () => {
+  it('edits the selected column layout cellspacing attribute', async () => {
+    const editorRef: React.RefObject<EmailEditorRef | null> = {
+      current: null,
+    };
+    render(<Harness editorRef={editorRef} />);
+
+    const editor = page.getByRole('textbox');
+    await expect.element(editor).toBeVisible();
+
+    selectColumnsNode(editorRef.current);
+
+    const section = await waitForColumnsSection();
+    const input = section.querySelector<HTMLInputElement>(
+      'input[data-re-inspector-input]',
+    );
+    if (!input) throw new Error('Column spacing input not rendered yet');
+
+    expect(input.value).toBe('8');
+
+    input.focus();
+    input.select();
+    await userEvent.keyboard('16');
+    await userEvent.keyboard('{Enter}');
+
+    await vi.waitFor(() => {
+      const columnsPos = findNodePos(editorRef.current, 'twoColumns');
+      const columnsNode =
+        editorRef.current?.editor?.state.doc.nodeAt(columnsPos);
+      expect(columnsNode?.attrs.cellspacing).toBe(16);
+    });
+  });
+});

--- a/packages/editor/src/extensions/__snapshots__/columns.spec.tsx.snap
+++ b/packages/editor/src/extensions/__snapshots__/columns.spec.tsx.snap
@@ -101,6 +101,32 @@ exports[`Column Variants > renders TwoColumns with 2 column children 1`] = `
 "
 `;
 
+exports[`Column Variants > renders column parent with custom column spacing 1`] = `
+"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--$-->
+<table
+  align="center"
+  width="100%"
+  border="0"
+  cellpadding="0"
+  cellspacing="12"
+  role="presentation"
+  style="margin:0;padding:0">
+  <tbody style="width:100%">
+    <tr style="width:100%">
+      <td data-id="__react-email-column" style="margin:0;padding:0">
+        Column A
+      </td>
+      <td data-id="__react-email-column" style="margin:0;padding:0">
+        Column B
+      </td>
+    </tr>
+  </tbody>
+</table>
+<!--/$-->
+"
+`;
+
 exports[`Column Variants > renders column parent with inline styles 1`] = `
 "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!--$-->

--- a/packages/editor/src/extensions/columns.spec.tsx
+++ b/packages/editor/src/extensions/columns.spec.tsx
@@ -161,6 +161,65 @@ describe('Column Variants', () => {
     ).toMatchSnapshot();
   });
 
+  it('renders column parent with custom column spacing', async () => {
+    const Parent = TwoColumns.config.renderToReactEmail;
+    const Child = ColumnsColumn.config.renderToReactEmail;
+
+    expect(
+      await render(
+        <Parent
+          node={{ type: 'twoColumns', attrs: { cellspacing: 12 } }}
+          style={columnsStyle}
+          extension={TwoColumns}
+        >
+          <Child
+            node={{ type: 'columnsColumn', attrs: {} }}
+            style={columnsStyle}
+            extension={ColumnsColumn}
+          >
+            Column A
+          </Child>
+          <Child
+            node={{ type: 'columnsColumn', attrs: {} }}
+            style={columnsStyle}
+            extension={ColumnsColumn}
+          >
+            Column B
+          </Child>
+        </Parent>,
+        { pretty: true },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('reflects column spacing in editor HTML without inventing a default gap', () => {
+    const renderHTML = TwoColumns.config.renderHTML;
+
+    const defaultHtml = renderHTML?.({
+      HTMLAttributes: {},
+    } as Parameters<NonNullable<typeof renderHTML>>[0]) as [
+      string,
+      Record<string, unknown>,
+      number,
+    ];
+    expect(defaultHtml[1]).not.toHaveProperty('style');
+
+    const spacedHtml = renderHTML?.({
+      HTMLAttributes: { cellspacing: '12', style: 'padding: 10px;' },
+    } as Parameters<NonNullable<typeof renderHTML>>[0]) as [
+      string,
+      Record<string, unknown>,
+      number,
+    ];
+
+    expect(spacedHtml[1]).toMatchObject({
+      'data-type': 'two-columns',
+      class: 'node-columns',
+      style: 'padding: 10px;--re-columns-gap:12px;',
+    });
+    expect(spacedHtml[1]).not.toHaveProperty('cellspacing');
+  });
+
   it('renders ColumnsColumn with inline styles', async () => {
     const Component = ColumnsColumn.config.renderToReactEmail;
 

--- a/packages/editor/src/extensions/columns.spec.tsx
+++ b/packages/editor/src/extensions/columns.spec.tsx
@@ -215,7 +215,7 @@ describe('Column Variants', () => {
     expect(spacedHtml[1]).toMatchObject({
       'data-type': 'two-columns',
       class: 'node-columns',
-      style: 'padding: 10px;--re-columns-gap:12px;',
+      style: 'padding: 10px;gap:12px;',
     });
     expect(spacedHtml[1]).not.toHaveProperty('cellspacing');
   });

--- a/packages/editor/src/extensions/columns.tsx
+++ b/packages/editor/src/extensions/columns.tsx
@@ -10,6 +10,58 @@ import {
 } from '../utils/attribute-helpers';
 import { inlineCssToJs } from '../utils/styles';
 
+const COLUMN_PARENT_ATTRIBUTES = ['cellspacing'] as const;
+
+function getColumnGapCss(cellspacing: unknown): string | undefined {
+  if (cellspacing === undefined || cellspacing === null || cellspacing === '') {
+    return undefined;
+  }
+
+  const value = String(cellspacing).trim();
+  if (value === '') {
+    return undefined;
+  }
+
+  if (/^\d+(\.\d+)?$/.test(value)) {
+    return `${value}px`;
+  }
+
+  return value;
+}
+
+function getRowCellSpacing(cellspacing: unknown): string | undefined {
+  if (cellspacing === undefined || cellspacing === null || cellspacing === '') {
+    return undefined;
+  }
+
+  const value = String(cellspacing).trim();
+  if (value === '' || value === '0') {
+    return undefined;
+  }
+
+  return value;
+}
+
+function mergeColumnsEditorStyle(
+  spacing: unknown,
+  existingStyle: unknown,
+): string | undefined {
+  const gap = getColumnGapCss(spacing);
+  const currentStyle =
+    typeof existingStyle === 'string' && existingStyle.trim() !== ''
+      ? existingStyle.trim()
+      : '';
+
+  if (!gap) {
+    return currentStyle || undefined;
+  }
+
+  const separator = currentStyle.endsWith(';') ? '' : ';';
+  return currentStyle
+    ? `${currentStyle}${separator}--re-columns-gap:${gap};`
+    : `--re-columns-gap:${gap};`;
+}
+
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     columns: {
@@ -88,6 +140,7 @@ function createColumnsNode(
       return createStandardAttributes([
         ...LAYOUT_ATTRIBUTES,
         ...COMMON_HTML_ATTRIBUTES,
+        ...COLUMN_PARENT_ATTRIBUTES,
       ]);
     },
 
@@ -96,11 +149,21 @@ function createColumnsNode(
     },
 
     renderHTML({ HTMLAttributes }) {
+      const { style, cellspacing, ...attributes } = HTMLAttributes as Record<
+        string,
+        unknown
+      >;
+      const mergedStyle = mergeColumnsEditorStyle(cellspacing, style);
+
       return [
         'div',
         mergeAttributes(
-          { 'data-type': config.dataType, class: 'node-columns' },
-          HTMLAttributes,
+          {
+            'data-type': config.dataType,
+            class: 'node-columns',
+            ...(mergedStyle ? { style: mergedStyle } : {}),
+          },
+          attributes,
         ),
         0,
       ];
@@ -139,10 +202,13 @@ function createColumnsNode(
 
     renderToReactEmail({ children, node, style }) {
       const inlineStyles = inlineCssToJs(node.attrs?.style);
+      const cellSpacing = getRowCellSpacing(node.attrs?.cellspacing);
+
       return (
         <Row
           className={node.attrs?.class || undefined}
           style={{ ...style, ...inlineStyles }}
+          {...(cellSpacing ? { cellSpacing } : {})}
         >
           {children}
         </Row>

--- a/packages/editor/src/extensions/columns.tsx
+++ b/packages/editor/src/extensions/columns.tsx
@@ -58,8 +58,8 @@ function mergeColumnsEditorStyle(
 
   const separator = currentStyle.endsWith(';') ? '' : ';';
   return currentStyle
-    ? `${currentStyle}${separator}--re-columns-gap:${gap};`
-    : `--re-columns-gap:${gap};`;
+    ? `${currentStyle}${separator}gap:${gap};`
+    : `gap:${gap};`;
 }
 
 declare module '@tiptap/core' {

--- a/packages/editor/src/ui/inspector/index.tsx
+++ b/packages/editor/src/ui/inspector/index.tsx
@@ -7,6 +7,7 @@ import { InspectorRoot } from './root';
 import { AttributesSection } from './sections/attributes';
 import { BackgroundSection } from './sections/background';
 import { BorderSection } from './sections/border';
+import { ColumnSpacingSection } from './sections/column-spacing';
 import { LinkSection } from './sections/link';
 import { PaddingSection } from './sections/padding';
 import { SizeSection } from './sections/size';
@@ -22,6 +23,7 @@ export const Inspector = {
   Attributes: AttributesSection,
   Background: BackgroundSection,
   Border: BorderSection,
+  ColumnSpacing: ColumnSpacingSection,
   Link: LinkSection,
   Padding: PaddingSection,
   Size: SizeSection,

--- a/packages/editor/src/ui/inspector/node.tsx
+++ b/packages/editor/src/ui/inspector/node.tsx
@@ -15,6 +15,7 @@ import { useInspector } from './root';
 import { AttributesSection } from './sections/attributes';
 import { BackgroundSection } from './sections/background';
 import { BorderSection } from './sections/border';
+import { ColumnSpacingSection } from './sections/column-spacing';
 import { PaddingSection } from './sections/padding';
 import { SizeSection } from './sections/size';
 import { TypographySection } from './sections/typography';
@@ -159,6 +160,7 @@ interface NodeLayout {
       | 'link'
       | 'typography'
       | 'padding'
+      | 'columnSpacing'
       | 'background'
       | 'border';
   }>;
@@ -212,6 +214,18 @@ function getDefaultLayout(nodeType: string): NodeLayout {
           { type: 'background' },
         ],
       };
+    case 'twoColumns':
+    case 'threeColumns':
+    case 'fourColumns':
+      return {
+        sections: [
+          { type: 'columnSpacing' },
+          { type: 'typography' },
+          { type: 'padding' },
+          { type: 'background' },
+          { type: 'border' },
+        ],
+      };
     default:
       return {
         sections: [
@@ -239,6 +253,8 @@ function InspectorNodeDefaults({ context }: { context: InspectorNodeContext }) {
             return <TypographySection key={section.type} {...context} />;
           case 'padding':
             return <PaddingSection key={section.type} {...context} />;
+          case 'columnSpacing':
+            return <ColumnSpacingSection key={section.type} {...context} />;
           case 'background':
             return <BackgroundSection key={section.type} {...context} />;
           case 'border':

--- a/packages/editor/src/ui/inspector/sections/column-spacing.tsx
+++ b/packages/editor/src/ui/inspector/sections/column-spacing.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { NumberInput } from '../components/number-input';
+import { PropRow } from '../components/prop-row';
+import { Section } from '../components/section';
+import type { InspectorNodeContext } from '../node';
+import { Label } from '../primitives';
+
+const COLUMN_PARENT_TYPES = new Set([
+  'twoColumns',
+  'threeColumns',
+  'fourColumns',
+]);
+
+type InspectorColumnSpacingProps = InspectorNodeContext;
+
+export function ColumnSpacingSection({
+  nodeType,
+  getAttr,
+  setAttr,
+}: InspectorColumnSpacingProps) {
+  if (!COLUMN_PARENT_TYPES.has(nodeType)) {
+    return null;
+  }
+
+  const rawCellspacing = getAttr('cellspacing');
+  const cellspacing =
+    rawCellspacing === undefined ||
+    rawCellspacing === null ||
+    rawCellspacing === ''
+      ? 0
+      : (rawCellspacing as string | number);
+
+  return (
+    <Section title="Column spacing">
+      <PropRow>
+        <Label>Cell spacing</Label>
+        <NumberInput
+          value={cellspacing}
+          onChange={(value) => setAttr('cellspacing', value === '' ? 0 : value)}
+          unit="px"
+          placeholder="0"
+          min={0}
+        />
+      </PropRow>
+    </Section>
+  );
+}

--- a/packages/editor/src/ui/inspector/utils/style-updates.ts
+++ b/packages/editor/src/ui/inspector/utils/style-updates.ts
@@ -1,4 +1,5 @@
 import type { useCurrentEditor } from '@tiptap/react';
+import { NodeSelection } from '@tiptap/pm/state';
 import type { NodeClickedEvent } from '../../../core/event-bus';
 import { SUPPORTED_CSS_PROPERTIES } from '../../../plugins/email-theming/themes';
 import type { KnownCssProperties } from '../../../plugins/email-theming/types';
@@ -34,7 +35,13 @@ export function customUpdateAttributes(
 
   setLocalAttr(attributes);
 
+  const wasNodeSelected =
+    editor.state.selection instanceof NodeSelection &&
+    editor.state.selection.from === pos;
   const transaction = editor.state.tr.setNodeMarkup(pos, null, attributes);
+  if (wasNodeSelected) {
+    transaction.setSelection(NodeSelection.create(transaction.doc, pos));
+  }
   editor.view.dispatch(transaction);
 }
 
@@ -83,10 +90,16 @@ export function customUpdateStyles(
 
   setLocalAttr(attributes);
 
+  const wasNodeSelected =
+    params.editor.state.selection instanceof NodeSelection &&
+    params.editor.state.selection.from === pos;
   const transaction = params.editor.state.tr.setNodeMarkup(
     pos,
     null,
     attributes,
   );
+  if (wasNodeSelected) {
+    transaction.setSelection(NodeSelection.create(transaction.doc, pos));
+  }
   params.editor.view.dispatch(transaction);
 }

--- a/packages/editor/src/ui/inspector/utils/style-updates.ts
+++ b/packages/editor/src/ui/inspector/utils/style-updates.ts
@@ -1,5 +1,5 @@
-import type { useCurrentEditor } from '@tiptap/react';
 import { NodeSelection } from '@tiptap/pm/state';
+import type { useCurrentEditor } from '@tiptap/react';
 import type { NodeClickedEvent } from '../../../core/event-bus';
 import { SUPPORTED_CSS_PROPERTIES } from '../../../plugins/email-theming/themes';
 import type { KnownCssProperties } from '../../../plugins/email-theming/types';

--- a/packages/editor/src/ui/themes/default.css
+++ b/packages/editor/src/ui/themes/default.css
@@ -380,7 +380,6 @@
 
 .tiptap .node-columns {
   display: flex;
-  gap: var(--re-columns-gap, 0px);
   width: 100%;
 }
 

--- a/packages/editor/src/ui/themes/default.css
+++ b/packages/editor/src/ui/themes/default.css
@@ -380,7 +380,7 @@
 
 .tiptap .node-columns {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--re-columns-gap, 0px);
   width: 100%;
 }
 


### PR DESCRIPTION
Closes #3273

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Match editor column layout spacing to exported HTML by removing the hardcoded editor-only gap fallback.
- Add a `cellspacing`-backed column spacing control for 2/3/4 column layouts and export it as React Email `Row` `cellSpacing`.
- Add focused unit/browser coverage and document the new column spacing behavior.

## Checks
- `pnpm --filter @react-email/editor exec vitest run --project unit src/extensions/columns.spec.tsx`
- `pnpm --filter @react-email/editor exec vitest run --project browser src/__tests__/inspector-column-spacing.browser.spec.tsx`
- `pnpm exec biome check packages/editor/src/extensions/columns.tsx packages/editor/src/ui/inspector/node.tsx packages/editor/src/ui/inspector/index.tsx packages/editor/src/ui/inspector/sections/column-spacing.tsx packages/editor/src/__tests__/inspector-column-spacing.browser.spec.tsx apps/docs/editor/features/column-layouts.mdx apps/docs/editor/features/styling.mdx`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eda461b0-905d-4826-b9f9-b026c7ff7e38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eda461b0-905d-4826-b9f9-b026c7ff7e38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a column spacing control for 2/3/4 column layouts and exports it as React Email `Row` `cellSpacing`. Removes the editor-only default gap and maps `cellspacing` to CSS gap so the editor matches exported HTML; includes a changeset for a minor `@react-email/editor` release.

- **New Features**
  - Inspector adds “Column spacing” for 2/3/4 columns backed by `cellspacing`; exported as `cellSpacing` on `Row` (omitted when 0).
  - Editor HTML sets `gap` from `cellspacing`; docs add “Column spacing” and remove the old gap override.

- **Bug Fixes**
  - Keeps the selected node after changing inspector attributes or styles.

<sup>Written for commit 3467d0506d81f07b9ecb64e29fcdb54f10f63e54. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3430?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



