### PR TITLE
fix(react-email): dividers with extra borders around it

### DIFF
--- a/.changeset/angry-tips-serve.md
+++ b/.changeset/angry-tips-serve.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+fix divider with extra borders around other corners

--- a/packages/editor/src/extensions/__snapshots__/divider.spec.tsx.snap
+++ b/packages/editor/src/extensions/__snapshots__/divider.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`Divider Node > renders React Email properly 1`] = `
 <!--$-->
 <hr
   class="divider"
-  style="width:100%;border:none;border-top:1px solid #eaeaea;padding-bottom:1em;border-width:2px" />
+  style="width:100%;border:none;border-color:transparent;border-top:1px solid #eaeaea;padding-bottom:1em;border-width:2px" />
 <!--/$-->
 "
 `;

--- a/packages/react-email/src/cli/commands/testing/export.spec.ts
+++ b/packages/react-email/src/cli/commands/testing/export.spec.ts
@@ -186,7 +186,7 @@ test('email export', { retry: 3 }, async () => {
                             target="_blank"></a>
                         </p>
                         <hr
-                          style="width:100%;border:none;border-top:1px solid #eaeaea;margin-right:0;margin-left:0;margin-bottom:26px;margin-top:26px;border-style:solid;border-width:1px;border-color:rgb(234,234,234)" />
+                          style="width:100%;border:none;border-color:rgb(234,234,234);border-top:1px solid #eaeaea;margin-right:0;margin-left:0;margin-bottom:26px;margin-top:26px;border-style:solid;border-width:1px" />
                         <p
                           style="font-size:12px;line-height:24px;color:rgb(102,102,102);margin-top:16px;margin-bottom:16px">
                           This invitation was intended for<!-- -->

--- a/packages/react-email/src/components/hr/hr.spec.tsx
+++ b/packages/react-email/src/components/hr/hr.spec.tsx
@@ -16,7 +16,7 @@ describe('<Hr> component', () => {
   it('renders correctly', async () => {
     const actualOutput = await render(<Hr />);
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><hr style="width:100%;border:none;border-top:1px solid #eaeaea"/><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><hr style="width:100%;border:none;border-color:transparent;border-top:1px solid #eaeaea"/><!--/$-->"`,
     );
   });
 });

--- a/packages/react-email/src/components/hr/hr.tsx
+++ b/packages/react-email/src/components/hr/hr.tsx
@@ -10,6 +10,7 @@ export const Hr = React.forwardRef<HTMLHRElement, HrProps>(
       style={{
         width: '100%',
         border: 'none',
+        borderColor: 'transparent',
         borderTop: '1px solid #eaeaea',
         ...style,
       }}

--- a/packages/react-email/src/components/tailwind/tailwind.spec.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.spec.tsx
@@ -330,7 +330,7 @@ describe('Tailwind component', () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><hr style="width:3rem;border:none;border-top:1px solid #eaeaea"/><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><hr style="width:3rem;border:none;border-color:transparent;border-top:1px solid #eaeaea"/><!--/$-->"`,
     );
   });
 

--- a/packages/ui/src/utils/get-email-component.spec.ts
+++ b/packages/ui/src/utils/get-email-component.spec.ts
@@ -203,7 +203,7 @@ describe('getEmailComponent()', () => {
                               >
                             </p>
                             <hr
-                              style="width:100%;border:none;border-top:1px solid #eaeaea;margin-right:0;margin-left:0;margin-bottom:26px;margin-top:26px;border-style:solid;border-width:1px;border-color:rgb(234,234,234)" />
+                              style="width:100%;border:none;border-color:rgb(234,234,234);border-top:1px solid #eaeaea;margin-right:0;margin-left:0;margin-bottom:26px;margin-top:26px;border-style:solid;border-width:1px" />
                             <p
                               style="font-size:12px;line-height:24px;color:rgb(102,102,102);margin-top:16px;margin-bottom:16px">
                               This invitation was intended for<!-- -->


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes extra borders around `Hr` dividers in `react-email` so only the top border shows, and updates related tests/snapshots. Adds `borderColor: 'transparent'` alongside `border: 'none'` for consistent rendering across email clients.

<sup>Written for commit 9f43d4574f7701165cb3a8949081a014ac9536b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

