### PR TITLE
chore(docs): reorder email export sections

### DIFF
--- a/apps/docs/editor/features/email-export.mdx
+++ b/apps/docs/editor/features/email-export.mdx
@@ -7,7 +7,45 @@ icon: "file-export"
 
 ## Quick start
 
-Use `composeReactEmail` to convert editor content into email-ready HTML and plain text.
+If you use the standalone `EmailEditor` component, you can access the email HTML and plain text through ref methods.
+
+```tsx
+import { EmailEditor, type EmailEditorRef } from '@react-email/editor';
+import { useRef, useState } from 'react';
+
+export function MyEditor() {
+  const ref = useRef<EmailEditorRef>(null);
+  const [html, setHtml] = useState('');
+
+  const handleExport = async () => {
+    if (!ref.current) return;
+    const html = await ref.current.getEmailHTML();
+    setHtml(html);
+  };
+
+  return (
+    <div>
+      <EmailEditor ref={ref} content="<p>Edit me</p>" />
+      <button onClick={handleExport}>Export HTML</button>
+      {html && <textarea readOnly value={html} />}
+    </div>
+  );
+}
+```
+
+The ref exposes three export methods:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getEmailHTML()` | `Promise<string>` | Email-ready HTML |
+| `getEmailText()` | `Promise<string>` | Plain text version |
+| `getEmail()` | `Promise<{ html, text }>` | Both in a single call |
+
+All three use [composeReactEmail](/editor/api-reference/compose-react-email) under the hood.
+
+## Using without EmailEditor
+
+Use [composeReactEmail](/editor/api-reference/compose-react-email) directly to convert editor content into email-ready HTML and plain text without [EmailEditor](/editor/api-reference/email-editor).
 
 ```tsx
 import { composeReactEmail } from '@react-email/editor/core';
@@ -59,44 +97,6 @@ export function MyEditor() {
   );
 }
 ```
-
-## Using with EmailEditor
-
-If you use the standalone `EmailEditor` component, you can access the email HTML and plain text through ref methods — no need to call `composeReactEmail` directly.
-
-```tsx
-import { EmailEditor, type EmailEditorRef } from '@react-email/editor';
-import { useRef, useState } from 'react';
-
-export function MyEditor() {
-  const ref = useRef<EmailEditorRef>(null);
-  const [html, setHtml] = useState('');
-
-  const handleExport = async () => {
-    if (!ref.current) return;
-    const html = await ref.current.getEmailHTML();
-    setHtml(html);
-  };
-
-  return (
-    <div>
-      <EmailEditor ref={ref} content="<p>Edit me</p>" />
-      <button onClick={handleExport}>Export HTML</button>
-      {html && <textarea readOnly value={html} />}
-    </div>
-  );
-}
-```
-
-The ref exposes three export methods:
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `getEmailHTML()` | `Promise<string>` | Email-ready HTML |
-| `getEmailText()` | `Promise<string>` | Plain text version |
-| `getEmail()` | `Promise<{ html, text }>` | Both in a single call |
-
-All three use `composeReactEmail` under the hood.
 
 ## How it works
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,7 +156,6 @@ overrides:
   react-dom: 19.2.4
   serve-static>send: ^0.19.0
   socket.io>socket.io-parser: ^4.2.6
-  tar@<6.2.1: ^6.2.1
   uuid@<14.0.0: ^14.0.0
 
 importers:
@@ -8032,8 +8031,8 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+  tar@6.1.15:
+    resolution: {integrity: sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==}
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
@@ -10360,7 +10359,7 @@ snapshots:
       openapi-types: 12.1.3
       react: 19.2.4
       socket.io: 4.7.2
-      tar: 6.2.1
+      tar: 6.1.15
       unist-util-visit: 4.1.2
       yargs: 17.7.1
     transitivePeerDependencies:
@@ -17203,7 +17202,7 @@ snapshots:
       fast-fifo: 1.3.2
       streamx: 2.22.0
 
-  tar@6.2.1:
+  tar@6.1.15:
     dependencies:
       chownr: 2.0.0
       fs-minipass: 2.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,12 +157,6 @@ overrides:
   serve-static>send: ^0.19.0
   socket.io>socket.io-parser: ^4.2.6
   tar@<6.2.1: ^6.2.1
-  tar@<7.5.7: ^7.5.7
-  tar@<7.5.8: ^7.5.8
-  tar@<=7.5.10: ^7.5.11
-  tar@<=7.5.2: ^7.5.3
-  tar@<=7.5.3: ^7.5.4
-  tar@<=7.5.9: ^7.5.10
   uuid@<14.0.0: ^14.0.0
 
 importers:
@@ -2141,10 +2135,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -4593,9 +4583,9 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
-  chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -5392,6 +5382,10 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -6609,13 +6603,21 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minizlib@3.1.0:
-    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
-    engines: {node: '>= 18'}
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
 
   mintlify@4.2.521:
     resolution: {integrity: sha512-CeeJD78JRJG15Zk36GuvCnFTkyblhSvTp9zgYH5apdXe4MMeXmbFJFyVWkugJb3TZyKs5pR0c3ofXQw/W5LYyw==}
@@ -6627,6 +6629,11 @@ packages:
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
@@ -8025,9 +8032,10 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@7.5.13:
-    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
-    engines: {node: '>=18'}
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -8766,9 +8774,8 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -9933,10 +9940,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
-  '@isaacs/fs-minipass@4.0.1':
-    dependencies:
-      minipass: 7.1.3
-
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -10357,7 +10360,7 @@ snapshots:
       openapi-types: 12.1.3
       react: 19.2.4
       socket.io: 4.7.2
-      tar: 7.5.13
+      tar: 6.2.1
       unist-util-visit: 4.1.2
       yargs: 17.7.1
     transitivePeerDependencies:
@@ -12835,7 +12838,7 @@ snapshots:
   chownr@1.1.4:
     optional: true
 
-  chownr@3.0.0: {}
+  chownr@2.0.0: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -13748,6 +13751,10 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
+
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
 
   fs.realpath@1.0.0: {}
 
@@ -15338,11 +15345,18 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
   minipass@7.1.3: {}
 
-  minizlib@3.1.0:
+  minizlib@2.1.2:
     dependencies:
-      minipass: 7.1.3
+      minipass: 3.3.6
+      yallist: 4.0.0
 
   mintlify@4.2.521(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@25.5.0)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
@@ -15369,6 +15383,8 @@ snapshots:
 
   mkdirp-classic@0.5.3:
     optional: true
+
+  mkdirp@1.0.4: {}
 
   mlly@1.7.4:
     dependencies:
@@ -17187,13 +17203,14 @@ snapshots:
       fast-fifo: 1.3.2
       streamx: 2.22.0
 
-  tar@7.5.13:
+  tar@6.2.1:
     dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
 
   term-size@2.2.1: {}
 
@@ -17938,7 +17955,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yallist@5.0.0: {}
+  yallist@4.0.0: {}
 
   yaml@2.8.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -103,11 +103,4 @@ overrides:
   react-dom: 19.2.4
   serve-static>send: ^0.19.0
   socket.io>socket.io-parser: ^4.2.6
-  tar@<6.2.1: ^6.2.1
-  tar@<7.5.7: ^7.5.7
-  tar@<7.5.8: ^7.5.8
-  tar@<=7.5.10: ^7.5.11
-  tar@<=7.5.2: ^7.5.3
-  tar@<=7.5.3: ^7.5.4
-  tar@<=7.5.9: ^7.5.10
   uuid@<14.0.0: ^14.0.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reordered the Email Export docs to highlight `EmailEditor` ref-based export in Quick start and moved `composeReactEmail` to its own section. This makes the recommended path clearer and links directly to the API docs.

- **Refactors**
  - Promote `EmailEditor` ref methods in Quick start with a concise example.
  - Move `composeReactEmail` usage to “Using without EmailEditor” with API links.

- **Dependencies**
  - Pin `tar` to `6.2.1` and remove workspace overrides.
  - Align transitive deps for compatibility: `chownr@2`, `fs-minipass@2`, `minipass@5`, `minizlib@2`, `mkdirp@1`, `yallist@4`.

<sup>Written for commit 42e95c4a43e2a0856ef96188bf804a0c7c840826. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3453?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

