### PR TITLE
chore(ci): only set `react-email` as the latest

### DIFF
--- a/scripts/release.mts
+++ b/scripts/release.mts
@@ -90,16 +90,17 @@ const createRelease = async ({
       `Could not find changelog entry for ${pkg.packageJson.name}@${pkg.packageJson.version}`,
     );
   }
+  const isPrerelease = pkg.packageJson.version.includes('-');
+  const shouldMarkAsLatest =
+    pkg.packageJson.name === LATEST_GITHUB_RELEASE_PACKAGE_NAME &&
+    !isPrerelease;
 
   await octokit.rest.repos.createRelease({
     name: tagName,
     tag_name: tagName,
     body: changelogEntry.content,
-    prerelease: pkg.packageJson.version.includes('-'),
-    make_latest:
-      pkg.packageJson.name === LATEST_GITHUB_RELEASE_PACKAGE_NAME
-        ? 'true'
-        : 'false',
+    prerelease: isPrerelease,
+    make_latest: shouldMarkAsLatest ? 'true' : 'false',
     ...github.context.repo,
   });
 };

--- a/scripts/release.mts
+++ b/scripts/release.mts
@@ -13,6 +13,7 @@ import { remark } from 'remark';
 const octokit = github.getOctokit(process.env.GITHUB_TOKEN || '');
 
 const processor = remark();
+const LATEST_GITHUB_RELEASE_PACKAGE_NAME = 'react-email';
 
 export const BumpLevels = {
   dep: 0,
@@ -95,6 +96,10 @@ const createRelease = async ({
     tag_name: tagName,
     body: changelogEntry.content,
     prerelease: pkg.packageJson.version.includes('-'),
+    make_latest:
+      pkg.packageJson.name === LATEST_GITHUB_RELEASE_PACKAGE_NAME
+        ? 'true'
+        : 'false',
     ...github.context.repo,
   });
 };


### PR DESCRIPTION
Since the main package, and the flagship package for React Email is `react-email` which includes both the CLI and all of our primitive components we should always only keep it as the latest GitHub Release. This means that it's the one that shows up in the Releases section on the right of the repository's home

<img width="580" height="1198" alt="image" src="https://github.com/user-attachments/assets/5ce2d23b-0b64-4195-b20b-141935d0a744" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI release script to mark only non-prerelease `react-email` releases as Latest. All other packages and any prerelease versions are not marked Latest to keep the Releases sidebar focused on the flagship package.

<sup>Written for commit 0e5ba8a1e17716f3f180e0eb4ab575ba30d13e70. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3435?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

