### PR TITLE
fix(ui): path aliases breaking ui build publishing

### DIFF
--- a/.changeset/fuzzy-esbuilds-exist.md
+++ b/.changeset/fuzzy-esbuilds-exist.md
@@ -1,0 +1,5 @@
+---
+"@react-email/ui": patch
+---
+
+Fix the preview server package build so Turbopack's externalized esbuild alias is included in the published tarball.

--- a/packages/ui/scripts/build.mts
+++ b/packages/ui/scripts/build.mts
@@ -22,6 +22,7 @@ nextBuildProcess.on('exit', (code) => {
 
   fs.rmSync(path.join(previewServerRoot, '.next', 'cache'), {
     recursive: true,
+    force: true,
   });
 
   const nodeModules = path.join(previewServerRoot, '.next', 'node_modules');

--- a/packages/ui/scripts/build.mts
+++ b/packages/ui/scripts/build.mts
@@ -2,10 +2,12 @@ import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
+const previewServerRoot = path.resolve(import.meta.dirname, '../');
+
 const nextBuildProcess = spawn('pnpm next build', {
   shell: true,
   stdio: 'inherit',
-  cwd: path.resolve(import.meta.dirname, '../'),
+  cwd: previewServerRoot,
 });
 
 process.on('SIGINT', () => {
@@ -18,7 +20,23 @@ nextBuildProcess.on('exit', (code) => {
     process.exit(code);
   }
 
-  fs.rmSync(path.resolve(import.meta.dirname, '../.next/cache'), {
+  fs.rmSync(path.join(previewServerRoot, '.next', 'cache'), {
     recursive: true,
   });
+
+  const nodeModules = path.join(previewServerRoot, '.next', 'node_modules');
+  if (!fs.existsSync(nodeModules)) {
+    return;
+  }
+
+  for (const entry of fs.readdirSync(nodeModules, { withFileTypes: true })) {
+    const entryPath = path.join(nodeModules, entry.name);
+    if (!entry.isSymbolicLink()) {
+      continue;
+    }
+
+    const realPath = fs.realpathSync(entryPath);
+    fs.unlinkSync(entryPath);
+    fs.cpSync(realPath, entryPath, { recursive: true });
+  }
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes `@react-email/ui` preview server publishing by bundling Turbopack’s externalized `esbuild` alias and preventing path alias issues during build.

- **Bug Fixes**
  - Replace symlinks in `.next/node_modules` with real files so they’re included in the published tarball.
  - Use a single `previewServerRoot` for path resolution and force-remove `.next/cache` after build.

<sup>Written for commit 3a58dd072f37484fe95ca902fdd84dac58453e29. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3451?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

