### PR TITLE
chore(root): add MailerSend to integrations list in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Emails built with React Email can be converted into HTML and sent using any emai
 - [Resend](https://github.com/resend/react-email/tree/main/examples/resend)
 - [Nodemailer](https://github.com/resend/react-email/tree/main/examples/nodemailer)
 - [SendGrid](https://github.com/resend/react-email/tree/main/examples/sendgrid)
+- [MailerSend](https://github.com/resend/react-email/tree/main/examples/mailersend)
 - [Mailgun](https://github.com/resend/react-email/tree/main/examples/mailgun)
 - [Postmark](https://github.com/resend/react-email/tree/main/examples/postmark)
 - [AWS SES](https://github.com/resend/react-email/tree/main/examples/aws-ses)


### PR DESCRIPTION
The mailersend example exists under examples/mailersend but was missing from the Integrations list in the root README.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MailerSend to the Integrations list in the root README to match the existing `examples/mailersend`. Ensures the docs are consistent and helps users find the MailerSend example.

<sup>Written for commit 3c35b01598b18b67bf3564c972573dca2dbb53d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

