### PR TITLE
fix: changeset

### DIFF
--- a/.changeset/downlevel-email-css.md
+++ b/.changeset/downlevel-email-css.md
@@ -1,5 +1,5 @@
 ---
-"@react-email/tailwind": patch
+"react-email": patch
 ---
 
-downlevel at rules for email client compatibility
+undo nesting of all media queries, and replace >= <= exxpressions with min-width/max-width on the Tailwind component


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the changeset to publish a patch for `react-email` instead of `@react-email/tailwind`, and clarifies the change summary for better release notes. This ensures the patch lands in the correct package and explains the CSS updates for email client compatibility (undo media query nesting and replace >=/<= with min/max-width).

<sup>Written for commit 5cc500a65178ecf3af3248ccca30233deaa9e63e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

