### PR TITLE
fix(topbar): handle GitHub API failure in getRepoStarCount

### DIFF
--- a/apps/web/src/components/topbar.tsx
+++ b/apps/web/src/components/topbar.tsx
@@ -5,15 +5,26 @@ import { Logo } from './logo';
 import { Menu } from './menu';
 
 async function getRepoStarCount() {
-  const res = await fetch('https://api.github.com/repos/resend/react-email', {
-    next: { revalidate: 3600, tags: ['github-repo-stars'] },
-  });
-  const data = await res.json();
-  const starCount = data.stargazers_count as number;
-  if (starCount > 999) {
-    return `${(starCount / 1000).toFixed(1)}K`;
+  try {
+    const res = await fetch('https://api.github.com/repos/resend/react-email', {
+      next: { revalidate: 3600, tags: ['github-repo-stars'] },
+    });
+
+    // Return fallback if GitHub API is down or rate-limited
+    if (!res.ok) return '—';
+
+    const data = await res.json();
+    const starCount = data.stargazers_count as number;
+
+    // Guard against undefined/NaN if API response shape changes
+    if (typeof starCount !== 'number' || Number.isNaN(starCount)) return '—';
+
+    if (starCount > 999) return `${(starCount / 1000).toFixed(1)}K`;
+    return `${starCount}`;
+  } catch {
+    // Network failure or JSON parse error — fail silently
+    return '—';
   }
-  return `${starCount}`;
 }
 
 export async function Topbar({

--- a/apps/web/src/components/topbar.tsx
+++ b/apps/web/src/components/topbar.tsx
@@ -25,7 +25,7 @@ async function getRepoStarCount() {
 
     return `${starCount}`;
   } catch {
-    // Network failure or JSON parse error — fail silently
+    // Network failure or JSON  parse error — fail silently
     return null;
   }
 }

--- a/apps/web/src/components/topbar.tsx
+++ b/apps/web/src/components/topbar.tsx
@@ -10,20 +10,23 @@ async function getRepoStarCount() {
       next: { revalidate: 3600, tags: ['github-repo-stars'] },
     });
 
-    // Return fallback if GitHub API is down or rate-limited
-    if (!res.ok) return '—';
+    // Avoid caching transient GitHub failures as valid fallback data
+    if (!res.ok) return null;
 
     const data = await res.json();
     const starCount = data.stargazers_count as number;
 
     // Guard against undefined/NaN if API response shape changes
-    if (typeof starCount !== 'number' || Number.isNaN(starCount)) return '—';
+    if (typeof starCount !== 'number' || Number.isNaN(starCount)) {
+      return null;
+    }
 
     if (starCount > 999) return `${(starCount / 1000).toFixed(1)}K`;
+
     return `${starCount}`;
   } catch {
     // Network failure or JSON parse error — fail silently
-    return '—';
+    return null;
   }
 }
 
@@ -48,7 +51,7 @@ export async function Topbar({
         <Logo />
         <span className="sr-only">Home</span>
       </Link>
-      <Menu starCount={starCount} />
+      <Menu starCount={starCount ?? '—'} />
     </header>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Adds error handling to the `getRepoStarCount` function in `topbar.tsx`.

Previously, if the GitHub API was down, rate-limited, or returned an 
unexpected response shape, the star count could display `NaN` or cause 
an unhandled error.

## Changes

- Return `'—'` fallback when `res.ok` is false (rate limit / downtime)
- Guard against `undefined`/`NaN` using `typeof` check instead of falsy check
- Catch network failures and JSON parse errors silently

## Before / After

**Before:** Star count shows `NaN` or crashes when GitHub API fails  
**After:** Star count shows `—` gracefully when GitHub API is unavailable

## Checklist

- [x] No breaking changes
- [x] No new dependencies added
- [x] Tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle GitHub API failures in the Topbar repo star count and avoid caching transient errors. `getRepoStarCount` now returns null for non-OK/invalid responses or parse failures, and the UI renders '—', preventing crashes or "NaN" while keeping the cache clean.

<sup>Written for commit a7ca384bc3523427636c23dbb0316b6e955a8e62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

