### PR TITLE
fix(examples): catalog use

### DIFF
--- a/examples/aws-ses/package.json
+++ b/examples/aws-ses/package.json
@@ -14,13 +14,13 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@aws-sdk/client-ses": "^3",
-    "react-email": "catalog:",
-    "react": "catalog:",
-    "react-dom": "catalog:"
+    "@aws-sdk/client-ses": "3.1038.0",
+    "react-email": "6.0.3",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
-    "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "tsdown": "0.21.9",
+    "typescript": "5.9.3"
   }
 }

--- a/examples/mailersend/package.json
+++ b/examples/mailersend/package.json
@@ -14,13 +14,13 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "react-email": "catalog:",
-    "mailersend": "^2",
-    "react": "catalog:",
-    "react-dom": "catalog:"
+    "react-email": "6.0.3",
+    "mailersend": "2.8.0",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
-    "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "tsdown": "0.21.9",
+    "typescript": "5.9.3"
   }
 }

--- a/examples/nodemailer/package.json
+++ b/examples/nodemailer/package.json
@@ -14,14 +14,14 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "react-email": "catalog:",
-    "nodemailer": "^8.0.0",
-    "react": "catalog:",
-    "react-dom": "catalog:"
+    "react-email": "6.0.3",
+    "nodemailer": "8.0.7",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
-    "@types/nodemailer": "^6",
-    "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "@types/nodemailer": "8.0.0",
+    "tsdown": "0.21.9",
+    "typescript": "5.9.3"
   }
 }

--- a/examples/plunk/package.json
+++ b/examples/plunk/package.json
@@ -14,13 +14,13 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@plunk/node": "^3",
-    "react-email": "catalog:",
-    "react": "catalog:",
-    "react-dom": "catalog:"
+    "@plunk/node": "3.0.3",
+    "react-email": "6.0.3",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
-    "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "tsdown": "0.21.9",
+    "typescript": "5.9.3"
   }
 }

--- a/examples/postmark/package.json
+++ b/examples/postmark/package.json
@@ -14,13 +14,13 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "postmark": "^3",
-    "react-email": "catalog:",
-    "react": "catalog:",
-    "react-dom": "catalog:"
+    "postmark": "3.11.0",
+    "react-email": "6.0.3",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
-    "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "tsdown": "0.21.9",
+    "typescript": "5.9.3"
   }
 }

--- a/examples/resend/package.json
+++ b/examples/resend/package.json
@@ -9,16 +9,16 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "catalog:",
-    "react-email": "catalog:",
-    "react": "catalog:",
-    "react-dom": "catalog:",
-    "resend": "catalog:"
+    "next": "16.2.3",
+    "react-email": "6.0.3",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "resend": "6.4.0"
   },
   "devDependencies": {
-    "@types/node": "catalog:",
-    "@types/react": "catalog:",
-    "@types/react-dom": "catalog:",
-    "typescript": "catalog:"
+    "@types/node": "22.19.17",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "typescript": "5.9.3"
   }
 }

--- a/examples/scaleway/next/package.json
+++ b/examples/scaleway/next/package.json
@@ -9,16 +9,16 @@
     "start": "next start"
   },
   "dependencies": {
-    "@scaleway/sdk": "catalog:",
-    "next": "catalog:",
-    "react-email": "catalog:",
-    "react": "catalog:",
-    "react-dom": "catalog:"
+    "@scaleway/sdk": "1.42.0",
+    "next": "16.2.3",
+    "react-email": "6.0.3",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
-    "@types/node": "catalog:",
-    "@types/react": "catalog:",
-    "@types/react-dom": "catalog:",
-    "typescript": "catalog:"
+    "@types/node": "22.19.17",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "typescript": "5.9.3"
   }
 }

--- a/examples/scaleway/node/package.json
+++ b/examples/scaleway/node/package.json
@@ -13,13 +13,13 @@
     "dev": "tsdown src/index.tsx --format esm --target node20 --watch"
   },
   "dependencies": {
-    "@scaleway/sdk": "catalog:",
-    "react-email": "catalog:",
-    "react": "catalog:",
-    "react-dom": "catalog:"
+    "@scaleway/sdk": "1.42.0",
+    "react-email": "6.0.3",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
-    "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "tsdown": "0.21.9",
+    "typescript": "5.9.3"
   }
 }

--- a/examples/sendgrid/package.json
+++ b/examples/sendgrid/package.json
@@ -14,13 +14,13 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@sendgrid/mail": "^7",
-    "react-email": "catalog:",
-    "react": "catalog:",
-    "react-dom": "catalog:"
+    "@sendgrid/mail": "7.7.0",
+    "react-email": "6.0.3",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
-    "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "tsdown": "0.21.9",
+    "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
removes the catalog: since the examples are not included in the workspace

it's better to use fixed versions because users can see that the examples are for that specific version easily without having to look at other files if they need to

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all `catalog:` references in example projects with pinned versions. This makes the examples self-contained, reproducible, and clearly tied to specific versions.

- **Dependencies**
  - Core: `react-email@6.0.3`, `react@19.2.4`, `react-dom@19.2.4`
  - Dev: `typescript@5.9.3`, `tsdown@0.21.9`, `@types/node@22.19.17`, `@types/react@19.2.14`, `@types/react-dom@19.2.3`, `@types/nodemailer@8.0.0`
  - Providers/Next: `next@16.2.3`, `@aws-sdk/client-ses@3.1038.0`, `mailersend@2.8.0`, `nodemailer@8.0.7`, `@plunk/node@3.0.3`, `postmark@3.11.0`, `@sendgrid/mail@7.7.0`, `resend@6.4.0`, `@scaleway/sdk@1.42.0`

<sup>Written for commit 6140cf439ee1fcd08f4d5810bfc944e433879cf1. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3444?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

