### PR TITLE
chore(react-email): unpin esbuild

### DIFF
--- a/.changeset/evil-kings-attack.md
+++ b/.changeset/evil-kings-attack.md
@@ -1,0 +1,6 @@
+---
+"react-email": patch
+"@react-email/ui": patch
+---
+
+unpin esbuild

--- a/.changeset/evil-kings-attack.md
+++ b/.changeset/evil-kings-attack.md
@@ -1,6 +1,5 @@
 ---
 "react-email": patch
-"@react-email/ui": patch
 ---
 
 unpin esbuild

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -52,7 +52,7 @@
     "conf": "^15.0.2",
     "css-tree": "3.2.1",
     "debounce": "^2.0.0",
-    "esbuild": "catalog:",
+    "esbuild": "^0.28.0",
     "glob": "^13.0.6",
     "jiti": "2.4.2",
     "log-symbols": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ catalogs:
       specifier: ^13.0.0
       version: 13.1.0
     esbuild:
-      specifier: ^0.28.0
+      specifier: 0.28.0
       version: 0.28.0
     framer-motion:
       specifier: 12.38.0
@@ -664,7 +664,7 @@ importers:
         specifier: ^2.0.0
         version: 2.2.0
       esbuild:
-        specifier: 'catalog:'
+        specifier: ^0.28.0
         version: 0.28.0
       glob:
         specifier: ^13.0.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ catalogs:
       specifier: ^13.0.0
       version: 13.1.0
     esbuild:
-      specifier: 0.28.0
+      specifier: ^0.28.0
       version: 0.28.0
     framer-motion:
       specifier: 12.38.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalog:
   '@types/react-dom': 19.2.3
   '@vitejs/plugin-react': 5.2.0
   commander: ^13.0.0
-  esbuild: ^0.28.0
+  esbuild: 0.28.0
   framer-motion: 12.38.0
   log-symbols: ^7.0.0
   next: 16.2.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalog:
   '@types/react-dom': 19.2.3
   '@vitejs/plugin-react': 5.2.0
   commander: ^13.0.0
-  esbuild: 0.28.0
+  esbuild: ^0.28.0
   framer-motion: 12.38.0
   log-symbols: ^7.0.0
   next: 16.2.3


### PR DESCRIPTION
https://github.com/resend/react-email/discussions/3407

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unpinned `esbuild` for `react-email` to allow minor and patch updates. `@react-email/ui` stays pinned; only `react-email` will ship a patch release.

- **Dependencies**
  - Set `esbuild` to `^0.28.0` in `react-email` and updated the lockfile; updates limited to 0.28.x.

<sup>Written for commit 15ebd94f87f33fe0d27544c8018c7fddc7856da8. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3441?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

