### PR TITLE
fix(ci): bump workflow closing existing PRs

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -31,11 +31,16 @@ jobs:
         uses: pnpm/action-setup@738f428026a1f5a72398de22aeed83d859c4a660
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Configure version bump git user
+        run: |
+          git config user.name "resend-version-bump[bot]"
+          git config user.email "277115511+resend-version-bump[bot]@users.noreply.github.com"
       - name: Create "version packages" pull request
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf
         with:
           version: pnpm run version
           title: "chore(root): version packages"
-          commitMode: github-api
+          commitMode: git-cli
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the version bump workflow that was closing existing PRs by switching `changesets/action` to `git-cli` commits and manually configuring the `resend-version-bump[bot]` git user (`setupGitUser: false`).

<sup>Written for commit 21aadf7183afc11f97e9195546349a963b3176b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

