### PR TITLE
fix(tailwind): parse non inline configuration variables

### DIFF
--- a/.changeset/old-shirts-tan.md
+++ b/.changeset/old-shirts-tan.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+fix(tailwind): parse non inline configuration variables

--- a/.changeset/old-shirts-tan.md
+++ b/.changeset/old-shirts-tan.md
@@ -2,4 +2,4 @@
 "react-email": patch
 ---
 
-fix(tailwind): parse non inline configuration variables
+Tailwind: parse non inline configuration variables

--- a/packages/ui/src/utils/caniemail/tailwind/get-tailwind-config.spec.ts
+++ b/packages/ui/src/utils/caniemail/tailwind/get-tailwind-config.spec.ts
@@ -41,6 +41,20 @@ describe('getTailwindConfig()', () => {
     });
   });
 
+  it('resolves the correct variable when the same name is shadowed in an inner scope', async () => {
+    const sourcePath = path.resolve(
+      __dirname,
+      './tests/dummy-email-template-shadowed-config.tsx',
+    );
+    const sourceCode = await fs.readFile(sourcePath, 'utf8');
+    const ast = parseSource(sourceCode);
+
+    expect(await getTailwindConfig(sourceCode, ast, sourcePath)).toEqual({
+      theme: {},
+      presets: [pixelBasedPreset],
+    });
+  });
+
   it('works with email templates that define an empty tailwind config inline as a variable', async () => {
     const sourcePath = path.resolve(
       __dirname,

--- a/packages/ui/src/utils/caniemail/tailwind/get-tailwind-config.spec.ts
+++ b/packages/ui/src/utils/caniemail/tailwind/get-tailwind-config.spec.ts
@@ -4,6 +4,14 @@ import { parse } from '@babel/parser';
 import { pixelBasedPreset } from 'react-email';
 import { getTailwindConfig } from './get-tailwind-config';
 
+const parseSource = (sourceCode: string) =>
+  parse(sourceCode, {
+    strictMode: false,
+    errorRecovery: true,
+    sourceType: 'unambiguous',
+    plugins: ['jsx', 'typescript', 'decorators'],
+  });
+
 describe('getTailwindConfig()', () => {
   it('works with email templates that import the tailwind config', async () => {
     const sourcePath = path.resolve(
@@ -11,16 +19,36 @@ describe('getTailwindConfig()', () => {
       './tests/dummy-email-template.tsx',
     );
     const sourceCode = await fs.readFile(sourcePath, 'utf8');
-    const ast = parse(sourceCode, {
-      strictMode: false,
-      errorRecovery: true,
-      sourceType: 'unambiguous',
-      plugins: ['jsx', 'typescript', 'decorators'],
-    });
+    const ast = parseSource(sourceCode);
 
     expect(await getTailwindConfig(sourceCode, ast, sourcePath)).toEqual({
       theme: {},
       presets: [pixelBasedPreset],
     });
+  });
+
+  it('works with email templates that define the tailwind config inline as a variable', async () => {
+    const sourcePath = path.resolve(
+      __dirname,
+      './tests/dummy-email-template-inline-config.tsx',
+    );
+    const sourceCode = await fs.readFile(sourcePath, 'utf8');
+    const ast = parseSource(sourceCode);
+
+    expect(await getTailwindConfig(sourceCode, ast, sourcePath)).toEqual({
+      theme: {},
+      presets: [pixelBasedPreset],
+    });
+  });
+
+  it('works with email templates that define an empty tailwind config inline as a variable', async () => {
+    const sourcePath = path.resolve(
+      __dirname,
+      './tests/dummy-email-template-empty-config.tsx',
+    );
+    const sourceCode = await fs.readFile(sourcePath, 'utf8');
+    const ast = parseSource(sourceCode);
+
+    expect(await getTailwindConfig(sourceCode, ast, sourcePath)).toEqual({});
   });
 });

--- a/packages/ui/src/utils/caniemail/tailwind/get-tailwind-config.spec.ts
+++ b/packages/ui/src/utils/caniemail/tailwind/get-tailwind-config.spec.ts
@@ -4,14 +4,6 @@ import { parse } from '@babel/parser';
 import { pixelBasedPreset } from 'react-email';
 import { getTailwindConfig } from './get-tailwind-config';
 
-const parseSource = (sourceCode: string) =>
-  parse(sourceCode, {
-    strictMode: false,
-    errorRecovery: true,
-    sourceType: 'unambiguous',
-    plugins: ['jsx', 'typescript', 'decorators'],
-  });
-
 describe('getTailwindConfig()', () => {
   it('works with email templates that import the tailwind config', async () => {
     const sourcePath = path.resolve(
@@ -19,7 +11,12 @@ describe('getTailwindConfig()', () => {
       './tests/dummy-email-template.tsx',
     );
     const sourceCode = await fs.readFile(sourcePath, 'utf8');
-    const ast = parseSource(sourceCode);
+    const ast = parse(sourceCode, {
+      strictMode: false,
+      errorRecovery: true,
+      sourceType: 'unambiguous',
+      plugins: ['jsx', 'typescript', 'decorators'],
+    });
 
     expect(await getTailwindConfig(sourceCode, ast, sourcePath)).toEqual({
       theme: {},
@@ -33,7 +30,12 @@ describe('getTailwindConfig()', () => {
       './tests/dummy-email-template-inline-config.tsx',
     );
     const sourceCode = await fs.readFile(sourcePath, 'utf8');
-    const ast = parseSource(sourceCode);
+    const ast = parse(sourceCode, {
+      strictMode: false,
+      errorRecovery: true,
+      sourceType: 'unambiguous',
+      plugins: ['jsx', 'typescript', 'decorators'],
+    });
 
     expect(await getTailwindConfig(sourceCode, ast, sourcePath)).toEqual({
       theme: {},
@@ -47,7 +49,12 @@ describe('getTailwindConfig()', () => {
       './tests/dummy-email-template-shadowed-config.tsx',
     );
     const sourceCode = await fs.readFile(sourcePath, 'utf8');
-    const ast = parseSource(sourceCode);
+    const ast = parse(sourceCode, {
+      strictMode: false,
+      errorRecovery: true,
+      sourceType: 'unambiguous',
+      plugins: ['jsx', 'typescript', 'decorators'],
+    });
 
     expect(await getTailwindConfig(sourceCode, ast, sourcePath)).toEqual({
       theme: {},
@@ -61,7 +68,12 @@ describe('getTailwindConfig()', () => {
       './tests/dummy-email-template-empty-config.tsx',
     );
     const sourceCode = await fs.readFile(sourcePath, 'utf8');
-    const ast = parseSource(sourceCode);
+    const ast = parse(sourceCode, {
+      strictMode: false,
+      errorRecovery: true,
+      sourceType: 'unambiguous',
+      plugins: ['jsx', 'typescript', 'decorators'],
+    });
 
     expect(await getTailwindConfig(sourceCode, ast, sourcePath)).toEqual({});
   });

--- a/packages/ui/src/utils/caniemail/tailwind/get-tailwind-config.ts
+++ b/packages/ui/src/utils/caniemail/tailwind/get-tailwind-config.ts
@@ -22,10 +22,22 @@ export const getTailwindConfig = async (
         ? configAttribute.value.expression
         : undefined;
     if (configExpressionValue?.start && configExpressionValue.end) {
-      const configSourceValue = sourceCode.slice(
+      let configSourceValue = sourceCode.slice(
         configExpressionValue.start,
         configExpressionValue.end,
       );
+
+      if (configExpressionValue.type === 'Identifier') {
+        const initSource = findVariableInitializer(
+          ast,
+          sourceCode,
+          (configExpressionValue as { name: string }).name,
+        );
+
+        if (initSource !== undefined) {
+          configSourceValue = initSource;
+        }
+      }
 
       try {
         return getConfigFromCode(
@@ -109,6 +121,34 @@ export { reactEmailTailwindConfigInternal };`,
       },
     },
   );
+};
+
+const findVariableInitializer = (
+  ast: AST,
+  sourceCode: string,
+  name: string,
+): string | undefined => {
+  let initSource: string | undefined;
+
+  traverse(ast, {
+    VariableDeclarator(nodePath) {
+      if (
+        nodePath.node.id.type === 'Identifier' &&
+        nodePath.node.id.name === name &&
+        nodePath.node.init != null &&
+        nodePath.node.init.start != null &&
+        nodePath.node.init.end != null
+      ) {
+        initSource = sourceCode.slice(
+          nodePath.node.init.start,
+          nodePath.node.init.end,
+        );
+        nodePath.stop();
+      }
+    },
+  });
+
+  return initSource;
 };
 
 type JSXAttribute = Node & { type: 'JSXAttribute' };

--- a/packages/ui/src/utils/caniemail/tailwind/get-tailwind-config.ts
+++ b/packages/ui/src/utils/caniemail/tailwind/get-tailwind-config.ts
@@ -31,7 +31,7 @@ export const getTailwindConfig = async (
         const initSource = findVariableInitializer(
           ast,
           sourceCode,
-          (configExpressionValue as { name: string }).name,
+          configExpressionValue.name,
         );
 
         if (initSource !== undefined) {
@@ -131,18 +131,18 @@ const findVariableInitializer = (
   let initSource: string | undefined;
 
   traverse(ast, {
-    VariableDeclarator(nodePath) {
+    JSXOpeningElement(nodePath) {
       if (
-        nodePath.node.id.type === 'Identifier' &&
-        nodePath.node.id.name === name &&
-        nodePath.node.init != null &&
-        nodePath.node.init.start != null &&
-        nodePath.node.init.end != null
+        nodePath.node.name.type === 'JSXIdentifier' &&
+        nodePath.node.name.name === 'Tailwind'
       ) {
-        initSource = sourceCode.slice(
-          nodePath.node.init.start,
-          nodePath.node.init.end,
-        );
+        const binding = nodePath.scope.getBinding(name);
+        if (binding?.path.isVariableDeclarator()) {
+          const { init } = binding.path.node;
+          if (init?.start != null && init.end != null) {
+            initSource = sourceCode.slice(init.start, init.end);
+          }
+        }
         nodePath.stop();
       }
     },

--- a/packages/ui/src/utils/caniemail/tailwind/tests/dummy-email-template-empty-config.tsx
+++ b/packages/ui/src/utils/caniemail/tailwind/tests/dummy-email-template-empty-config.tsx
@@ -1,0 +1,10 @@
+import { Tailwind } from 'react-email';
+
+export default function EmailTemplate() {
+  const config = {};
+  return (
+    <Tailwind config={config}>
+      <div className="bg-red-400 w-20" />
+    </Tailwind>
+  );
+}

--- a/packages/ui/src/utils/caniemail/tailwind/tests/dummy-email-template-inline-config.tsx
+++ b/packages/ui/src/utils/caniemail/tailwind/tests/dummy-email-template-inline-config.tsx
@@ -1,5 +1,4 @@
-import { pixelBasedPreset } from 'react-email';
-import { Tailwind } from 'react-email';
+import { pixelBasedPreset, Tailwind } from 'react-email';
 
 export default function EmailTemplate() {
   const config = {

--- a/packages/ui/src/utils/caniemail/tailwind/tests/dummy-email-template-inline-config.tsx
+++ b/packages/ui/src/utils/caniemail/tailwind/tests/dummy-email-template-inline-config.tsx
@@ -1,0 +1,14 @@
+import { pixelBasedPreset } from 'react-email';
+import { Tailwind } from 'react-email';
+
+export default function EmailTemplate() {
+  const config = {
+    theme: {},
+    presets: [pixelBasedPreset],
+  };
+  return (
+    <Tailwind config={config}>
+      <div className="bg-red-400 w-20" />
+    </Tailwind>
+  );
+}

--- a/packages/ui/src/utils/caniemail/tailwind/tests/dummy-email-template-shadowed-config.tsx
+++ b/packages/ui/src/utils/caniemail/tailwind/tests/dummy-email-template-shadowed-config.tsx
@@ -1,7 +1,6 @@
-import { pixelBasedPreset } from 'react-email';
-import { Tailwind } from 'react-email';
+import { pixelBasedPreset, Tailwind } from 'react-email';
 
-const config = { wrong: true };
+const _config = { wrong: true };
 
 export default function EmailTemplate() {
   const config = {

--- a/packages/ui/src/utils/caniemail/tailwind/tests/dummy-email-template-shadowed-config.tsx
+++ b/packages/ui/src/utils/caniemail/tailwind/tests/dummy-email-template-shadowed-config.tsx
@@ -1,0 +1,16 @@
+import { pixelBasedPreset } from 'react-email';
+import { Tailwind } from 'react-email';
+
+const config = { wrong: true };
+
+export default function EmailTemplate() {
+  const config = {
+    theme: {},
+    presets: [pixelBasedPreset],
+  };
+  return (
+    <Tailwind config={config}>
+      <div className="bg-red-400 w-20" />
+    </Tailwind>
+  );
+}

--- a/packages/ui/src/utils/caniemail/tailwind/tests/dummy-email-template-shadowed-config.tsx
+++ b/packages/ui/src/utils/caniemail/tailwind/tests/dummy-email-template-shadowed-config.tsx
@@ -1,6 +1,7 @@
 import { pixelBasedPreset, Tailwind } from 'react-email';
 
-const _config = { wrong: true };
+// biome-ignore lint/correctness/noUnusedVariables: intentional shadowing decoy
+const config = { wrong: true };
 
 export default function EmailTemplate() {
   const config = {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

## Description
getTailwindConfig only handled cases where the <Tailwind config={...}> prop was an inline object literal. If the config was stored in a variable (e.g., const config = { ... }; <Tailwind config={config} />), it failed to parse it.                                                                                              
                                                                                                                 
The Fix: When the config prop value is an Identifier (a variable reference), a new findVariableInitializer helper traverses the AST to locate that variable's declaration and extract its source code, then uses that as the config value.                                                                                                          
                                                                                                                 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Tailwind config parsing when the `config` prop uses a variable instead of an inline object. The compatibility check now resolves the variable initializer from the right scope (even with shadowed names), addressing DEV-361.

- **Bug Fixes**
  - Resolve `config` identifiers with scope-aware AST binding and extract the initializer source; keep parsing local (avoid shared helper).
  - Add tests for variable config, empty config, and shadowed `config` names; add `biome-ignore` to allow intentional shadowing in the fixture.

<sup>Written for commit 561fdc39b3fae7755dac24e0b5383fba81c7242f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

