### PR TITLE
fix(ui): fs warnings on every fs import

### DIFF
--- a/.changeset/shaky-bushes-flow.md
+++ b/.changeset/shaky-bushes-flow.md
@@ -1,0 +1,5 @@
+---
+"@react-email/ui": patch
+---
+
+fix fs constants warnings on every fs warning

--- a/packages/ui/src/utils/run-bundled-code.spec.ts
+++ b/packages/ui/src/utils/run-bundled-code.spec.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { vi } from 'vitest';
 import { z } from 'zod';
 import { isErr, isOk } from './result';
 import { runBundledCode } from './run-bundled-code';
@@ -68,6 +69,46 @@ export default path.join('a', 'b', 'c');
       return;
     }
     expect(result.value).toEqual({ default: path.join('a', 'b', 'c') });
+  });
+
+  it('does not emit fs access mode deprecation warnings for regular node:fs imports', async () => {
+    const emitWarning = vi.spyOn(process, 'emitWarning');
+
+    try {
+      const result = await runBundledCode(
+        `
+import { readFileSync } from 'node:fs';
+
+export default typeof readFileSync;
+    `,
+        'test-fs.js',
+      );
+      if (!isOk(result)) {
+        expect(isOk(result), 'there should be no errors').toBe(true);
+        console.log(result.error);
+        return;
+      }
+
+      const hasDeprecatedAccessModeWarning = emitWarning.mock.calls.some(
+        ([, optionsOrType, code]) => {
+          if (code === 'DEP0176') {
+            return true;
+          }
+
+          return (
+            typeof optionsOrType === 'object' &&
+            optionsOrType !== null &&
+            'code' in optionsOrType &&
+            optionsOrType.code === 'DEP0176'
+          );
+        },
+      );
+
+      expect(result.value).toEqual({ default: 'function' });
+      expect(hasDeprecatedAccessModeWarning).toBe(false);
+    } finally {
+      emitWarning.mockRestore();
+    }
   });
 
   it('returns an error if the code throws', async () => {

--- a/packages/ui/src/utils/run-bundled-code.ts
+++ b/packages/ui/src/utils/run-bundled-code.ts
@@ -1,7 +1,10 @@
 import path from 'node:path';
 import vm from 'node:vm';
 import { err, ok, type Result } from './result';
-import { staticNodeModulesForVM } from './static-node-modules-for-vm';
+import {
+  deprecatedKeysByModule,
+  staticNodeModulesForVM,
+} from './static-node-modules-for-vm';
 
 export function createContext(
   filename: string,
@@ -117,8 +120,10 @@ export async function runBundledCode(
 
       if (m in staticNodeModulesForVM) {
         const moduleExports = staticNodeModulesForVM[m];
+        const deprecatedKeys = deprecatedKeysByModule[m];
         const exportKeys = Reflect.ownKeys(moduleExports).filter(
-          (key) => typeof key === 'string',
+          (key) =>
+            typeof key === 'string' && !(deprecatedKeys?.has(key) ?? false),
         ) as string[];
 
         const syntheticModule = new vm.SyntheticModule(

--- a/packages/ui/src/utils/static-node-modules-for-vm.ts
+++ b/packages/ui/src/utils/static-node-modules-for-vm.ts
@@ -43,6 +43,20 @@ import zlib from 'node:zlib';
 import punycode from 'module-punycode';
 
 /**
+ * Keys that should not be enumerated as named exports on the synthetic
+ * modules we build for the VM. Reading them triggers a Node deprecation
+ * warning even when user code never references them (e.g. `fs.F_OK`
+ * triggers DEP0176 just by enumerating the `fs` module's keys).
+ *
+ * The values are still reachable through the default export, so user
+ * code that explicitly opts into the deprecated API still works (and
+ * still gets the warning at the actual call site, where it belongs).
+ */
+export const deprecatedKeysByModule: Record<string, ReadonlySet<string>> = {
+  fs: new Set(['F_OK', 'R_OK', 'W_OK', 'X_OK']),
+};
+
+/**
  * A map of the name of the modules (including `node:` prefixed ones)
  * provided by Node because dynamic requires of them, even on the server
  * will not be resolved properly


### PR DESCRIPTION
Closes DEV-382

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops noisy Node deprecation warnings (DEP0176) from firing on every `node:fs` import by adjusting how the VM exposes `fs` exports. Deprecated access mode constants are no longer enumerated, preventing warnings without breaking existing code.

- **Bug Fixes**
  - Exclude deprecated `fs` constants (`F_OK`, `R_OK`, `W_OK`, `X_OK`) from named exports in `runBundledCode`, avoiding DEP0176.
  - Keep constants available via the default `fs` export; behavior remains the same for users.
  - Add a regression test to ensure no warnings on regular `node:fs` imports; publish patch for `@react-email/ui`.

<sup>Written for commit 251c12be671a98b5e111615fc70e4f6ff9a0f9c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

