### PR TITLE
feat(react-email): replace ora with picospinner

### DIFF
--- a/.changeset/dry-brooms-deliver.md
+++ b/.changeset/dry-brooms-deliver.md
@@ -1,0 +1,6 @@
+---
+"@react-email/ui": patch
+"react-email": patch
+---
+
+Replace ora with picospinner for CLI and preview spinner output.

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -60,7 +60,7 @@
     "mime-types": "^3.0.0",
     "normalize-path": "^3.0.0",
     "nypm": "catalog:",
-    "ora": "catalog:",
+    "picospinner": "catalog:",
     "prismjs": "^1.30.0",
     "prompts": "2.4.2",
     "socket.io": "^4.8.1",

--- a/packages/react-email/src/cli/commands/build.ts
+++ b/packages/react-email/src/cli/commands/build.ts
@@ -4,13 +4,13 @@ import { fileURLToPath } from 'node:url';
 import { getPackages } from '@manypkg/get-packages';
 import logSymbols from 'log-symbols';
 import { installDependencies, type PackageManagerName, runScript } from 'nypm';
-import ora from 'ora';
 import {
   type EmailsDirectory,
   getEmailsDirectoryMetadata,
 } from '../utils/get-emails-directory-metadata.js';
 import { getUiLocation } from '../utils/get-ui-location.js';
 import { registerSpinnerAutostopping } from '../utils/register-spinner-autostopping.js';
+import { createSpinner, stopSpinnerAndPersist } from '../utils/spinner.js';
 
 interface Args {
   dir: string;
@@ -178,13 +178,14 @@ export const build = async ({
     const usersProjectLocation = process.cwd();
     const previewServerLocation = await getUiLocation();
 
-    const spinner = ora({
+    const spinner = createSpinner({
       text: 'Starting build process...',
       prefixText: '  ',
-    }).start();
+    });
+    spinner.start();
     registerSpinnerAutostopping(spinner);
 
-    spinner.text = `Checking if ${emailsDirRelativePath} folder exists`;
+    spinner.setText(`Checking if ${emailsDirRelativePath} folder exists`);
     if (!fs.existsSync(emailsDirRelativePath)) {
       process.exit(1);
     }
@@ -198,11 +199,11 @@ export const build = async ({
     const builtPreviewAppPath = path.join(usersProjectLocation, '.react-email');
 
     if (fs.existsSync(builtPreviewAppPath)) {
-      spinner.text = 'Deleting pre-existing `.react-email` folder';
+      spinner.setText('Deleting pre-existing `.react-email` folder');
       await fs.promises.rm(builtPreviewAppPath, { recursive: true });
     }
 
-    spinner.text = 'Copying preview app from CLI to `.react-email`';
+    spinner.setText('Copying preview app from CLI to `.react-email`');
     await fs.promises.cp(previewServerLocation, builtPreviewAppPath, {
       recursive: true,
       filter: (source: string) => {
@@ -216,8 +217,9 @@ export const build = async ({
     });
 
     if (fs.existsSync(staticPath)) {
-      spinner.text =
-        'Copying `static` folder into `.react-email/public/static`';
+      spinner.setText(
+        'Copying `static` folder into `.react-email/public/static`',
+      );
       const builtStaticDirectory = path.resolve(
         builtPreviewAppPath,
         './public/static',
@@ -227,22 +229,25 @@ export const build = async ({
       });
     }
 
-    spinner.text =
-      'Setting Next environment variables for preview app to work properly';
+    spinner.setText(
+      'Setting Next environment variables for preview app to work properly',
+    );
     await setNextEnvironmentVariablesForBuild(
       emailsDirRelativePath,
       builtPreviewAppPath,
       usersProjectLocation,
     );
 
-    spinner.text = 'Setting server side generation for the email preview pages';
+    spinner.setText(
+      'Setting server side generation for the email preview pages',
+    );
     await forceSSGForEmailPreviews(emailsDirPath, builtPreviewAppPath);
 
-    spinner.text = "Updating package.json's build and start scripts";
+    spinner.setText("Updating package.json's build and start scripts");
     await updatePackageJson(builtPreviewAppPath);
 
     if (!isInReactEmailMonorepo) {
-      spinner.text = 'Installing dependencies on `.react-email`';
+      spinner.setText('Installing dependencies on `.react-email`');
       await installDependencies({
         cwd: builtPreviewAppPath,
         silent: true,
@@ -250,7 +255,7 @@ export const build = async ({
       });
     }
 
-    spinner.stopAndPersist({
+    stopSpinnerAndPersist(spinner, {
       text: 'Successfully prepared `.react-email` for `next build`',
       symbol: logSymbols.success,
     });

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -7,7 +7,6 @@ import { type BuildFailure, build } from 'esbuild';
 import { glob } from 'glob';
 import logSymbols from 'log-symbols';
 import normalize from 'normalize-path';
-import ora, { type Ora } from 'ora';
 import type React from 'react';
 import { renderingUtilitiesExporter } from '../utils/esbuild/renderring-utilities-exporter.js';
 import {
@@ -16,6 +15,11 @@ import {
 } from '../utils/get-emails-directory-metadata.js';
 import { tree } from '../utils/index.js';
 import { registerSpinnerAutostopping } from '../utils/register-spinner-autostopping.js';
+import {
+  createSpinner,
+  type Spinner,
+  stopSpinnerAndPersist,
+} from '../utils/spinner.js';
 
 const getEmailTemplatesFromDirectory = (emailDirectory: EmailsDirectory) => {
   const templatePaths = [] as string[];
@@ -48,9 +52,10 @@ export const exportTemplates = async (
   emailsDirectoryPath: string,
   options: ExportTemplatesOptions,
 ) => {
-  let spinner: Ora | undefined;
+  let spinner: Spinner | undefined;
   if (!options.silent) {
-    spinner = ora('Preparing files...\n').start();
+    spinner = createSpinner('Preparing files...\n');
+    spinner.start();
     registerSpinnerAutostopping(spinner);
   }
 
@@ -61,7 +66,7 @@ export const exportTemplates = async (
 
   if (typeof emailsDirectoryMetadata === 'undefined') {
     if (spinner) {
-      spinner.stopAndPersist({
+      stopSpinnerAndPersist(spinner, {
         symbol: logSymbols.error,
         text: `Could not find the directory at ${emailsDirectoryPath}`,
       });
@@ -94,7 +99,7 @@ export const exportTemplates = async (
     });
   } catch (exception) {
     if (spinner) {
-      spinner.stopAndPersist({
+      stopSpinnerAndPersist(spinner, {
         symbol: logSymbols.error,
         text: 'Failed to build emails',
       });
@@ -117,11 +122,15 @@ export const exportTemplates = async (
     },
   );
 
+  if (spinner && allBuiltTemplates.length > 0) {
+    spinner.setText(`rendering ${allBuiltTemplates[0]?.split('/').pop()}`);
+    spinner.start();
+  }
+
   for await (const template of allBuiltTemplates) {
     try {
       if (spinner) {
-        spinner.text = `rendering ${template.split('/').pop()}`;
-        spinner.render();
+        spinner.setText(`rendering ${template.split('/').pop()}`);
       }
       delete require.cache[template];
       const emailModule = require(template) as {
@@ -144,7 +153,7 @@ export const exportTemplates = async (
       unlinkSync(template);
     } catch (exception) {
       if (spinner) {
-        spinner.stopAndPersist({
+        stopSpinnerAndPersist(spinner, {
           symbol: logSymbols.error,
           text: `failed when rendering ${template.split('/').pop()}`,
         });
@@ -155,8 +164,8 @@ export const exportTemplates = async (
   }
   if (spinner) {
     spinner.succeed('Rendered all files');
-    spinner.text = 'Copying static files';
-    spinner.render();
+    spinner.setText('Copying static files');
+    spinner.start();
   }
 
   // ex: emails/static
@@ -179,7 +188,7 @@ export const exportTemplates = async (
     } catch (exception) {
       console.error(exception);
       if (spinner) {
-        spinner.stopAndPersist({
+        stopSpinnerAndPersist(spinner, {
           symbol: logSymbols.error,
           text: 'Failed to copy static files',
         });
@@ -197,10 +206,6 @@ export const exportTemplates = async (
     const fileTree = await tree(pathToWhereEmailMarkupShouldBeDumped, 4);
 
     console.log(fileTree);
-
-    spinner.stopAndPersist({
-      symbol: logSymbols.success,
-      text: 'Successfully exported emails',
-    });
+    console.log(`${logSymbols.success} Successfully exported emails`);
   }
 };

--- a/packages/react-email/src/cli/utils/preview/start-dev-server.ts
+++ b/packages/react-email/src/cli/utils/preview/start-dev-server.ts
@@ -4,8 +4,8 @@ import path from 'node:path';
 import url from 'node:url';
 import { createJiti } from 'jiti';
 import logSymbols from 'log-symbols';
-import ora from 'ora';
 import { registerSpinnerAutostopping } from '../../utils/register-spinner-autostopping.js';
+import { createSpinner, stopSpinnerAndPersist } from '../../utils/spinner.js';
 import { conf } from '../conf.js';
 import { getUiLocation } from '../get-ui-location.js';
 import { packageJson } from '../packageJson.js';
@@ -108,17 +108,18 @@ export const startDevServer = async (
   });
 
   devServer.on('error', (e: NodeJS.ErrnoException) => {
-    spinner.stopAndPersist({
+    stopSpinnerAndPersist(spinner, {
       symbol: logSymbols.error,
       text: `Preview Server had an error: ${e}`,
     });
     process.exit(1);
   });
 
-  const spinner = ora({
+  const spinner = createSpinner({
     text: 'Getting react-email preview server ready...\n',
     prefixText: ' ',
-  }).start();
+  });
+  spinner.start();
 
   registerSpinnerAutostopping(spinner);
   const timeBeforeNextReady = performance.now();
@@ -180,7 +181,7 @@ export const startDevServer = async (
   try {
     await nextReadyPromise;
   } catch (exception) {
-    spinner.stopAndPersist({
+    stopSpinnerAndPersist(spinner, {
       symbol: logSymbols.error,
       text: ` Preview Server had an error: ${exception}`,
     });
@@ -197,7 +198,7 @@ export const startDevServer = async (
     1000
   ).toFixed(1);
 
-  spinner.stopAndPersist({
+  stopSpinnerAndPersist(spinner, {
     text: `Ready in ${secondsToNextReady}s\n`,
     symbol: logSymbols.success,
   });

--- a/packages/react-email/src/cli/utils/register-spinner-autostopping.ts
+++ b/packages/react-email/src/cli/utils/register-spinner-autostopping.ts
@@ -1,11 +1,10 @@
-import logSymbols from 'log-symbols';
-import type { Ora } from 'ora';
+import type { Spinner } from './spinner.js';
 
-const spinners = new Set<Ora>();
+const spinners = new Set<Spinner>();
 
 process.on('SIGINT', () => {
   spinners.forEach((spinner) => {
-    if (spinner.isSpinning) {
+    if (spinner.running) {
       spinner.stop();
     }
   });
@@ -14,15 +13,13 @@ process.on('SIGINT', () => {
 process.on('exit', (code) => {
   if (code !== 0) {
     spinners.forEach((spinner) => {
-      if (spinner.isSpinning) {
-        spinner.stopAndPersist({
-          symbol: logSymbols.error,
-        });
+      if (spinner.running) {
+        spinner.fail();
       }
     });
   }
 });
 
-export const registerSpinnerAutostopping = (spinner: Ora) => {
+export const registerSpinnerAutostopping = (spinner: Spinner) => {
   spinners.add(spinner);
 };

--- a/packages/react-email/src/cli/utils/spinner.ts
+++ b/packages/react-email/src/cli/utils/spinner.ts
@@ -1,0 +1,57 @@
+import {
+  type DisplayOptions,
+  type Formatter,
+  Spinner as PicoSpinner,
+  type SpinnerOptions,
+} from 'picospinner';
+
+type SpinnerDisplay =
+  | string
+  | (DisplayOptions & {
+      prefixText?: string;
+      stream?: NodeJS.WriteStream;
+    });
+
+type PersistDisplay = DisplayOptions & {
+  symbol: string;
+};
+
+export type Spinner = PicoSpinner;
+
+const withPrefixText = (
+  prefixText: string | undefined,
+  symbolFormatter: Formatter | undefined,
+) => {
+  if (typeof prefixText === 'undefined') {
+    return symbolFormatter;
+  }
+
+  return (symbol: string) =>
+    `${prefixText}${symbolFormatter?.(symbol) ?? symbol}`;
+};
+
+const normalizeDisplay = (display: SpinnerDisplay): DisplayOptions | string => {
+  if (typeof display === 'string') {
+    return display;
+  }
+
+  const { prefixText, stream, symbolFormatter, ...spinnerDisplay } = display;
+  void stream;
+
+  return {
+    ...spinnerDisplay,
+    symbolFormatter: withPrefixText(prefixText, symbolFormatter),
+  };
+};
+
+export const createSpinner = (
+  display: SpinnerDisplay,
+  options?: SpinnerOptions,
+) => new PicoSpinner(normalizeDisplay(display), options);
+
+export const stopSpinnerAndPersist = (
+  spinner: Spinner | undefined,
+  display: PersistDisplay,
+) => {
+  spinner?.setDisplay(display);
+};

--- a/packages/react-email/src/cli/utils/tree.spec.ts
+++ b/packages/react-email/src/cli/utils/tree.spec.ts
@@ -22,6 +22,7 @@ test('tree(__dirname, 2)', async () => {
     ├── index.ts
     ├── packageJson.ts
     ├── register-spinner-autostopping.ts
+    ├── spinner.ts
     ├── style-text.ts
     ├── tree.spec.ts
     └── tree.ts"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -63,7 +63,7 @@
     "module-punycode": "npm:punycode@2.3.1",
     "next-safe-action": "8.5.2",
     "node-html-parser": "7.1.0",
-    "ora": "catalog:",
+    "picospinner": "catalog:",
     "postcss": "catalog:",
     "pretty-bytes": "6.1.1",
     "prism-react-renderer": "catalog:",

--- a/packages/ui/src/actions/render-email-by-path.tsx
+++ b/packages/ui/src/actions/render-email-by-path.tsx
@@ -3,7 +3,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import logSymbols from 'log-symbols';
-import ora, { type Ora } from 'ora';
 import type React from 'react';
 import {
   isBuilding,
@@ -15,6 +14,11 @@ import { convertStackWithSourceMap } from '../utils/convert-stack-with-sourcemap
 import { createJsxRuntime } from '../utils/create-jsx-runtime';
 import { getEmailComponent } from '../utils/get-email-component';
 import { registerSpinnerAutostopping } from '../utils/register-spinner-autostopping';
+import {
+  createSpinner,
+  type Spinner,
+  stopSpinnerAndPersist,
+} from '../utils/spinner';
 import { styleText } from '../utils/style-text';
 import type { ErrorObject } from '../utils/types/error-object';
 
@@ -99,17 +103,18 @@ export const renderEmailByPath = async (
   }
 
   const emailFilename = path.basename(emailPath);
-  let spinner: Ora | undefined;
+  let spinner: Spinner | undefined;
   if (!isBuilding && !isPreviewDevelopment) {
     logBufferer.buffer();
     errorBufferer.buffer();
     infoBufferer.buffer();
     warnBufferer.buffer();
-    spinner = ora({
+    spinner = createSpinner({
       text: `Rendering email template ${emailFilename}\n`,
       prefixText: ' ',
       stream: process.stderr,
-    }).start();
+    });
+    spinner.start();
     registerSpinnerAutostopping(spinner);
   }
 
@@ -127,7 +132,7 @@ export const renderEmailByPath = async (
   const millisecondsToBundled = performance.now() - timeBeforeEmailBundled;
 
   if ('error' in componentResult) {
-    spinner?.stopAndPersist({
+    stopSpinnerAndPersist(spinner, {
       symbol: logSymbols.error,
       text: `Failed while rendering ${emailFilename}`,
     });
@@ -175,7 +180,7 @@ export const renderEmailByPath = async (
     } else {
       timeForConsole = styleText('red', timeForConsole);
     }
-    spinner?.stopAndPersist({
+    stopSpinnerAndPersist(spinner, {
       symbol: logSymbols.success,
       text: `Successfully rendered ${emailFilename} in ${timeForConsole} (bundled in ${millisecondsToBundled.toFixed(0)}ms)`,
     });
@@ -204,7 +209,7 @@ export const renderEmailByPath = async (
   } catch (exception) {
     const error = exception as Error;
 
-    spinner?.stopAndPersist({
+    stopSpinnerAndPersist(spinner, {
       symbol: logSymbols.error,
       text: `Failed while rendering ${emailFilename}`,
     });

--- a/packages/ui/src/utils/register-spinner-autostopping.ts
+++ b/packages/ui/src/utils/register-spinner-autostopping.ts
@@ -1,11 +1,10 @@
-import logSymbols from 'log-symbols';
-import type { Ora } from 'ora';
+import type { Spinner } from './spinner';
 
-const spinners = new Set<Ora>();
+const spinners = new Set<Spinner>();
 
 process.on('SIGINT', () => {
   spinners.forEach((spinner) => {
-    if (spinner.isSpinning) {
+    if (spinner.running) {
       spinner.stop();
     }
   });
@@ -14,15 +13,13 @@ process.on('SIGINT', () => {
 process.on('exit', (code) => {
   if (code !== 0) {
     spinners.forEach((spinner) => {
-      if (spinner.isSpinning) {
-        spinner.stopAndPersist({
-          symbol: logSymbols.error,
-        });
+      if (spinner.running) {
+        spinner.fail();
       }
     });
   }
 });
 
-export const registerSpinnerAutostopping = (spinner: Ora) => {
+export const registerSpinnerAutostopping = (spinner: Spinner) => {
   spinners.add(spinner);
 };

--- a/packages/ui/src/utils/spinner.ts
+++ b/packages/ui/src/utils/spinner.ts
@@ -1,0 +1,57 @@
+import {
+  type DisplayOptions,
+  type Formatter,
+  Spinner as PicoSpinner,
+  type SpinnerOptions,
+} from 'picospinner';
+
+type SpinnerDisplay =
+  | string
+  | (DisplayOptions & {
+      prefixText?: string;
+      stream?: NodeJS.WriteStream;
+    });
+
+type PersistDisplay = DisplayOptions & {
+  symbol: string;
+};
+
+export type Spinner = PicoSpinner;
+
+const withPrefixText = (
+  prefixText: string | undefined,
+  symbolFormatter: Formatter | undefined,
+) => {
+  if (typeof prefixText === 'undefined') {
+    return symbolFormatter;
+  }
+
+  return (symbol: string) =>
+    `${prefixText}${symbolFormatter?.(symbol) ?? symbol}`;
+};
+
+const normalizeDisplay = (display: SpinnerDisplay): DisplayOptions | string => {
+  if (typeof display === 'string') {
+    return display;
+  }
+
+  const { prefixText, stream, symbolFormatter, ...spinnerDisplay } = display;
+  void stream;
+
+  return {
+    ...spinnerDisplay,
+    symbolFormatter: withPrefixText(prefixText, symbolFormatter),
+  };
+};
+
+export const createSpinner = (
+  display: SpinnerDisplay,
+  options?: SpinnerOptions,
+) => new PicoSpinner(normalizeDisplay(display), options);
+
+export const stopSpinnerAndPersist = (
+  spinner: Spinner | undefined,
+  display: PersistDisplay,
+) => {
+  spinner?.setDisplay(display);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ catalogs:
     ora:
       specifier: ^8.0.0
       version: 8.2.0
+    picospinner:
+      specifier: ^3.0.0
+      version: 3.0.0
     postcss:
       specifier: 8.5.10
       version: 8.5.10
@@ -687,9 +690,9 @@ importers:
       nypm:
         specifier: 'catalog:'
         version: 0.6.6
-      ora:
+      picospinner:
         specifier: 'catalog:'
-        version: 8.2.0
+        version: 3.0.0
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
@@ -892,9 +895,9 @@ importers:
       node-html-parser:
         specifier: 7.1.0
         version: 7.1.0
-      ora:
+      picospinner:
         specifier: 'catalog:'
-        version: 8.2.0
+        version: 3.0.0
       postcss:
         specifier: 'catalog:'
         version: 8.5.10
@@ -6990,6 +6993,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  picospinner@3.0.0:
+    resolution: {integrity: sha512-lGA1TNsmy2bxvRsTI2cV01kfTwKzZjnZSDmF9llYNyMHMrU4sP87lQ5taiIKm88L3cbswjl008nwyGc3WpNvzg==}
+    engines: {node: '>=18.0.0'}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -15754,6 +15761,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  picospinner@3.0.0: {}
 
   pify@2.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,6 +41,7 @@ catalog:
   next: 16.2.3
   nypm: 0.6.6
   ora: ^8.0.0
+  picospinner: ^3.0.0
   postcss: 8.5.10
   prism-react-renderer: 2.4.1
   react: 19.2.4


### PR DESCRIPTION
## Summary
- Replace ora with picospinner in packages/ui and packages/react-email.
- Add small spinner adapters to preserve existing start, status, and persist behavior.
- Update workspace catalog and lockfile entries for picospinner.

## Test plan
- pnpm exec biome check packages/ui/src/utils/spinner.ts packages/ui/src/utils/register-spinner-autostopping.ts packages/ui/src/actions/render-email-by-path.tsx packages/react-email/src/cli/utils/spinner.ts packages/react-email/src/cli/utils/register-spinner-autostopping.ts packages/react-email/src/cli/commands/build.ts packages/react-email/src/cli/utils/preview/start-dev-server.ts packages/react-email/src/cli/commands/export.ts packages/ui/package.json packages/react-email/package.json pnpm-workspace.yaml
- pnpm --filter react-email build
- pnpm --filter @react-email/render build && pnpm --filter @react-email/ui build


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace `ora` with `picospinner` in `packages/ui` and `packages/react-email`, preserving the same CLI UX with lightweight adapters and improved auto-stop behavior. Added a changeset and updated tests/snapshots.

- **Refactors**
  - Swapped spinner usage in build, export, preview, and render flows to `picospinner`.
  - Added `createSpinner` and `stopSpinnerAndPersist` to keep prefix/status/persist behavior.
  - Updated auto-stop to use `running`, `stop()`, and `fail()`; switched to `setText`/`start()` calls.
  - Updated test snapshot (CLI utils tree now includes `spinner.ts`); final export success logs via console.

- **Dependencies**
  - Added `picospinner` to workspace catalog; replaced `ora` in `packages/ui` and `packages/react-email`.
  - Updated `pnpm-lock.yaml`, `pnpm-workspace.yaml`, and added a changeset entry.

<sup>Written for commit f6fa18bd57f0fbd8e4ab459a31d7ba53e35df382. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3442?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

