### PR TITLE
fix(editor): hr border width

### DIFF
--- a/.changeset/petite-teeth-tap.md
+++ b/.changeset/petite-teeth-tap.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+reset styles for divider

--- a/packages/editor/src/plugins/email-theming/themes.ts
+++ b/packages/editor/src/plugins/email-theming/themes.ts
@@ -735,7 +735,8 @@ const RESET_BASIC: ResetTheme = {
   hr: {
     paddingBottom: '1em',
     borderStyle: 'solid',
-    borderWidth: '2px',
+    borderWidth: 0,
+    borderTopWidth: '2px',
   },
   image: {
     maxWidth: '100%',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Resets the divider (`<hr>`) styles in `@react-email/editor` so only a 2px top border renders, preventing side/bottom borders and ensuring a consistent divider.

<sup>Written for commit 3fb8e971ff86ad0bd8f65903e564ddecb65b9d9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

