### PR TITLE
fix(docs): remove stray + chars in inbound integration frontmatter

### DIFF
--- a/apps/docs/integrations/inbound.mdx
+++ b/apps/docs/integrations/inbound.mdx
@@ -1,7 +1,7 @@
 ---
-+title: 'Send (& receive) emails using Inbound'
+title: 'Send (& receive) emails using Inbound'
 sidebarTitle: 'Inbound'
-+description: 'Learn how to send and receive emails using React Email and the Inbound Node.js SDK.'
+description: 'Learn how to send and receive emails using React Email and the Inbound Node.js SDK.'
 'og:image': 'https://react.email/static/covers/react-email.png'
 ---
 


### PR DESCRIPTION
The title and description keys in the YAML frontmatter were prefixed with `+` (leftover diff markers from a previous patch), making them `+title` and `+description`. The docs site can't pick those up, leaving the page without a proper title or description.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored the Inbound integration docs title and description by fixing the YAML frontmatter. Removed stray `+` prefixes from the `title` and `description` keys in `apps/docs/integrations/inbound.mdx` so the page metadata renders correctly.

<sup>Written for commit bbcb9e4e827653b8c9d67de06947fa47b1482c00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

