### PR TITLE
fix(editor): reliability for focus scope handling

### DIFF
--- a/.changeset/green-spoons-focus.md
+++ b/.changeset/green-spoons-focus.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": minor
+---
+
+Add focus scope handling for editor menus and inspector controls.

--- a/.changeset/green-spoons-focus.md
+++ b/.changeset/green-spoons-focus.md
@@ -2,4 +2,6 @@
 "@react-email/editor": minor
 ---
 
-Add focus scope handling for editor menus and inspector controls.
+- Add the `FocusScopes` extension to replace provider-based editor focus tracking.
+- Always wrap bubble menus and slash commands with editor focus scopes.
+- Improve reliability when handling `focusout` events from menus, inspector controls, and remounted focused elements.

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ node_modules
 
 # testing
 coverage
+**/.vitest-attachments/
+**/__screenshots__/
 **/*/package-lock.json
 **/*/yalc.lock
 

--- a/apps/docs/editor/api-reference/ui/editor-focus-scope.mdx
+++ b/apps/docs/editor/api-reference/ui/editor-focus-scope.mdx
@@ -1,7 +1,7 @@
 ---
 title: "EditorFocusScope"
 sidebarTitle: "EditorFocusScope"
-description: "Track editor focus across portaled UI with EditorFocusScope and EditorFocusScopeProvider."
+description: "Track editor focus across portaled UI with EditorFocusScope."
 icon: "crosshairs"
 ---
 
@@ -10,61 +10,55 @@ Everything is accessed through a single import:
 ```tsx
 import {
   EditorFocusScope,
-  EditorFocusScopeProvider,
 } from '@react-email/editor/ui';
 ```
 
-Use `EditorFocusScopeProvider` to keep the editor's focus and blur behavior in
-sync across registered surfaces, then wrap each portaled surface that should
-still count as being inside the editor UI with `EditorFocusScope`.
+The `FocusScopes` extension, included by default in `StarterKit`, keeps the
+editor's focus and blur behavior in sync across registered surfaces. Wrap each
+custom portaled surface that should still count as being inside the editor UI
+with `EditorFocusScope`.
 
 <Tip>
-  `Inspector.Root` already renders `EditorFocusScopeProvider` and wraps itself
-  in `EditorFocusScope` by default, so the Inspector handles the editor's focus
-  idiomatically and reliably. Inside a custom inspector, you usually only add
-  `EditorFocusScope` around extra portaled content. Built-in bubble menus and
-  slash commands register themselves when rendered under a provider.
+  `Inspector.Root`, built-in bubble menus, and slash commands already register
+  themselves. Inside custom portaled UI, you usually only add
+  `EditorFocusScope` around the portaled content.
 </Tip>
 
 <h2 id="editor-focus-scope-provider">EditorFocusScopeProvider</h2>
 
-Wrap your editor UI with `EditorFocusScopeProvider` when you need focus-aware
-portals outside the built-in Inspector. The provider must be rendered inside
-the current editor context so it can access the active editor instance.
+`EditorFocusScopeProvider` is deprecated and now renders its children unchanged.
+Focus tracking moved to the `FocusScopes` extension, which is included by
+default in `StarterKit`.
 
 ### Example
 
 ```tsx
-import {
-  EditorFocusScope,
-  EditorFocusScopeProvider,
-} from '@react-email/editor/ui';
+import { StarterKit } from '@react-email/editor/extensions';
+import { EditorFocusScope } from '@react-email/editor/ui';
 import { EditorContent, EditorContext, useEditor } from '@tiptap/react';
 import * as Popover from '@radix-ui/react-popover';
 
 export function MyEditor() {
   const editor = useEditor({
-    extensions,
+    extensions: [StarterKit.configure()],
     content,
   });
 
   return (
     <EditorContext.Provider value={{ editor }}>
-      <EditorFocusScopeProvider clearSelectionOnBlur={false}>
-        <EditorContent editor={editor} />
+      <EditorContent editor={editor} />
 
-        <Popover.Root>
-          <Popover.Trigger type="button">Theme presets</Popover.Trigger>
+      <Popover.Root>
+        <Popover.Trigger type="button">Theme presets</Popover.Trigger>
 
-          <Popover.Portal>
-            <EditorFocusScope>
-              <Popover.Content sideOffset={8}>
-                <button type="button">Apply preset</button>
-              </Popover.Content>
-            </EditorFocusScope>
-          </Popover.Portal>
-        </Popover.Root>
-      </EditorFocusScopeProvider>
+        <Popover.Portal>
+          <EditorFocusScope>
+            <Popover.Content sideOffset={8}>
+              <button type="button">Apply preset</button>
+            </Popover.Content>
+          </EditorFocusScope>
+        </Popover.Portal>
+      </Popover.Root>
     </EditorContext.Provider>
   );
 }
@@ -76,13 +70,11 @@ being inside the editor UI.
 ### Props
 
 <ResponseField name="children" type="ReactNode">
-  The editor UI subtree that should share focus tracking.
+  Rendered unchanged.
 </ResponseField>
 
 <ResponseField name="clearSelectionOnBlur" type="boolean" default="true">
-  When focus leaves every registered scope, clear the current selection as part
-  of blur handling. Set this to `false` if you want to preserve the selection
-  when the editor truly loses focus.
+  Deprecated and ignored. Configure `FocusScopes` in `StarterKit` instead.
 </ResponseField>
 
 ## EditorFocusScope
@@ -91,10 +83,8 @@ Use `EditorFocusScope` around portaled UI like Radix `Select.Content`,
 `Popover.Content`, or dialog content so moving focus into that portal is still
 treated as staying inside the editor UI.
 
-`EditorFocusScope` only registers focus tracking inside
-[`EditorFocusScopeProvider`](/editor/api-reference/ui/editor-focus-scope#editor-focus-scope-provider),
-which tracks registered focus scopes and updates the editor's focus state for
-them. Without a provider, it renders its children unchanged.
+`EditorFocusScope` registers with the editor's `FocusScopes` extension. If the
+extension is not present, it renders its children unchanged.
 
 ### Example
 
@@ -134,10 +124,9 @@ import * as Select from '@radix-ui/react-select';
 </Inspector.Node>
 ```
 
-If you are building a focus-aware editor shell outside `Inspector.Root`, wrap
-the editor with
-[`EditorFocusScopeProvider`](/editor/api-reference/ui/editor-focus-scope#editor-focus-scope-provider)
-and then use `EditorFocusScope` for each portaled surface.
+If you are building a focus-aware editor shell without `StarterKit`, add the
+`FocusScopes` extension and then use `EditorFocusScope` for each portaled
+surface.
 
 ### Props
 

--- a/apps/docs/editor/api-reference/ui/editor-focus-scope.mdx
+++ b/apps/docs/editor/api-reference/ui/editor-focus-scope.mdx
@@ -22,7 +22,8 @@ still count as being inside the editor UI with `EditorFocusScope`.
   `Inspector.Root` already renders `EditorFocusScopeProvider` and wraps itself
   in `EditorFocusScope` by default, so the Inspector handles the editor's focus
   idiomatically and reliably. Inside a custom inspector, you usually only add
-  `EditorFocusScope` around extra portaled content.
+  `EditorFocusScope` around extra portaled content. Built-in bubble menus and
+  slash commands register themselves when rendered under a provider.
 </Tip>
 
 <h2 id="editor-focus-scope-provider">EditorFocusScopeProvider</h2>
@@ -90,10 +91,10 @@ Use `EditorFocusScope` around portaled UI like Radix `Select.Content`,
 `Popover.Content`, or dialog content so moving focus into that portal is still
 treated as staying inside the editor UI.
 
-`EditorFocusScope` must be used inside
+`EditorFocusScope` only registers focus tracking inside
 [`EditorFocusScopeProvider`](/editor/api-reference/ui/editor-focus-scope#editor-focus-scope-provider),
 which tracks registered focus scopes and updates the editor's focus state for
-them.
+them. Without a provider, it renders its children unchanged.
 
 ### Example
 

--- a/apps/docs/editor/api-reference/ui/editor-focus-scope.mdx
+++ b/apps/docs/editor/api-reference/ui/editor-focus-scope.mdx
@@ -26,9 +26,10 @@ with `EditorFocusScope`.
 
 <h2 id="editor-focus-scope-provider">EditorFocusScopeProvider</h2>
 
-`EditorFocusScopeProvider` is deprecated and now renders its children unchanged.
-Focus tracking moved to the `FocusScopes` extension, which is included by
-default in `StarterKit`.
+`EditorFocusScopeProvider` is deprecated. Focus tracking moved to the
+`FocusScopes` extension, which is included by default in `StarterKit`, but the
+provider still installs the same tracking plugin for editors that do not use
+`StarterKit`.
 
 ### Example
 
@@ -74,7 +75,8 @@ being inside the editor UI.
 </ResponseField>
 
 <ResponseField name="clearSelectionOnBlur" type="boolean" default="true">
-  Deprecated and ignored. Configure `FocusScopes` in `StarterKit` instead.
+  Deprecated. Used only by the provider's fallback plugin. Prefer configuring
+  `FocusScopes` in `StarterKit` instead.
 </ResponseField>
 
 ## EditorFocusScope

--- a/apps/docs/editor/api-reference/ui/inspector.mdx
+++ b/apps/docs/editor/api-reference/ui/inspector.mdx
@@ -61,9 +61,7 @@ export function MyEditor() {
 </Tip>
 
 <Tip>
-  `Inspector.Root` already renders
-  [EditorFocusScopeProvider](/editor/api-reference/ui/editor-focus-scope#editor-focus-scope-provider)
-  and wraps itself in
+  `Inspector.Root` already wraps itself in
   [EditorFocusScope](/editor/api-reference/ui/editor-focus-scope) by default,
   so the Inspector handles the editor's focus idiomatically and reliably. Add
   `EditorFocusScope` yourself only when custom inspector controls render

--- a/apps/docs/editor/features/inspector.mdx
+++ b/apps/docs/editor/features/inspector.mdx
@@ -382,13 +382,11 @@ import * as Select from '@radix-ui/react-select';
 </Inspector.Node>
 ```
 
-`Inspector.Root` already includes
-[`EditorFocusScopeProvider`](/editor/api-reference/ui/editor-focus-scope#editor-focus-scope-provider),
-and it uses both focus-scope components by default to handle the editor's focus
-idiomatically and reliably. Inside a custom inspector you usually only need to
-add [`EditorFocusScope`](/editor/api-reference/ui/editor-focus-scope) around
-the portaled content. The same pattern works for other portaled Radix
-components, not just `Select`.
+`Inspector.Root` already uses
+[`EditorFocusScope`](/editor/api-reference/ui/editor-focus-scope) by default to
+handle the editor's focus idiomatically and reliably. Inside a custom inspector
+you usually only need to add `EditorFocusScope` around the portaled content.
+The same pattern works for other portaled Radix components, not just `Select`.
 
 ## Reusing built-in sections
 

--- a/packages/editor/src/__tests__/inspector-padding.browser.spec.tsx
+++ b/packages/editor/src/__tests__/inspector-padding.browser.spec.tsx
@@ -30,16 +30,19 @@ function Harness({
   editorRef: React.RefObject<EmailEditorRef | null>;
 }) {
   return (
-    <EmailEditor
-      ref={(value) => {
-        editorRef.current = value;
-      }}
-      content={CONTENT}
-    >
-      <Inspector.Root data-testid="inspector">
-        <Inspector.Node />
-      </Inspector.Root>
-    </EmailEditor>
+    <>
+      <EmailEditor
+        ref={(value) => {
+          editorRef.current = value;
+        }}
+        content={CONTENT}
+      >
+        <Inspector.Root data-testid="inspector">
+          <Inspector.Node />
+        </Inspector.Root>
+      </EmailEditor>
+      <button type="button">Outside editor</button>
+    </>
   );
 }
 
@@ -156,7 +159,7 @@ describe('inspector padding input (browser)', () => {
     expect(paddingInput.value).toBe('12');
   });
 
-  it('keeps the editor focused when expanding per-side padding controls', async () => {
+  it('keeps focus after expanding padding controls, then blurs on an outside click', async () => {
     const editorRef: React.RefObject<EmailEditorRef | null> = {
       current: null,
     };
@@ -184,6 +187,42 @@ describe('inspector padding input (browser)', () => {
     });
 
     expect(editor.isFocused).toBe(true);
+
+    await userEvent.click(page.getByRole('button', { name: 'Outside editor' }));
+
+    await vi.waitFor(() => {
+      if (editor.isFocused) {
+        throw new Error('Editor is still focused');
+      }
+    });
+
+    expect(editor.isFocused).toBe(false);
+  });
+
+  it('blurs the editor when focus moves outside the editor and inspector', async () => {
+    const editorRef: React.RefObject<EmailEditorRef | null> = {
+      current: null,
+    };
+    render(<Harness editorRef={editorRef} />);
+
+    const editorElement = page.getByRole('textbox');
+    await expect.element(editorElement).toBeVisible();
+
+    selectSectionNode(editorRef.current);
+
+    const editor = editorRef.current?.editor;
+    if (!editor) throw new Error('Editor not ready');
+    expect(editor.isFocused).toBe(true);
+
+    await userEvent.click(page.getByRole('button', { name: 'Outside editor' }));
+
+    await vi.waitFor(() => {
+      if (editor.isFocused) {
+        throw new Error('Editor is still focused');
+      }
+    });
+
+    expect(editor.isFocused).toBe(false);
   });
 });
 

--- a/packages/editor/src/__tests__/inspector-padding.browser.spec.tsx
+++ b/packages/editor/src/__tests__/inspector-padding.browser.spec.tsx
@@ -91,6 +91,17 @@ async function waitForPaddingInputWithValue(expected: string) {
   });
 }
 
+function getPerSidePaddingButton(spacing: HTMLElement) {
+  const tooltip = Array.from(
+    spacing.querySelectorAll<HTMLElement>('[data-re-inspector-tooltip]'),
+  ).find((el) => el.textContent?.includes('Per side'));
+  const button = tooltip?.querySelector<HTMLButtonElement>(
+    '[data-re-inspector-toggle-item]',
+  );
+  if (!button) throw new Error('Per side padding button not rendered yet');
+  return button;
+}
+
 describe('inspector padding input (browser)', () => {
   it('keeps the same value after focus + blur', async () => {
     const editorRef: React.RefObject<EmailEditorRef | null> = {
@@ -143,6 +154,36 @@ describe('inspector padding input (browser)', () => {
     paddingInput.blur();
 
     expect(paddingInput.value).toBe('12');
+  });
+
+  it('keeps the editor focused when expanding per-side padding controls', async () => {
+    const editorRef: React.RefObject<EmailEditorRef | null> = {
+      current: null,
+    };
+    render(<Harness editorRef={editorRef} />);
+
+    const editorElement = page.getByRole('textbox');
+    await expect.element(editorElement).toBeVisible();
+
+    selectSectionNode(editorRef.current);
+
+    const editor = editorRef.current?.editor;
+    if (!editor) throw new Error('Editor not ready');
+    expect(editor.isFocused).toBe(true);
+
+    const spacing = await waitForSpacingSection();
+    await userEvent.click(getPerSidePaddingButton(spacing));
+
+    await vi.waitFor(() => {
+      const inputs = spacing.querySelectorAll<HTMLInputElement>(
+        'input[data-re-inspector-input]',
+      );
+      if (inputs.length < 4) {
+        throw new Error('Per-side padding inputs not rendered yet');
+      }
+    });
+
+    expect(editor.isFocused).toBe(true);
   });
 });
 

--- a/packages/editor/src/extensions/focus-scopes.spec.ts
+++ b/packages/editor/src/extensions/focus-scopes.spec.ts
@@ -1,0 +1,78 @@
+import { Editor, extensions as nativeTiptapExtensions } from '@tiptap/core';
+import { StarterKit } from '.';
+import { focusScopePluginKey } from './focus-scopes';
+
+function waitForCreate() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createEditor() {
+  const element = document.createElement('div');
+  document.body.append(element);
+
+  const editor = new Editor({
+    element,
+    extensions: [StarterKit.configure()],
+    content: '<p>Hello world</p>',
+  });
+
+  return { editor, element };
+}
+
+describe('FocusScopes', () => {
+  it('replaces the default Tiptap focus events plugin', async () => {
+    const { editor, element } = createEditor();
+    await waitForCreate();
+
+    expect(
+      editor.state.plugins.some(
+        (plugin) => plugin.spec.key === focusScopePluginKey,
+      ),
+    ).toBe(true);
+    expect(
+      editor.state.plugins.some(
+        (plugin) =>
+          plugin.spec.key === nativeTiptapExtensions.focusEventsPluginKey,
+      ),
+    ).toBe(false);
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('keeps editor focus and selection when focus moves into a registered scope', async () => {
+    const { editor, element } = createEditor();
+    const externalScope = document.createElement('button');
+    document.body.append(externalScope);
+    await waitForCreate();
+
+    editor.commands.setTextSelection({ from: 2, to: 7 });
+    editor.view.dom.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    editor.extensionStorage.focusScope.registerScope(externalScope);
+    editor.view.dom.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: true,
+        relatedTarget: externalScope,
+      }),
+    );
+
+    expect(editor.isFocused).toBe(true);
+    expect(editor.state.selection.from).toBe(2);
+    expect(editor.state.selection.to).toBe(7);
+
+    externalScope.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: true,
+        relatedTarget: document.body,
+      }),
+    );
+
+    expect(editor.isFocused).toBe(false);
+    expect(editor.state.selection.from).toBe(0);
+
+    editor.destroy();
+    element.remove();
+    externalScope.remove();
+  });
+});

--- a/packages/editor/src/extensions/focus-scopes.ts
+++ b/packages/editor/src/extensions/focus-scopes.ts
@@ -48,36 +48,56 @@ export function createFocusScopePlugin({
       return;
     }
 
+    var previous = editor.isFocused;
     editor.isFocused = true;
 
-    const transaction = editor.state.tr
-      .setMeta('focus', { event })
-      .setMeta('addToHistory', false);
+    if (previous !== editor.isFocused) {
+      const transaction = editor.state.tr
+        .setMeta('focus', { event })
+        .setMeta('addToHistory', false);
 
-    editor.view.dispatch(transaction);
+      editor.view.dispatch(transaction);
+    }
   };
 
   const handleFocusOut = (event: FocusEvent) => {
-    const nextFocus = event.relatedTarget as Node | null;
-    const stillInside = [...scopeRefs].some(
-      (el) => nextFocus && el.contains(nextFocus),
-    );
+    // queueMicrotask is needed so that we can determine reliably
+    // whether or not previousFocus is inside of the DOM
+    queueMicrotask(() => {
+      const nextFocus = event.relatedTarget as Node | null;
+      if (!nextFocus) {
+        // a fail safe for when a focused element inside a focus scope is removed from the DOM.
+        // our wanted behavior is that focus kept even after that
+        const previousFocus = event.target as Node | null;
+        if (!previousFocus?.isConnected) {
+          return;
+        }
+      }
 
-    if (stillInside) {
-      return;
-    }
+      if (nextFocus) {
+        const stillInside = [...scopeRefs].some(
+          (el) => nextFocus && el.contains(nextFocus),
+        );
+        if (stillInside) {
+          return;
+        }
+      }
 
-    editor.isFocused = false;
+      var previous = editor.isFocused;
+      editor.isFocused = false;
 
-    const transaction = editor.state.tr
-      .setMeta('blur', { event })
-      .setMeta('addToHistory', false);
+      if (previous !== editor.isFocused) {
+        const transaction = editor.state.tr
+          .setMeta('blur', { event })
+          .setMeta('addToHistory', false);
 
-    if (clearSelectionOnBlur) {
-      transaction.setSelection(TextSelection.create(transaction.doc, 0));
-    }
+        if (clearSelectionOnBlur) {
+          transaction.setSelection(TextSelection.create(transaction.doc, 0));
+        }
 
-    editor.view.dispatch(transaction);
+        editor.view.dispatch(transaction);
+      }
+    });
   };
 
   const registerScope = (el: HTMLElement | null) => {

--- a/packages/editor/src/extensions/focus-scopes.ts
+++ b/packages/editor/src/extensions/focus-scopes.ts
@@ -22,7 +22,7 @@ declare module '@tiptap/core' {
 
 export const focusScopePluginKey = new PluginKey('reactEmailFocusScopes');
 
-const noop = () => { };
+const noop = () => {};
 
 export function createFocusScopesStorage(): FocusScopesStorage {
   return {

--- a/packages/editor/src/extensions/focus-scopes.ts
+++ b/packages/editor/src/extensions/focus-scopes.ts
@@ -22,7 +22,7 @@ declare module '@tiptap/core' {
 
 export const focusScopePluginKey = new PluginKey('reactEmailFocusScopes');
 
-const noop = () => {};
+const noop = () => { };
 
 export function createFocusScopesStorage(): FocusScopesStorage {
   return {
@@ -94,13 +94,13 @@ export function createFocusScopePlugin({
       }
     };
 
-    // queueMicrotask is needed so that we can determine reliably
-    // whether or not previousFocus is inside of the DOM
     const nextFocus = event.relatedTarget as Node | null;
     if (!nextFocus) {
       const previousFocus = event.target as Node | null;
       const fallbackScope = getClosestScope(previousFocus);
 
+      // queueMicrotask is needed so that we can determine reliably
+      // whether or not previousFocus is inside of the DOM
       queueMicrotask(() => {
         if (isInsideScope(event.view?.document.activeElement ?? null)) {
           return;
@@ -113,12 +113,13 @@ export function createFocusScopePlugin({
 
         blur();
       });
-    } else {
-      if (isInsideScope(nextFocus)) {
-        return;
-      }
-      blur();
     }
+
+    if (isInsideScope(nextFocus)) {
+      return;
+    }
+    blur();
+    return;
   };
 
   const registerScope = (el: HTMLElement | null) => {

--- a/packages/editor/src/extensions/focus-scopes.ts
+++ b/packages/editor/src/extensions/focus-scopes.ts
@@ -1,4 +1,8 @@
-import { Extension, extensions as nativeTiptapExtensions } from '@tiptap/core';
+import {
+  type Editor,
+  Extension,
+  extensions as nativeTiptapExtensions,
+} from '@tiptap/core';
 import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
 
 export interface FocusScopesOptions {
@@ -20,6 +24,101 @@ export const focusScopePluginKey = new PluginKey('reactEmailFocusScopes');
 
 const noop = () => {};
 
+export function createFocusScopesStorage(): FocusScopesStorage {
+  return {
+    registerScope: noop,
+    unregisterScope: noop,
+  };
+}
+
+export function createFocusScopePlugin({
+  editor,
+  storage,
+  clearSelectionOnBlur,
+}: {
+  editor: Editor;
+  storage: FocusScopesStorage;
+  clearSelectionOnBlur: boolean;
+}) {
+  const scopeRefs = new Set<HTMLElement>();
+
+  const handleFocusIn = (event: FocusEvent) => {
+    const target = event.target;
+    if (!(target instanceof Node) || !editor.view.dom.contains(target)) {
+      return;
+    }
+
+    editor.isFocused = true;
+
+    const transaction = editor.state.tr
+      .setMeta('focus', { event })
+      .setMeta('addToHistory', false);
+
+    editor.view.dispatch(transaction);
+  };
+
+  const handleFocusOut = (event: FocusEvent) => {
+    const nextFocus = event.relatedTarget as Node | null;
+    const stillInside = [...scopeRefs].some(
+      (el) => nextFocus && el.contains(nextFocus),
+    );
+
+    if (stillInside) {
+      return;
+    }
+
+    editor.isFocused = false;
+
+    const transaction = editor.state.tr
+      .setMeta('blur', { event })
+      .setMeta('addToHistory', false);
+
+    if (clearSelectionOnBlur) {
+      transaction.setSelection(TextSelection.create(transaction.doc, 0));
+    }
+
+    editor.view.dispatch(transaction);
+  };
+
+  const registerScope = (el: HTMLElement | null) => {
+    if (!el || scopeRefs.has(el)) return;
+
+    scopeRefs.add(el);
+    el.addEventListener('focusin', handleFocusIn);
+    el.addEventListener('focusout', handleFocusOut);
+  };
+
+  const unregisterScope = (el: HTMLElement | null) => {
+    if (!el || !scopeRefs.has(el)) return;
+
+    scopeRefs.delete(el);
+    el.removeEventListener('focusin', handleFocusIn);
+    el.removeEventListener('focusout', handleFocusOut);
+  };
+
+  storage.registerScope = registerScope;
+  storage.unregisterScope = unregisterScope;
+
+  return new Plugin({
+    key: focusScopePluginKey,
+    view(view) {
+      storage.registerScope = registerScope;
+      storage.unregisterScope = unregisterScope;
+      registerScope(view.dom);
+
+      return {
+        destroy() {
+          for (const scope of [...scopeRefs]) {
+            unregisterScope(scope);
+          }
+          storage.registerScope = noop;
+          storage.unregisterScope = noop;
+        },
+      };
+    },
+  });
+}
+
 export const FocusScopes = Extension.create<
   FocusScopesOptions,
   FocusScopesStorage
@@ -33,10 +132,7 @@ export const FocusScopes = Extension.create<
   },
 
   addStorage() {
-    return {
-      registerScope: noop,
-      unregisterScope: noop,
-    };
+    return createFocusScopesStorage();
   },
 
   onCreate() {
@@ -44,84 +140,11 @@ export const FocusScopes = Extension.create<
   },
 
   addProseMirrorPlugins() {
-    const { editor, options, storage } = this;
-    const scopeRefs = new Set<HTMLElement>();
-
-    const handleFocusIn = (event: FocusEvent) => {
-      const target = event.target;
-      if (!(target instanceof Node) || !editor.view.dom.contains(target)) {
-        return;
-      }
-
-      editor.isFocused = true;
-
-      const transaction = editor.state.tr
-        .setMeta('focus', { event })
-        .setMeta('addToHistory', false);
-
-      editor.view.dispatch(transaction);
-    };
-
-    const handleFocusOut = (event: FocusEvent) => {
-      const nextFocus = event.relatedTarget as Node | null;
-      const stillInside = [...scopeRefs].some(
-        (el) => nextFocus && el.contains(nextFocus),
-      );
-
-      if (stillInside) {
-        return;
-      }
-
-      editor.isFocused = false;
-
-      const transaction = editor.state.tr
-        .setMeta('blur', { event })
-        .setMeta('addToHistory', false);
-
-      if (options.clearSelectionOnBlur) {
-        transaction.setSelection(TextSelection.create(transaction.doc, 0));
-      }
-
-      editor.view.dispatch(transaction);
-    };
-
-    const registerScope = (el: HTMLElement | null) => {
-      if (!el || scopeRefs.has(el)) return;
-
-      scopeRefs.add(el);
-      el.addEventListener('focusin', handleFocusIn);
-      el.addEventListener('focusout', handleFocusOut);
-    };
-
-    const unregisterScope = (el: HTMLElement | null) => {
-      if (!el || !scopeRefs.has(el)) return;
-
-      scopeRefs.delete(el);
-      el.removeEventListener('focusin', handleFocusIn);
-      el.removeEventListener('focusout', handleFocusOut);
-    };
-
-    storage.registerScope = registerScope;
-    storage.unregisterScope = unregisterScope;
-
     return [
-      new Plugin({
-        key: focusScopePluginKey,
-        view(view) {
-          storage.registerScope = registerScope;
-          storage.unregisterScope = unregisterScope;
-          registerScope(view.dom);
-
-          return {
-            destroy() {
-              for (const scope of [...scopeRefs]) {
-                unregisterScope(scope);
-              }
-              storage.registerScope = noop;
-              storage.unregisterScope = noop;
-            },
-          };
-        },
+      createFocusScopePlugin({
+        editor: this.editor,
+        storage: this.storage,
+        clearSelectionOnBlur: this.options.clearSelectionOnBlur,
       }),
     ];
   },

--- a/packages/editor/src/extensions/focus-scopes.ts
+++ b/packages/editor/src/extensions/focus-scopes.ts
@@ -42,13 +42,29 @@ export function createFocusScopePlugin({
 }) {
   const scopeRefs = new Set<HTMLElement>();
 
+  const isInsideScope = (node: Node | null) =>
+    Boolean(node && [...scopeRefs].some((el) => el.contains(node)));
+
+  const getClosestScope = (node: Node | null) => {
+    if (!node) return null;
+
+    let closest: HTMLElement | null = null;
+    for (const scope of scopeRefs) {
+      if (!scope.contains(node)) continue;
+      if (!closest || closest.contains(scope)) {
+        closest = scope;
+      }
+    }
+    return closest;
+  };
+
   const handleFocusIn = (event: FocusEvent) => {
     const target = event.target;
     if (!(target instanceof Node) || !editor.view.dom.contains(target)) {
       return;
     }
 
-    var previous = editor.isFocused;
+    const previous = editor.isFocused;
     editor.isFocused = true;
 
     if (previous !== editor.isFocused) {
@@ -61,29 +77,8 @@ export function createFocusScopePlugin({
   };
 
   const handleFocusOut = (event: FocusEvent) => {
-    // queueMicrotask is needed so that we can determine reliably
-    // whether or not previousFocus is inside of the DOM
-    queueMicrotask(() => {
-      const nextFocus = event.relatedTarget as Node | null;
-      if (!nextFocus) {
-        // a fail safe for when a focused element inside a focus scope is removed from the DOM.
-        // our wanted behavior is that focus kept even after that
-        const previousFocus = event.target as Node | null;
-        if (!previousFocus?.isConnected) {
-          return;
-        }
-      }
-
-      if (nextFocus) {
-        const stillInside = [...scopeRefs].some(
-          (el) => nextFocus && el.contains(nextFocus),
-        );
-        if (stillInside) {
-          return;
-        }
-      }
-
-      var previous = editor.isFocused;
+    const blur = () => {
+      const previous = editor.isFocused;
       editor.isFocused = false;
 
       if (previous !== editor.isFocused) {
@@ -97,7 +92,33 @@ export function createFocusScopePlugin({
 
         editor.view.dispatch(transaction);
       }
-    });
+    };
+
+    // queueMicrotask is needed so that we can determine reliably
+    // whether or not previousFocus is inside of the DOM
+    const nextFocus = event.relatedTarget as Node | null;
+    if (!nextFocus) {
+      const previousFocus = event.target as Node | null;
+      const fallbackScope = getClosestScope(previousFocus);
+
+      queueMicrotask(() => {
+        if (isInsideScope(event.view?.document.activeElement ?? null)) {
+          return;
+        }
+
+        if (!previousFocus?.isConnected && fallbackScope?.isConnected) {
+          fallbackScope.focus({ preventScroll: true });
+          return;
+        }
+
+        blur();
+      });
+    } else {
+      if (isInsideScope(nextFocus)) {
+        return;
+      }
+      blur();
+    }
   };
 
   const registerScope = (el: HTMLElement | null) => {

--- a/packages/editor/src/extensions/focus-scopes.ts
+++ b/packages/editor/src/extensions/focus-scopes.ts
@@ -113,13 +113,14 @@ export function createFocusScopePlugin({
 
         blur();
       });
+      return;
     }
 
     if (isInsideScope(nextFocus)) {
       return;
     }
+
     blur();
-    return;
   };
 
   const registerScope = (el: HTMLElement | null) => {

--- a/packages/editor/src/extensions/focus-scopes.ts
+++ b/packages/editor/src/extensions/focus-scopes.ts
@@ -1,0 +1,128 @@
+import { Extension, extensions as nativeTiptapExtensions } from '@tiptap/core';
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
+
+export interface FocusScopesOptions {
+  clearSelectionOnBlur: boolean;
+}
+
+export interface FocusScopesStorage {
+  registerScope: (el: HTMLElement | null) => void;
+  unregisterScope: (el: HTMLElement | null) => void;
+}
+
+declare module '@tiptap/core' {
+  interface Storage {
+    focusScope: FocusScopesStorage;
+  }
+}
+
+export const focusScopePluginKey = new PluginKey('reactEmailFocusScopes');
+
+const noop = () => {};
+
+export const FocusScopes = Extension.create<
+  FocusScopesOptions,
+  FocusScopesStorage
+>({
+  name: 'focusScope',
+
+  addOptions() {
+    return {
+      clearSelectionOnBlur: true,
+    };
+  },
+
+  addStorage() {
+    return {
+      registerScope: noop,
+      unregisterScope: noop,
+    };
+  },
+
+  onCreate() {
+    this.editor.unregisterPlugin(nativeTiptapExtensions.focusEventsPluginKey);
+  },
+
+  addProseMirrorPlugins() {
+    const { editor, options, storage } = this;
+    const scopeRefs = new Set<HTMLElement>();
+
+    const handleFocusIn = (event: FocusEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node) || !editor.view.dom.contains(target)) {
+        return;
+      }
+
+      editor.isFocused = true;
+
+      const transaction = editor.state.tr
+        .setMeta('focus', { event })
+        .setMeta('addToHistory', false);
+
+      editor.view.dispatch(transaction);
+    };
+
+    const handleFocusOut = (event: FocusEvent) => {
+      const nextFocus = event.relatedTarget as Node | null;
+      const stillInside = [...scopeRefs].some(
+        (el) => nextFocus && el.contains(nextFocus),
+      );
+
+      if (stillInside) {
+        return;
+      }
+
+      editor.isFocused = false;
+
+      const transaction = editor.state.tr
+        .setMeta('blur', { event })
+        .setMeta('addToHistory', false);
+
+      if (options.clearSelectionOnBlur) {
+        transaction.setSelection(TextSelection.create(transaction.doc, 0));
+      }
+
+      editor.view.dispatch(transaction);
+    };
+
+    const registerScope = (el: HTMLElement | null) => {
+      if (!el || scopeRefs.has(el)) return;
+
+      scopeRefs.add(el);
+      el.addEventListener('focusin', handleFocusIn);
+      el.addEventListener('focusout', handleFocusOut);
+    };
+
+    const unregisterScope = (el: HTMLElement | null) => {
+      if (!el || !scopeRefs.has(el)) return;
+
+      scopeRefs.delete(el);
+      el.removeEventListener('focusin', handleFocusIn);
+      el.removeEventListener('focusout', handleFocusOut);
+    };
+
+    storage.registerScope = registerScope;
+    storage.unregisterScope = unregisterScope;
+
+    return [
+      new Plugin({
+        key: focusScopePluginKey,
+        view(view) {
+          storage.registerScope = registerScope;
+          storage.unregisterScope = unregisterScope;
+          registerScope(view.dom);
+
+          return {
+            destroy() {
+              for (const scope of [...scopeRefs]) {
+                unregisterScope(scope);
+              }
+              storage.registerScope = noop;
+              storage.unregisterScope = noop;
+            },
+          };
+        },
+      }),
+    ];
+  },
+});

--- a/packages/editor/src/extensions/index.ts
+++ b/packages/editor/src/extensions/index.ts
@@ -39,6 +39,7 @@ import type { DivOptions } from './div';
 import { Div } from './div';
 import type { DividerOptions } from './divider';
 import { Divider } from './divider';
+import { FocusScopes, type FocusScopesOptions } from './focus-scopes';
 import type { GlobalContentOptions } from './global-content';
 import { GlobalContent } from './global-content';
 import { HardBreak } from './hard-break';
@@ -84,6 +85,7 @@ export * from './columns';
 export * from './container';
 export * from './div';
 export * from './divider';
+export * from './focus-scopes';
 export * from './global-content';
 export * from './hard-break';
 export * from './heading';
@@ -146,6 +148,7 @@ const starterKitExtensions: Record<string, AnyExtension> = {
   ClassAttribute,
   MaxNesting,
   UndoRedo,
+  FocusScopes,
 };
 
 export type StarterKitOptions = {
@@ -189,6 +192,7 @@ export type StarterKitOptions = {
   ClassAttribute: Partial<ClassAttributeOptions> | false;
   MaxNesting: Partial<MaxNestingOptions> | false;
   UndoRedo: Partial<UndoRedoOptions> | false;
+  FocusScopes: Partial<FocusScopesOptions> | false;
   TiptapStarterKit: Partial<TipTapStarterKitOptions> | false;
 };
 
@@ -338,6 +342,7 @@ export const StarterKit = Extension.create<StarterKitOptions>({
         nodeTypes: ['section', 'bulletList', 'orderedList'],
       },
       UndoRedo: {},
+      FocusScopes: {},
     };
   },
 

--- a/packages/editor/src/extensions/trailing-node.spec.ts
+++ b/packages/editor/src/extensions/trailing-node.spec.ts
@@ -227,7 +227,9 @@ describe('TrailingNode', () => {
     const container = json.content!.find((n) => n.type === 'container')!;
     const section = container.content!.find((n) => n.type === 'section')!;
 
-    expect(section.content!.at(-1)!.type).toBe('paragraph');
+    expect(
+      'content' in section ? section.content?.at(-1)?.type : undefined,
+    ).toBe('paragraph');
     expect(container.content!.at(-1)!.type).toBe('paragraph');
   });
 

--- a/packages/editor/src/plugins/image/extension.spec.tsx
+++ b/packages/editor/src/plugins/image/extension.spec.tsx
@@ -1,4 +1,5 @@
 import type { Editor } from '@tiptap/core';
+import type { NodeType } from '@tiptap/pm/model';
 import { render } from 'react-email';
 import { describe, expect, it, vi } from 'vitest';
 import { createImageExtension } from './extension';
@@ -9,6 +10,14 @@ describe('Image extension', () => {
   const renderToReactEmail =
     (extension.options as any).renderToReactEmail ??
     extension.config.renderToReactEmail;
+  const extensionContext = {
+    name: extension.name,
+    options: extension.options,
+    storage: extension.storage as Record<string, never>,
+    editor: {} as Editor,
+    type: {} as NodeType,
+    parent: undefined,
+  };
 
   it('renders basic image', async () => {
     const Component = () =>
@@ -57,7 +66,7 @@ describe('Image extension', () => {
   });
 
   it('defines expected attributes', () => {
-    const attrs = extension.config.addAttributes?.call(extension) ?? {};
+    const attrs = extension.config.addAttributes?.call(extensionContext) ?? {};
     expect(attrs).toHaveProperty('src');
     expect(attrs).toHaveProperty('alt');
     expect(attrs).toHaveProperty('width');
@@ -78,19 +87,14 @@ describe('Image extension', () => {
   });
 
   it('has setImage and uploadImage commands', () => {
-    const commands = extension.config.addCommands?.call(extension);
+    const commands = extension.config.addCommands?.call(extensionContext);
     expect(commands).toHaveProperty('setImage');
     expect(commands).toHaveProperty('uploadImage');
   });
 
   it('registers the image file handler plugin', () => {
-    const context = {
-      ...extension,
-      editor: {} as Editor,
-      options: extension.options,
-      storage: extension.storage,
-    };
-    const plugins = extension.config.addProseMirrorPlugins?.call(context);
+    const plugins =
+      extension.config.addProseMirrorPlugins?.call(extensionContext);
     expect(plugins).toHaveLength(1);
   });
 });

--- a/packages/editor/src/ui/bubble-menu/root.spec.tsx
+++ b/packages/editor/src/ui/bubble-menu/root.spec.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render, screen } from '@testing-library/react';
-import { EditorProvider } from '@tiptap/react';
+import { Editor } from '@tiptap/core';
+import { EditorContext, EditorProvider } from '@tiptap/react';
 import { StarterKit } from '../../extensions';
 import { BubbleMenuRoot } from './root';
 
@@ -8,12 +9,15 @@ vi.mock('@tiptap/react/menus', () => ({
     children,
     className,
     options,
+    ref,
   }: {
     children: React.ReactNode;
     className?: string;
     options?: { placement?: string; offset?: number; onHide?: () => void };
+    ref?: React.Ref<HTMLDivElement>;
   }) => (
     <div
+      ref={ref}
       data-testid="bubble-menu-root"
       data-re-bubble-menu=""
       data-placement={options?.placement}
@@ -26,6 +30,23 @@ vi.mock('@tiptap/react/menus', () => ({
 }));
 
 const extensions = [StarterKit];
+
+function waitForCreate() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createEditor() {
+  const element = document.createElement('div');
+  document.body.append(element);
+
+  const editor = new Editor({
+    element,
+    extensions: [StarterKit.configure()],
+    content: '<p>Hello world</p>',
+  });
+
+  return { editor, element };
+}
 
 function renderWithEditor(ui: React.ReactElement) {
   return render(
@@ -86,6 +107,37 @@ describe('BubbleMenuRoot', () => {
       expect(screen.getByText('custom child')).toBeDefined();
       expect(screen.queryByLabelText('bold')).toBeNull();
       expect(screen.queryByLabelText('Add link')).toBeNull();
+    });
+
+    it('keeps the editor focused when focus moves into the bubble menu', async () => {
+      const { editor, element } = createEditor();
+      await waitForCreate();
+
+      const { unmount } = render(
+        <EditorContext.Provider value={{ editor }}>
+          <BubbleMenuRoot>
+            <span>custom child</span>
+          </BubbleMenuRoot>
+        </EditorContext.Provider>,
+      );
+
+      const root = screen.getByTestId('bubble-menu-root');
+      editor.view.dom.dispatchEvent(
+        new FocusEvent('focusin', { bubbles: true }),
+      );
+      editor.view.dom.dispatchEvent(
+        new FocusEvent('focusout', {
+          bubbles: true,
+          relatedTarget: root,
+        }),
+      );
+      root.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+      expect(editor.isFocused).toBe(true);
+
+      unmount();
+      editor.destroy();
+      element.remove();
     });
 
     it('forwards placement and offset to the BubbleMenu', () => {

--- a/packages/editor/src/ui/bubble-menu/root.tsx
+++ b/packages/editor/src/ui/bubble-menu/root.tsx
@@ -2,6 +2,7 @@ import { PluginKey } from '@tiptap/pm/state';
 import { useCurrentEditor } from '@tiptap/react';
 import { BubbleMenu } from '@tiptap/react/menus';
 import * as React from 'react';
+import { EditorFocusScope } from '../editor-focus-scope';
 import { BubbleMenuAlignCenter } from './align-center';
 import { BubbleMenuAlignLeft } from './align-left';
 import { BubbleMenuAlignRight } from './align-right';
@@ -54,26 +55,28 @@ function Root({
   }
 
   return (
-    <BubbleMenu
-      editor={editor}
-      pluginKey={pluginKey}
-      data-re-bubble-menu=""
-      shouldShow={resolvedTrigger}
-      options={{
-        placement,
-        offset,
-        onHide: () => {
-          setIsEditing(false);
-          onHide?.();
-        },
-      }}
-      className={className}
-      {...rest}
-    >
-      <BubbleMenuContext.Provider value={{ editor, isEditing, setIsEditing }}>
-        {children}
-      </BubbleMenuContext.Provider>
-    </BubbleMenu>
+    <EditorFocusScope>
+      <BubbleMenu
+        editor={editor}
+        pluginKey={pluginKey}
+        data-re-bubble-menu=""
+        shouldShow={resolvedTrigger}
+        options={{
+          placement,
+          offset,
+          onHide: () => {
+            setIsEditing(false);
+            onHide?.();
+          },
+        }}
+        className={className}
+        {...rest}
+      >
+        <BubbleMenuContext.Provider value={{ editor, isEditing, setIsEditing }}>
+          {children}
+        </BubbleMenuContext.Provider>
+      </BubbleMenu>
+    </EditorFocusScope>
   );
 }
 

--- a/packages/editor/src/ui/editor-focus-scope.spec.tsx
+++ b/packages/editor/src/ui/editor-focus-scope.spec.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import { EditorContext } from '@tiptap/react';
+import {
+  EditorFocusScope,
+  EditorFocusScopeProvider,
+  useEditorFocusScope,
+} from './editor-focus-scope';
+
+describe('EditorFocusScope', () => {
+  it('renders children without a provider', () => {
+    render(
+      <EditorFocusScope>
+        <button type="button">Scoped action</button>
+      </EditorFocusScope>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Scoped action' })).toBeDefined();
+  });
+
+  it('registers and unregisters children with extension storage', () => {
+    const registerScope = vi.fn();
+    const unregisterScope = vi.fn();
+    const editor = {
+      extensionStorage: {
+        focusScope: {
+          registerScope,
+          unregisterScope,
+        },
+      },
+    };
+
+    const { unmount } = render(
+      <EditorContext.Provider value={{ editor: editor as any }}>
+        <EditorFocusScope>
+          <button type="button">Scoped action</button>
+        </EditorFocusScope>
+      </EditorContext.Provider>,
+    );
+
+    const button = screen.getByRole('button', { name: 'Scoped action' });
+    expect(registerScope).toHaveBeenCalledWith(button);
+
+    unmount();
+    expect(unregisterScope).toHaveBeenCalledWith(button);
+  });
+});
+
+describe('EditorFocusScopeProvider', () => {
+  it('is a no-op compatibility wrapper', () => {
+    render(
+      <EditorFocusScopeProvider clearSelectionOnBlur={false}>
+        <button type="button">Inside provider</button>
+      </EditorFocusScopeProvider>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Inside provider' }),
+    ).toBeDefined();
+  });
+});
+
+describe('useEditorFocusScope', () => {
+  it('returns the extension storage registration functions', () => {
+    const registerScope = vi.fn();
+    const unregisterScope = vi.fn();
+    const editor = {
+      extensionStorage: {
+        focusScope: {
+          registerScope,
+          unregisterScope,
+        },
+      },
+    };
+
+    function Probe() {
+      const focusScope = useEditorFocusScope();
+      focusScope.registerScope(null);
+      focusScope.unregisterScope(null);
+      return null;
+    }
+
+    render(
+      <EditorContext.Provider value={{ editor: editor as any }}>
+        <Probe />
+      </EditorContext.Provider>,
+    );
+
+    expect(registerScope).toHaveBeenCalledWith(null);
+    expect(unregisterScope).toHaveBeenCalledWith(null);
+  });
+});

--- a/packages/editor/src/ui/editor-focus-scope.spec.tsx
+++ b/packages/editor/src/ui/editor-focus-scope.spec.tsx
@@ -1,10 +1,16 @@
 import { render, screen } from '@testing-library/react';
+import { Editor } from '@tiptap/core';
 import { EditorContext } from '@tiptap/react';
+import TipTapStarterKit from '@tiptap/starter-kit';
 import {
   EditorFocusScope,
   EditorFocusScopeProvider,
   useEditorFocusScope,
 } from './editor-focus-scope';
+
+function waitForCreate() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 describe('EditorFocusScope', () => {
   it('renders children without a provider', () => {
@@ -46,7 +52,7 @@ describe('EditorFocusScope', () => {
 });
 
 describe('EditorFocusScopeProvider', () => {
-  it('is a no-op compatibility wrapper', () => {
+  it('renders children', () => {
     render(
       <EditorFocusScopeProvider clearSelectionOnBlur={false}>
         <button type="button">Inside provider</button>
@@ -56,6 +62,42 @@ describe('EditorFocusScopeProvider', () => {
     expect(
       screen.getByRole('button', { name: 'Inside provider' }),
     ).toBeDefined();
+  });
+
+  it('installs focus scope tracking when the editor does not use StarterKit', async () => {
+    const element = document.createElement('div');
+    document.body.append(element);
+    const editor = new Editor({
+      element,
+      extensions: [TipTapStarterKit],
+      content: '<p>Hello world</p>',
+    });
+    await waitForCreate();
+
+    render(
+      <EditorContext.Provider value={{ editor }}>
+        <EditorFocusScopeProvider>
+          <EditorFocusScope>
+            <button type="button">Scoped action</button>
+          </EditorFocusScope>
+        </EditorFocusScopeProvider>
+      </EditorContext.Provider>,
+    );
+
+    const button = screen.getByRole('button', { name: 'Scoped action' });
+    editor.view.dom.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    editor.view.dom.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: true,
+        relatedTarget: button,
+      }),
+    );
+    button.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    expect(editor.isFocused).toBe(true);
+
+    editor.destroy();
+    element.remove();
   });
 });
 

--- a/packages/editor/src/ui/editor-focus-scope.tsx
+++ b/packages/editor/src/ui/editor-focus-scope.tsx
@@ -1,7 +1,13 @@
 import { Slot } from '@radix-ui/react-slot';
+import { extensions as nativeTiptapExtensions } from '@tiptap/core';
 import { useCurrentEditor } from '@tiptap/react';
 import * as React from 'react';
-import type { FocusScopesStorage } from '../extensions/focus-scopes';
+import {
+  createFocusScopePlugin,
+  createFocusScopesStorage,
+  type FocusScopesStorage,
+  focusScopePluginKey,
+} from '../extensions/focus-scopes';
 
 type FocusScopeContextValue = FocusScopesStorage;
 
@@ -14,8 +20,9 @@ const noopFocusScope: FocusScopeContextValue = {
 };
 
 export function useEditorFocusScope() {
+  const context = React.useContext(FocusScopeContext);
   const { editor } = useCurrentEditor();
-  return editor?.extensionStorage?.focusScope ?? noopFocusScope;
+  return context ?? editor?.extensionStorage?.focusScope ?? noopFocusScope;
 }
 
 export interface EditorFocusScopeProviderProps {
@@ -25,12 +32,67 @@ export interface EditorFocusScopeProviderProps {
 
 /**
  * @deprecated Focus scope tracking now lives in the FocusScopes extension,
- * included by default through StarterKit. This component is kept as a no-op
- * compatibility wrapper.
+ * included by default through StarterKit. This component is kept as a
+ * compatibility wrapper for editors that do not use StarterKit.
  */
 export function EditorFocusScopeProvider({
   children,
+  clearSelectionOnBlur = true,
 }: EditorFocusScopeProviderProps) {
+  const { editor } = useCurrentEditor();
+  const [fallbackFocusScope, setFallbackFocusScope] =
+    React.useState<FocusScopeContextValue | null>(null);
+
+  React.useLayoutEffect(() => {
+    if (!editor) return;
+
+    const hasFocusScopePlugin = editor.state.plugins.some(
+      (plugin) => plugin.spec.key === focusScopePluginKey,
+    );
+    if (hasFocusScopePlugin) {
+      setFallbackFocusScope(editor.extensionStorage.focusScope ?? null);
+      return;
+    }
+
+    const defaultFocusPlugin = editor.state.plugins.find(
+      (plugin) =>
+        plugin.spec.key === nativeTiptapExtensions.focusEventsPluginKey,
+    );
+    if (defaultFocusPlugin) {
+      editor.unregisterPlugin(nativeTiptapExtensions.focusEventsPluginKey);
+    }
+
+    const storage =
+      editor.extensionStorage.focusScope ?? createFocusScopesStorage();
+    editor.extensionStorage.focusScope = storage;
+    editor.registerPlugin(
+      createFocusScopePlugin({
+        editor,
+        storage,
+        clearSelectionOnBlur,
+      }),
+    );
+    setFallbackFocusScope(storage);
+
+    return () => {
+      editor.unregisterPlugin(focusScopePluginKey);
+      if (!editor.isDestroyed && defaultFocusPlugin) {
+        editor.registerPlugin(defaultFocusPlugin);
+      }
+    };
+  }, [editor, clearSelectionOnBlur]);
+
+  const focusScope =
+    fallbackFocusScope ?? editor?.extensionStorage?.focusScope ?? null;
+
+  if (focusScope) {
+    return (
+      <FocusScopeContext.Provider value={focusScope}>
+        {children}
+      </FocusScopeContext.Provider>
+    );
+  }
+
   return <>{children}</>;
 }
 
@@ -39,8 +101,9 @@ export interface EditorFocusScopeProps {
 }
 
 export function EditorFocusScope({ children }: EditorFocusScopeProps) {
+  const context = React.useContext(FocusScopeContext);
   const { editor } = useCurrentEditor();
-  const focusScope = editor?.extensionStorage?.focusScope;
+  const focusScope = context ?? editor?.extensionStorage?.focusScope;
 
   if (!focusScope) {
     return <>{children}</>;

--- a/packages/editor/src/ui/editor-focus-scope.tsx
+++ b/packages/editor/src/ui/editor-focus-scope.tsx
@@ -83,17 +83,15 @@ export function EditorFocusScopeProvider({
   }, [editor, clearSelectionOnBlur]);
 
   const focusScope =
-    fallbackFocusScope ?? editor?.extensionStorage?.focusScope ?? null;
+    fallbackFocusScope ??
+    editor?.extensionStorage?.focusScope ??
+    noopFocusScope;
 
-  if (focusScope) {
-    return (
-      <FocusScopeContext.Provider value={focusScope}>
-        {children}
-      </FocusScopeContext.Provider>
-    );
-  }
-
-  return <>{children}</>;
+  return (
+    <FocusScopeContext.Provider value={focusScope}>
+      {children}
+    </FocusScopeContext.Provider>
+  );
 }
 
 export interface EditorFocusScopeProps {

--- a/packages/editor/src/ui/editor-focus-scope.tsx
+++ b/packages/editor/src/ui/editor-focus-scope.tsx
@@ -1,27 +1,21 @@
 import { Slot } from '@radix-ui/react-slot';
-import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
-import {
-  extensions as nativeTiptapExtensions,
-  useCurrentEditor,
-} from '@tiptap/react';
+import { useCurrentEditor } from '@tiptap/react';
 import * as React from 'react';
+import type { FocusScopesStorage } from '../extensions/focus-scopes';
 
-interface FocusScopeContextValue {
-  registerScope: (el: HTMLElement | null) => void;
-  unregisterScope: (el: HTMLElement | null) => void;
-}
+type FocusScopeContextValue = FocusScopesStorage;
 
 export const FocusScopeContext =
   React.createContext<FocusScopeContextValue | null>(null);
 
+const noopFocusScope: FocusScopeContextValue = {
+  registerScope: () => {},
+  unregisterScope: () => {},
+};
+
 export function useEditorFocusScope() {
-  const context = React.useContext(FocusScopeContext);
-  if (!context) {
-    throw new Error(
-      'InspectorFocusScope must be used inside an InspectorFocusScopeProvider',
-    );
-  }
-  return context;
+  const { editor } = useCurrentEditor();
+  return editor?.extensionStorage?.focusScope ?? noopFocusScope;
 }
 
 export interface EditorFocusScopeProviderProps {
@@ -29,116 +23,15 @@ export interface EditorFocusScopeProviderProps {
   clearSelectionOnBlur?: boolean;
 }
 
+/**
+ * @deprecated Focus scope tracking now lives in the FocusScopes extension,
+ * included by default through StarterKit. This component is kept as a no-op
+ * compatibility wrapper.
+ */
 export function EditorFocusScopeProvider({
   children,
-  clearSelectionOnBlur = true,
 }: EditorFocusScopeProviderProps) {
-  const { editor } = useCurrentEditor();
-
-  const scopeRefs = React.useRef(new Set<HTMLElement>());
-
-  const handleFocusIn = React.useCallback(
-    (event: FocusEvent) => {
-      if (!editor) return;
-      const t = event.target;
-      if (!(t instanceof Node) || !editor.view.dom.contains(t)) {
-        return;
-      }
-
-      editor.isFocused = true;
-
-      const transaction = editor.state.tr
-        .setMeta('focus', { event })
-        .setMeta('addToHistory', false);
-
-      editor.view.dispatch(transaction);
-    },
-    [editor],
-  );
-
-  const handleFocusOut = React.useCallback(
-    (event: FocusEvent) => {
-      const nextFocus = event.relatedTarget as Node | null;
-      const stillInside = [...scopeRefs.current].some(
-        (el) => nextFocus && el.contains(nextFocus),
-      );
-      if (!stillInside && editor) {
-        editor.isFocused = false;
-
-        const transaction = editor.state.tr
-          .setMeta('blur', { event })
-          .setMeta('addToHistory', false);
-
-        if (clearSelectionOnBlur) {
-          transaction.setSelection(TextSelection.create(transaction.doc, 0));
-        }
-
-        editor.view.dispatch(transaction);
-      }
-    },
-    [editor, clearSelectionOnBlur],
-  );
-
-  const registerScope = React.useCallback(
-    (el: HTMLElement | null) => {
-      if (!el) return;
-      scopeRefs.current.add(el);
-      el.addEventListener('focusin', handleFocusIn);
-      el.addEventListener('focusout', handleFocusOut);
-    },
-    [handleFocusIn, handleFocusOut],
-  );
-
-  const unregisterScope = React.useCallback(
-    (el: HTMLElement | null) => {
-      if (!el) return;
-      scopeRefs.current.delete(el);
-      el.removeEventListener('focusin', handleFocusIn);
-      el.removeEventListener('focusout', handleFocusOut);
-    },
-    [handleFocusIn, handleFocusOut],
-  );
-
-  React.useEffect(() => {
-    const defaultFocusPlugin = editor?.state.plugins.find(
-      (plugin) =>
-        plugin.spec.key === nativeTiptapExtensions.focusEventsPluginKey,
-    );
-    if (editor && defaultFocusPlugin) {
-      editor.unregisterPlugin(nativeTiptapExtensions.focusEventsPluginKey);
-      const pluginKey = new PluginKey('inspectorReactEmailFocusEvents');
-      editor.registerPlugin(
-        new Plugin({
-          key: pluginKey,
-          view(view) {
-            registerScope(view.dom);
-
-            return {
-              destroy() {
-                unregisterScope(view.dom);
-              },
-            };
-          },
-        }),
-      );
-
-      return () => {
-        editor?.unregisterPlugin(pluginKey);
-        editor?.registerPlugin(defaultFocusPlugin);
-      };
-    }
-  }, [editor]);
-
-  return (
-    <FocusScopeContext.Provider
-      value={{
-        registerScope,
-        unregisterScope,
-      }}
-    >
-      {children}
-    </FocusScopeContext.Provider>
-  );
+  return <>{children}</>;
 }
 
 export interface EditorFocusScopeProps {
@@ -146,17 +39,22 @@ export interface EditorFocusScopeProps {
 }
 
 export function EditorFocusScope({ children }: EditorFocusScopeProps) {
-  const { registerScope, unregisterScope } = useEditorFocusScope();
+  const { editor } = useCurrentEditor();
+  const focusScope = editor?.extensionStorage?.focusScope;
+
+  if (!focusScope) {
+    return <>{children}</>;
+  }
 
   return (
     <Slot
       ref={(element) => {
-        if (element) {
-          registerScope(element);
-          return () => {
-            unregisterScope(element);
-          };
-        }
+        if (!element) return;
+
+        focusScope.registerScope(element);
+        return () => {
+          focusScope.unregisterScope(element);
+        };
       }}
     >
       {children}

--- a/packages/editor/src/ui/inspector/root.spec.tsx
+++ b/packages/editor/src/ui/inspector/root.spec.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import { Editor } from '@tiptap/core';
+import { EditorContext } from '@tiptap/react';
+import TipTapStarterKit from '@tiptap/starter-kit';
+import { afterEach, describe, expect, it } from 'vitest';
+import { StarterKit } from '../../extensions';
+import { focusScopePluginKey } from '../../extensions/focus-scopes';
+import { EmailTheming } from '../../plugins';
+import { EditorFocusScopeProvider } from '../editor-focus-scope';
+import { InspectorRoot } from './root';
+
+let editor: Editor | null = null;
+let element: HTMLElement | null = null;
+
+function createEditor(extensions: Parameters<typeof Editor>[0]['extensions']) {
+  element = document.createElement('div');
+  document.body.append(element);
+
+  editor = new Editor({
+    element,
+    extensions,
+    content: '<p>Hello world</p>',
+  });
+
+  return editor;
+}
+
+function countFocusScopePlugins(editor: Editor) {
+  return editor.state.plugins.filter(
+    (plugin) => plugin.spec.key === focusScopePluginKey,
+  ).length;
+}
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+  element?.remove();
+  element = null;
+});
+
+describe('InspectorRoot focus scope compatibility', () => {
+  it('installs focus scope tracking when the editor does not use StarterKit', () => {
+    const editor = createEditor([TipTapStarterKit, EmailTheming]);
+
+    render(
+      <EditorContext.Provider value={{ editor }}>
+        <InspectorRoot data-testid="inspector">Inspector</InspectorRoot>
+      </EditorContext.Provider>,
+    );
+
+    const inspector = screen.getByTestId('inspector');
+    editor.view.dom.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    editor.view.dom.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: true,
+        relatedTarget: inspector,
+      }),
+    );
+    inspector.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    expect(countFocusScopePlugins(editor)).toBe(1);
+    expect(editor.isFocused).toBe(true);
+  });
+
+  it('does not duplicate focus scope tracking when StarterKit already provides it', () => {
+    const editor = createEditor([StarterKit.configure(), EmailTheming]);
+    expect(countFocusScopePlugins(editor)).toBe(1);
+
+    const { unmount } = render(
+      <EditorContext.Provider value={{ editor }}>
+        <InspectorRoot data-testid="inspector">Inspector</InspectorRoot>
+      </EditorContext.Provider>,
+    );
+
+    expect(countFocusScopePlugins(editor)).toBe(1);
+
+    unmount();
+    expect(countFocusScopePlugins(editor)).toBe(1);
+  });
+
+  it('does not duplicate focus scope tracking with an ancestor provider', () => {
+    const editor = createEditor([TipTapStarterKit, EmailTheming]);
+
+    render(
+      <EditorContext.Provider value={{ editor }}>
+        <EditorFocusScopeProvider>
+          <InspectorRoot data-testid="inspector">Inspector</InspectorRoot>
+        </EditorFocusScopeProvider>
+      </EditorContext.Provider>,
+    );
+
+    expect(countFocusScopePlugins(editor)).toBe(1);
+  });
+});

--- a/packages/editor/src/ui/inspector/root.tsx
+++ b/packages/editor/src/ui/inspector/root.tsx
@@ -4,11 +4,7 @@ import { NodeSelection, TextSelection } from '@tiptap/pm/state';
 import { useCurrentEditor, useEditorState } from '@tiptap/react';
 import * as React from 'react';
 import type { NodeClickedEvent } from '../../core';
-import {
-  EditorFocusScope,
-  EditorFocusScopeProvider,
-  FocusScopeContext,
-} from '../editor-focus-scope';
+import { EditorFocusScope } from '../editor-focus-scope';
 
 const IGNORED_NODES = ['doc', 'text'];
 
@@ -170,7 +166,6 @@ export function useInspector() {
 export const InspectorRoot = React.forwardRef<HTMLElement, RootProps>(
   function InspectorRoot({ children, asChild, ...restProps }, forwardedRef) {
     const { editor } = useCurrentEditor();
-    const existingFocusScope = React.useContext(FocusScopeContext);
 
     if (editor) {
       const hasEmailTheming = editor.extensionManager.extensions.some(
@@ -256,13 +251,7 @@ export const InspectorRoot = React.forwardRef<HTMLElement, RootProps>(
 
     return (
       <InspectorContext.Provider value={contextValue}>
-        {existingFocusScope ? (
-          inspectorContent
-        ) : (
-          <EditorFocusScopeProvider>
-            {inspectorContent}
-          </EditorFocusScopeProvider>
-        )}
+        {inspectorContent}
       </InspectorContext.Provider>
     );
   },

--- a/packages/editor/src/ui/inspector/root.tsx
+++ b/packages/editor/src/ui/inspector/root.tsx
@@ -4,7 +4,11 @@ import { NodeSelection, TextSelection } from '@tiptap/pm/state';
 import { useCurrentEditor, useEditorState } from '@tiptap/react';
 import * as React from 'react';
 import type { NodeClickedEvent } from '../../core';
-import { EditorFocusScope } from '../editor-focus-scope';
+import {
+  EditorFocusScope,
+  EditorFocusScopeProvider,
+  FocusScopeContext,
+} from '../editor-focus-scope';
 
 const IGNORED_NODES = ['doc', 'text'];
 
@@ -166,6 +170,7 @@ export function useInspector() {
 export const InspectorRoot = React.forwardRef<HTMLElement, RootProps>(
   function InspectorRoot({ children, asChild, ...restProps }, forwardedRef) {
     const { editor } = useCurrentEditor();
+    const existingFocusScope = React.useContext(FocusScopeContext);
 
     if (editor) {
       const hasEmailTheming = editor.extensionManager.extensions.some(
@@ -251,7 +256,13 @@ export const InspectorRoot = React.forwardRef<HTMLElement, RootProps>(
 
     return (
       <InspectorContext.Provider value={contextValue}>
-        {inspectorContent}
+        {existingFocusScope ? (
+          inspectorContent
+        ) : (
+          <EditorFocusScopeProvider>
+            {inspectorContent}
+          </EditorFocusScopeProvider>
+        )}
       </InspectorContext.Provider>
     );
   },

--- a/packages/editor/src/ui/slash-command/root.tsx
+++ b/packages/editor/src/ui/slash-command/root.tsx
@@ -17,6 +17,7 @@ import {
   useState,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { EditorFocusScope } from '../editor-focus-scope';
 import { CommandList } from './command-list';
 import { defaultSlashCommands } from './commands';
 import { filterAndRankItems } from './search';
@@ -203,9 +204,11 @@ export function SlashCommandRoot({
   }
 
   return createPortal(
-    <div ref={refs.setFloating} style={floatingStyles}>
-      {content}
-    </div>,
+    <EditorFocusScope>
+      <div ref={refs.setFloating} style={floatingStyles}>
+        {content}
+      </div>
+    </EditorFocusScope>,
     document.body,
   );
 }

--- a/packages/editor/vitest.config.ts
+++ b/packages/editor/vitest.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
       },
       {
         extends: true,
-        plugins: [react()],
+        plugins: [react({})],
         resolve: {
           alias: {
             '@react-email/render': renderStub,


### PR DESCRIPTION
## Summary
- Move editor focus scope tracking into a StarterKit extension while keeping the deprecated provider as a compatibility installer.
- Register bubble menus, slash commands, and inspector surfaces with focus scopes so selection/focus survives portaled UI interactions.
- Ignore focusout of elements in focus scopes that are removed from the DOM (thus triggering focusout to the body)
- Add focused tests for focus scope behavior, inspector padding interactions, and related type fixes.

## Test plan
- pnpm --filter @react-email/editor test:browser -- inspector-padding.browser.spec.tsx
- pnpm --filter @react-email/editor test:unit -- focus-scopes.spec.ts editor-focus-scope.spec.tsx
- pnpm --filter @react-email/editor typecheck


Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves editor focus tracking into a new `FocusScopes` extension (included in `StarterKit`) and wraps bubble menus and slash commands with `EditorFocusScope` to keep focus/selection across portaled UI. Deprecates `EditorFocusScopeProvider` and installs a fallback only when `StarterKit` isn’t used, avoiding duplicate plugins.

- **New Features**
  - Added `FocusScopes` in `@react-email/editor/extensions`; replaces Tiptap focus events and ships in `StarterKit`.
  - `EditorFocusScope` registers with extension storage; built-in bubble menus, slash commands, and `Inspector.Root` are scope-aware.
  - Provider remains as a fallback for non-`StarterKit` editors.

- **Bug Fixes**
  - Preserves focus moving into menus/inspector controls, across remounts, and for per-side padding.
  - Blurs only on true outside focus; handles `focusout` with no `relatedTarget` and deletion of focused elements.
  - Adds tests for backwards compatibility and prevents installing duplicate focus-scope plugins.

<sup>Written for commit f4bf14f23bfeac464a967b3b02abcf6e9b226213. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3431?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



