### PR TITLE
fix(editor): bubble menu closing when clicking node selector

### DIFF
--- a/.changeset/tame-clocks-give.md
+++ b/.changeset/tame-clocks-give.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+fix bubble menu's node selector closing bubble menu

--- a/packages/editor/src/ui/bubble-menu/node-selector.tsx
+++ b/packages/editor/src/ui/bubble-menu/node-selector.tsx
@@ -1,6 +1,7 @@
 import * as Popover from '@radix-ui/react-popover';
 import { useEditorState } from '@tiptap/react';
 import * as React from 'react';
+import { EditorFocusScope } from '../editor-focus-scope';
 import {
   CheckIcon,
   ChevronDownIcon,
@@ -200,13 +201,15 @@ export function NodeSelectorRoot({
   return (
     <NodeSelectorContext.Provider value={contextValue}>
       <Popover.Root open={isOpen} onOpenChange={setIsOpen}>
-        <div
-          data-re-node-selector=""
-          {...(isOpen ? { 'data-open': '' } : {})}
-          className={className}
-        >
-          {children}
-        </div>
+        <EditorFocusScope>
+          <div
+            data-re-node-selector=""
+            {...(isOpen ? { 'data-open': '' } : {})}
+            className={className}
+          >
+            {children}
+          </div>
+        </EditorFocusScope>
       </Popover.Root>
     </NodeSelectorContext.Provider>
   );
@@ -261,27 +264,31 @@ export function NodeSelectorContent({
       data-re-node-selector-content=""
       className={className}
     >
-      {children
-        ? children(items, () => setIsOpen(false))
-        : items.map((item) => {
-            const Icon = item.icon;
-            return (
-              <button
-                key={item.name}
-                type="button"
-                data-re-node-selector-item=""
-                {...(item.isActive ? { 'data-active': '' } : {})}
-                onClick={() => {
-                  item.command();
-                  setIsOpen(false);
-                }}
-              >
-                <Icon />
-                <span>{item.name}</span>
-                {item.isActive && <CheckIcon />}
-              </button>
-            );
-          })}
+      <EditorFocusScope>
+        <div>
+          {children
+            ? children(items, () => setIsOpen(false))
+            : items.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <button
+                    key={item.name}
+                    type="button"
+                    data-re-node-selector-item=""
+                    {...(item.isActive ? { 'data-active': '' } : {})}
+                    onClick={() => {
+                      item.command();
+                      setIsOpen(false);
+                    }}
+                  >
+                    <Icon />
+                    <span>{item.name}</span>
+                    {item.isActive && <CheckIcon />}
+                  </button>
+                );
+              })}
+        </div>
+      </EditorFocusScope>
     </Popover.Content>
   );
 }

--- a/packages/editor/src/ui/editor-focus-scope.spec.tsx
+++ b/packages/editor/src/ui/editor-focus-scope.spec.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { Editor } from '@tiptap/core';
 import { EditorContext } from '@tiptap/react';
 import TipTapStarterKit from '@tiptap/starter-kit';
+import * as React from 'react';
 import {
   EditorFocusScope,
   EditorFocusScopeProvider,
@@ -11,6 +12,23 @@ import {
 function waitForCreate() {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
+
+const ManuallyForwardedRefChild = React.forwardRef<HTMLDivElement>(
+  function ManuallyForwardedRefChild(_, forwardedRef) {
+    const elementRef = React.useRef<HTMLDivElement>(null);
+
+    React.useLayoutEffect(() => {
+      if (typeof forwardedRef !== 'function') return;
+
+      forwardedRef(elementRef.current);
+      return () => {
+        forwardedRef(null);
+      };
+    }, [forwardedRef]);
+
+    return <div ref={elementRef}>Manual ref child</div>;
+  },
+);
 
 describe('EditorFocusScope', () => {
   it('renders children without a provider', () => {
@@ -48,6 +66,114 @@ describe('EditorFocusScope', () => {
 
     unmount();
     expect(unregisterScope).toHaveBeenCalledWith(button);
+  });
+
+  it('unregisters the previous child when the scoped element changes', () => {
+    const registerScope = vi.fn();
+    const unregisterScope = vi.fn();
+    const editor = {
+      extensionStorage: {
+        focusScope: {
+          registerScope,
+          unregisterScope,
+        },
+      },
+    };
+
+    const { rerender } = render(
+      <EditorContext.Provider value={{ editor: editor as any }}>
+        <EditorFocusScope>
+          <button type="button">First action</button>
+        </EditorFocusScope>
+      </EditorContext.Provider>,
+    );
+
+    const firstButton = screen.getByRole('button', { name: 'First action' });
+    expect(registerScope).toHaveBeenCalledWith(firstButton);
+
+    rerender(
+      <EditorContext.Provider value={{ editor: editor as any }}>
+        <EditorFocusScope>
+          <a href="/second">Second action</a>
+        </EditorFocusScope>
+      </EditorContext.Provider>,
+    );
+
+    const secondLink = screen.getByRole('link', { name: 'Second action' });
+    expect(unregisterScope).toHaveBeenCalledWith(firstButton);
+    expect(registerScope).toHaveBeenCalledWith(secondLink);
+  });
+
+  it('unregisters from the old focus scope when extension storage changes', () => {
+    const firstRegisterScope = vi.fn();
+    const firstUnregisterScope = vi.fn();
+    const secondRegisterScope = vi.fn();
+    const secondUnregisterScope = vi.fn();
+    const editor = {
+      extensionStorage: {
+        focusScope: {
+          registerScope: firstRegisterScope,
+          unregisterScope: firstUnregisterScope,
+        },
+      },
+    };
+
+    const { rerender, unmount } = render(
+      <EditorContext.Provider value={{ editor: editor as any }}>
+        <EditorFocusScope>
+          <button type="button">Scoped action</button>
+        </EditorFocusScope>
+      </EditorContext.Provider>,
+    );
+
+    const button = screen.getByRole('button', { name: 'Scoped action' });
+    expect(firstRegisterScope).toHaveBeenCalledWith(button);
+
+    editor.extensionStorage.focusScope = {
+      registerScope: secondRegisterScope,
+      unregisterScope: secondUnregisterScope,
+    };
+
+    rerender(
+      <EditorContext.Provider value={{ editor: editor as any }}>
+        <EditorFocusScope>
+          <button type="button">Scoped action</button>
+        </EditorFocusScope>
+      </EditorContext.Provider>,
+    );
+
+    expect(firstUnregisterScope).toHaveBeenCalledWith(button);
+    expect(secondRegisterScope).toHaveBeenCalledWith(button);
+
+    unmount();
+    expect(secondUnregisterScope).toHaveBeenCalledWith(button);
+  });
+
+  it('unregisters when a forwarded child manually clears the ref', () => {
+    const registerScope = vi.fn();
+    const unregisterScope = vi.fn();
+    const editor = {
+      extensionStorage: {
+        focusScope: {
+          registerScope,
+          unregisterScope,
+        },
+      },
+    };
+
+    const { unmount } = render(
+      <EditorContext.Provider value={{ editor: editor as any }}>
+        <EditorFocusScope>
+          <ManuallyForwardedRefChild />
+        </EditorFocusScope>
+      </EditorContext.Provider>,
+    );
+
+    const child = screen.getByText('Manual ref child');
+    expect(registerScope).toHaveBeenCalledWith(child);
+
+    unmount();
+    expect(unregisterScope).toHaveBeenCalledWith(child);
   });
 });
 

--- a/packages/editor/src/ui/editor-focus-scope.tsx
+++ b/packages/editor/src/ui/editor-focus-scope.tsx
@@ -101,24 +101,30 @@ export interface EditorFocusScopeProps {
 export function EditorFocusScope({ children }: EditorFocusScopeProps) {
   const context = React.useContext(FocusScopeContext);
   const { editor } = useCurrentEditor();
-  const focusScope = context ?? editor?.extensionStorage?.focusScope;
+  const focusScope = context ?? editor?.extensionStorage?.focusScope ?? null;
+  const attachedElRef = React.useRef<HTMLElement | null>(null);
+
+  const setScopeRef = React.useCallback(
+    (element: HTMLElement | null) => {
+      if (!focusScope) return;
+
+      const prev = attachedElRef.current;
+      if (prev && prev !== element) {
+        focusScope.unregisterScope(prev);
+      }
+
+      attachedElRef.current = element;
+
+      if (element) {
+        focusScope.registerScope(element);
+      }
+    },
+    [focusScope],
+  );
 
   if (!focusScope) {
     return <>{children}</>;
   }
 
-  return (
-    <Slot
-      ref={(element) => {
-        if (!element) return;
-
-        focusScope.registerScope(element);
-        return () => {
-          focusScope.unregisterScope(element);
-        };
-      }}
-    >
-      {children}
-    </Slot>
-  );
+  return <Slot ref={setScopeRef}>{children}</Slot>;
 }


### PR DESCRIPTION
Closes #3454 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3454 by preventing the bubble menu from closing when clicking the node selector through correct focus scoping.

- **Bug Fixes**
  - Wrapped node selector UI with `EditorFocusScope` so interactions don’t close the bubble menu.
  - Improved `EditorFocusScope` to track the attached element and reliably register/unregister when elements or `extensionStorage.focusScope` change, including forwarded refs.
  - Added tests for re-registration and cleanup scenarios, and a patch changeset for `@react-email/editor`.

<sup>Written for commit a0a7935dfee01ec6d886e8534c0ee5f0244d84ed. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3456?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

