### PR TITLE
fix(editor): clear global CSS style on empty input

### DIFF
--- a/.changeset/empty-global-css-clears-editor.md
+++ b/.changeset/empty-global-css-clears-editor.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Clear the injected global CSS `<style>` element when the user empties global CSS in the editor. Previously, deleting all global CSS at once left the previously injected rules in the DOM, so the email editor preview kept showing stale styles.

--- a/packages/editor/src/plugins/email-theming/css-transforms.spec.ts
+++ b/packages/editor/src/plugins/email-theming/css-transforms.spec.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { injectThemeCss, transformToCssJs } from './css-transforms';
+import {
+  injectGlobalPlainCss,
+  injectThemeCss,
+  transformToCssJs,
+} from './css-transforms';
 import { DEFAULT_INBOX_FONT_SIZE_PX } from './themes';
 import type { CssJs, PanelGroup } from './types';
 
@@ -377,5 +381,88 @@ describe('injectThemeCss', () => {
       '.editor-scope .node-container{width:600px;}',
     );
     expect(styleTag?.textContent).not.toContain('.editor-scope .node-body');
+  });
+});
+
+describe('injectGlobalPlainCss', () => {
+  const STYLE_ID = 'inject-global-plain-css-test';
+  const SCOPE = '.editor-scope';
+
+  afterEach(() => {
+    document.getElementById(STYLE_ID)?.remove();
+  });
+
+  it('injects css into a new <style> element', () => {
+    injectGlobalPlainCss('.foo { color: red; }', {
+      styleId: STYLE_ID,
+      scopeSelector: SCOPE,
+    });
+
+    const styleTag = document.getElementById(STYLE_ID);
+    expect(styleTag).not.toBeNull();
+    expect(styleTag?.textContent).toBe(
+      `${SCOPE} { .foo { color: red; } }`,
+    );
+  });
+
+  it('updates existing <style> textContent on subsequent calls', () => {
+    injectGlobalPlainCss('.foo { color: red; }', {
+      styleId: STYLE_ID,
+      scopeSelector: SCOPE,
+    });
+    injectGlobalPlainCss('.bar { color: blue; }', {
+      styleId: STYLE_ID,
+      scopeSelector: SCOPE,
+    });
+
+    const styleTags = document.querySelectorAll(`#${STYLE_ID}`);
+    expect(styleTags.length).toBe(1);
+    expect(styleTags[0]?.textContent).toBe(
+      `${SCOPE} { .bar { color: blue; } }`,
+    );
+  });
+
+  it('clears existing <style> textContent when css is "" (MES-551)', () => {
+    injectGlobalPlainCss('.foo { color: red; }', {
+      styleId: STYLE_ID,
+      scopeSelector: SCOPE,
+    });
+
+    injectGlobalPlainCss('', { styleId: STYLE_ID, scopeSelector: SCOPE });
+
+    const styleTag = document.getElementById(STYLE_ID);
+    expect(styleTag).not.toBeNull();
+    expect(styleTag?.textContent).toBe('');
+  });
+
+  it('clears existing <style> textContent when css is null', () => {
+    injectGlobalPlainCss('.foo { color: red; }', {
+      styleId: STYLE_ID,
+      scopeSelector: SCOPE,
+    });
+
+    injectGlobalPlainCss(null, { styleId: STYLE_ID, scopeSelector: SCOPE });
+
+    expect(document.getElementById(STYLE_ID)?.textContent).toBe('');
+  });
+
+  it('clears existing <style> textContent when css is undefined', () => {
+    injectGlobalPlainCss('.foo { color: red; }', {
+      styleId: STYLE_ID,
+      scopeSelector: SCOPE,
+    });
+
+    injectGlobalPlainCss(undefined, {
+      styleId: STYLE_ID,
+      scopeSelector: SCOPE,
+    });
+
+    expect(document.getElementById(STYLE_ID)?.textContent).toBe('');
+  });
+
+  it('does not create a <style> element when css is empty and none exists', () => {
+    injectGlobalPlainCss('', { styleId: STYLE_ID, scopeSelector: SCOPE });
+
+    expect(document.getElementById(STYLE_ID)).toBeNull();
   });
 });

--- a/packages/editor/src/plugins/email-theming/css-transforms.spec.ts
+++ b/packages/editor/src/plugins/email-theming/css-transforms.spec.ts
@@ -400,9 +400,7 @@ describe('injectGlobalPlainCss', () => {
 
     const styleTag = document.getElementById(STYLE_ID);
     expect(styleTag).not.toBeNull();
-    expect(styleTag?.textContent).toBe(
-      `${SCOPE} { .foo { color: red; } }`,
-    );
+    expect(styleTag?.textContent).toBe(`${SCOPE} { .foo { color: red; } }`);
   });
 
   it('updates existing <style> textContent on subsequent calls', () => {
@@ -422,7 +420,7 @@ describe('injectGlobalPlainCss', () => {
     );
   });
 
-  it('clears existing <style> textContent when css is "" (MES-551)', () => {
+  it('clears existing <style> textContent when css is empty string', () => {
     injectGlobalPlainCss('.foo { color: red; }', {
       styleId: STYLE_ID,
       scopeSelector: SCOPE,

--- a/packages/editor/src/plugins/email-theming/css-transforms.ts
+++ b/packages/editor/src/plugins/email-theming/css-transforms.ts
@@ -123,13 +123,16 @@ export function injectGlobalPlainCss(
   css?: string | null,
   options: { styleId?: string; scopeSelector?: string } = {},
 ) {
-  if (!css) {
-    return;
-  }
-
   const styleId = options.styleId ?? 'global-editor-style';
   const container = options.scopeSelector ?? '.tiptap-extended .ProseMirror';
   let styleElement = document.getElementById(styleId);
+
+  if (!css) {
+    if (styleElement) {
+      styleElement.textContent = '';
+    }
+    return;
+  }
 
   if (!styleElement) {
     styleElement = document.createElement('style');


### PR DESCRIPTION
## Summary

- `injectGlobalPlainCss` returned early on empty/null/undefined css, leaving the previously injected `<style id="global-editor-style">` intact in the DOM. Selecting all global CSS in the editor sidebar and deleting it kept stale rules applied to the email editor preview.
- Now resolves `styleId` first; on empty input it clears the existing `<style>` element's `textContent` instead of returning early. Non-empty inputs behave as before.
- Added regression tests for empty string, `null`, `undefined`, and the no-prior-element case.

Fixes [MES-551](https://linear.app/resend/issue/MES-551).

https://github.com/user-attachments/assets/e37e8049-b317-47c9-a92c-054e197ebcce


## Test plan

- [x] `pnpm --filter @react-email/editor test:unit` (440 passed, 1 skipped)
- [ ] Manual: in dashboard editor, add a CSS rule, select-all + delete, confirm rules clear from preview.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the global CSS style in `@react-email/editor` when the user deletes all rules, so the preview does not keep stale styles. Fixes MES-551.

- **Bug Fixes**
  - Update `injectGlobalPlainCss` to clear the existing style textContent on empty, null, or undefined input, and avoid creating a style when none exists.
  - Resolve `styleId` before handling empty input to target the correct element.
  - Add regression tests for "", null, undefined, and the no-existing-style case; fix lint and remove Linear ID from test titles.

<sup>Written for commit 1a9a75e64fbfecfd2e9edbf4ee7306a6790288b2. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3448?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

