### PR TITLE
fix(react-email): missing react peer dependencies

### DIFF
--- a/.changeset/two-crabs-design.md
+++ b/.changeset/two-crabs-design.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+fix missing react and react-dom peer dependencies

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -39,6 +39,10 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "peerDependencies": {
+    "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+  },
   "dependencies": {
     "@babel/parser": "catalog:",
     "@babel/traverse": "catalog:",


### PR DESCRIPTION
closes #3438

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare `react` and `react-dom` as peer dependencies in `react-email` to fix missing peers and prevent React duplication or warnings. Supports React 18 and 19 (including 19 RC).

<sup>Written for commit d05680a42a01a646c499c497d0fb5cd1d1797f7f. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3439?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

