### PR TITLE
feat(column): support column deletion

### DIFF
--- a/.changeset/red-maps-yawn.md
+++ b/.changeset/red-maps-yawn.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": minor
+---
+
+Enable single columns deletion, and columns focus improvements.

--- a/packages/editor/src/extensions/columns.spec.tsx
+++ b/packages/editor/src/extensions/columns.spec.tsx
@@ -1,3 +1,4 @@
+import { Editor, type JSONContent } from '@tiptap/core';
 import { render } from 'react-email';
 import { DEFAULT_STYLES } from '../utils/default-styles';
 import {
@@ -6,6 +7,7 @@ import {
   ThreeColumns,
   TwoColumns,
 } from './columns';
+import { StarterKit } from './index';
 
 const columnsStyle = { ...DEFAULT_STYLES.reset };
 
@@ -238,5 +240,201 @@ describe('Column Variants', () => {
         { pretty: true },
       ),
     ).toMatchSnapshot();
+  });
+});
+
+describe('Column Deletion', () => {
+  const emptyCol = { type: 'columnsColumn', content: [{ type: 'paragraph' }] };
+
+  function createColumnEditor(content: JSONContent) {
+    const element = document.createElement('div');
+    document.body.append(element);
+    return new Editor({
+      element,
+      extensions: [
+        StarterKit.configure({ Container: false, TrailingNode: false }),
+      ],
+      content,
+    });
+  }
+
+  function findColDepth(
+    $from: ReturnType<typeof Editor.prototype.state.selection.$from>,
+  ): number | undefined {
+    for (let d = $from.depth; d >= 0; d--) {
+      if ($from.node(d).type.name === 'columnsColumn') return d;
+    }
+    return undefined;
+  }
+
+  // editor.commands.keyboardShortcut() uses captureTransaction + step replay,
+  // which discards the setSelection call. Calling handleKeyDown directly ensures
+  // our custom dispatch (including selection) takes effect as-is.
+  function pressBackspace(editor: Editor): void {
+    const event = new KeyboardEvent('keydown', {
+      key: 'Backspace',
+      bubbles: true,
+      cancelable: true,
+    });
+    editor.view.someProp('handleKeyDown', (f) => f(editor.view, event));
+  }
+
+  it('insertColumns focuses the first column', () => {
+    for (const count of [2, 3, 4] as const) {
+      const editor = createColumnEditor({
+        type: 'doc',
+        content: [{ type: 'paragraph' }],
+      });
+      editor.commands.insertColumns(count);
+      const { $from } = editor.state.selection;
+      const colDepth = findColDepth($from);
+      expect(
+        colDepth,
+        `count=${count}: cursor not inside a columnsColumn`,
+      ).toBeDefined();
+      expect(
+        $from.index(colDepth! - 1),
+        `count=${count}: cursor not in first column`,
+      ).toBe(0);
+      editor.destroy();
+    }
+  });
+
+  it('backspace on empty second column of twoColumns unwraps to paragraph', () => {
+    const editor = createColumnEditor({
+      type: 'doc',
+      content: [{ type: 'twoColumns', content: [emptyCol, emptyCol] }],
+    });
+    editor.commands.setTextSelection(7);
+    pressBackspace(editor);
+    const json = editor.getJSON();
+    expect(json.content?.find((n) => n.type === 'twoColumns')).toBeUndefined();
+    expect(json.content?.[0].type).toBe('paragraph');
+    editor.destroy();
+  });
+
+  it('backspace on empty third column of threeColumns reduces to twoColumns', () => {
+    const editor = createColumnEditor({
+      type: 'doc',
+      content: [
+        { type: 'threeColumns', content: [emptyCol, emptyCol, emptyCol] },
+      ],
+    });
+    editor.commands.setTextSelection(11);
+    pressBackspace(editor);
+    const json = editor.getJSON();
+    expect(json.content?.[0].type).toBe('twoColumns');
+    expect(json.content?.[0].content).toHaveLength(2);
+    editor.destroy();
+  });
+
+  it('backspace on empty fourth column of fourColumns reduces to threeColumns', () => {
+    const editor = createColumnEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'fourColumns',
+          content: [emptyCol, emptyCol, emptyCol, emptyCol],
+        },
+      ],
+    });
+    editor.commands.setTextSelection(15);
+    pressBackspace(editor);
+    const json = editor.getJSON();
+    expect(json.content?.[0].type).toBe('threeColumns');
+    expect(json.content?.[0].content).toHaveLength(3);
+    editor.destroy();
+  });
+
+  it('backspace does not delete a non-empty column', () => {
+    const editor = createColumnEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'twoColumns',
+          content: [
+            emptyCol,
+            {
+              type: 'columnsColumn',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'hello' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    editor.commands.setTextSelection(7);
+    pressBackspace(editor);
+    expect(editor.getJSON().content?.[0].type).toBe('twoColumns');
+    editor.destroy();
+  });
+
+  it('focuses the previous column after deleting the last column', () => {
+    const editor = createColumnEditor({
+      type: 'doc',
+      content: [
+        { type: 'threeColumns', content: [emptyCol, emptyCol, emptyCol] },
+      ],
+    });
+    editor.commands.setTextSelection(11);
+    pressBackspace(editor);
+    const { $from } = editor.state.selection;
+    const colDepth = findColDepth($from);
+    expect(
+      colDepth,
+      'cursor not inside a columnsColumn after deletion',
+    ).toBeDefined();
+    expect($from.index(colDepth! - 1)).toBe(1);
+    editor.destroy();
+  });
+
+  it('focuses the first column after deleting the first empty column', () => {
+    const editor = createColumnEditor({
+      type: 'doc',
+      content: [
+        { type: 'threeColumns', content: [emptyCol, emptyCol, emptyCol] },
+      ],
+    });
+    // Find the cursor position inside col1 dynamically from the doc
+    let col1CursorPos = -1;
+    editor.state.doc.descendants((node, pos) => {
+      if (col1CursorPos !== -1) return false;
+      if (node.type.name === 'columnsColumn') {
+        col1CursorPos = pos + 2; // inside columnsColumn's first paragraph
+        return false;
+      }
+      return true;
+    });
+    editor.commands.setTextSelection(col1CursorPos);
+    pressBackspace(editor);
+    const { $from } = editor.state.selection;
+    const colDepth = findColDepth($from);
+    expect(
+      colDepth,
+      'cursor not inside a columnsColumn after deletion',
+    ).toBeDefined();
+    expect($from.index(colDepth! - 1)).toBe(0);
+    editor.destroy();
+  });
+
+  it('backspace with NodeSelection on all-empty column block deletes it', () => {
+    const editor = createColumnEditor({
+      type: 'doc',
+      content: [
+        { type: 'paragraph' },
+        { type: 'twoColumns', content: [emptyCol, emptyCol] },
+      ],
+    });
+    // paragraph nodeSize=2, so twoColumns starts at pos 2
+    editor.commands.setNodeSelection(2);
+    pressBackspace(editor);
+    expect(
+      editor.getJSON().content?.find((n) => n.type === 'twoColumns'),
+    ).toBeUndefined();
+    editor.destroy();
   });
 });

--- a/packages/editor/src/extensions/columns.tsx
+++ b/packages/editor/src/extensions/columns.tsx
@@ -1,6 +1,11 @@
-import { type CommandProps, mergeAttributes } from '@tiptap/core';
-import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
-import { TextSelection } from '@tiptap/pm/state';
+import { type CommandProps, type Editor, mergeAttributes } from '@tiptap/core';
+import type { Node as ProseMirrorNode, ResolvedPos } from '@tiptap/pm/model';
+import {
+  type EditorState,
+  NodeSelection,
+  TextSelection,
+  type Transaction,
+} from '@tiptap/pm/state';
 import { Column, Row } from 'react-email';
 import { EmailNode } from '../core/serializer/email-node';
 import {
@@ -125,6 +130,176 @@ const NODE_TYPE_MAP: Record<number, (typeof COLUMN_PARENT_TYPES)[number]> = {
   4: 'fourColumns',
 };
 
+function isColumnEmpty(col: ProseMirrorNode): boolean {
+  return (
+    col.childCount === 1 &&
+    col.firstChild?.type.name === 'paragraph' &&
+    col.firstChild?.childCount === 0
+  );
+}
+
+function deleteColumnParent(
+  editor: Editor,
+  state: EditorState,
+  from: number,
+  to: number,
+  parentChildCount: number,
+): boolean {
+  const tr = state.tr;
+  if (parentChildCount === 1) {
+    tr.replaceWith(from, to, state.schema.nodes.paragraph.create());
+  } else {
+    tr.delete(from, to);
+  }
+  tr.setSelection(TextSelection.near(tr.doc.resolve(from)));
+  editor.view.dispatch(tr);
+  return true;
+}
+
+function handleNodeSelectionBackspace(
+  editor: Editor,
+  selection: EditorState['selection'],
+  $from: ResolvedPos,
+  state: EditorState,
+): boolean {
+  if (!(selection instanceof NodeSelection)) return false;
+  if (!COLUMN_PARENT_SET.has(selection.node.type.name)) return false;
+
+  const allColumnsEmpty = Array.from(
+    { length: selection.node.childCount },
+    (_, i) => selection.node.child(i),
+  ).every(isColumnEmpty);
+
+  if (!allColumnsEmpty) return false;
+
+  const parent = $from.node($from.depth);
+  return deleteColumnParent(
+    editor,
+    state,
+    selection.from,
+    selection.to,
+    parent.childCount,
+  );
+}
+
+function handleCursorBackspace(
+  editor: Editor,
+  $from: ResolvedPos,
+  state: EditorState,
+): boolean {
+  for (let depth = $from.depth; depth >= 1; depth--) {
+    const currentNode = $from.node(depth);
+
+    if (currentNode.type.name === 'columnsColumn') {
+      return handleBackspaceInsideColumn(editor, $from, state, depth);
+    }
+
+    const indexInParent = $from.index(depth - 1);
+
+    if (indexInParent === 0) continue;
+
+    const parent = $from.node(depth - 1);
+    const prevNode = parent.child(indexInParent - 1);
+
+    if (COLUMN_PARENT_SET.has(prevNode.type.name)) {
+      const from = $from.before(depth) - prevNode.nodeSize;
+      const to = $from.before(depth);
+      editor.view.dispatch(state.tr.delete(from, to));
+      return true;
+    }
+
+    break;
+  }
+
+  return false;
+}
+
+function handleBackspaceInsideColumn(
+  editor: Editor,
+  $from: ResolvedPos,
+  state: EditorState,
+  depth: number,
+): boolean {
+  const column = $from.node(depth);
+  const columnParent = $from.node(depth - 1);
+
+  if (!COLUMN_PARENT_SET.has(columnParent.type.name)) return false;
+  if (!isColumnEmpty(column)) return false;
+
+  const deletedIndex = $from.index(depth - 1);
+  const remainingColumns = Array.from(
+    { length: columnParent.childCount },
+    (_, i) => columnParent.child(i),
+  ).filter((_, i) => i !== deletedIndex);
+
+  const columnParentFrom = $from.before(depth - 1);
+  const columnParentTo = $from.after(depth - 1);
+  const tr = state.tr;
+  const deletingFirstColumn = deletedIndex === 0;
+  const focusIndex = deletingFirstColumn ? 0 : deletedIndex - 1;
+  const direction = deletingFirstColumn ? 'right' : 'left';
+
+  if (remainingColumns.length === 1) {
+    // 2 → 1: replace the column layout with the surviving column's content
+    const survivingContent = Array.from(
+      { length: remainingColumns[0].childCount },
+      (_, i) => remainingColumns[0].child(i),
+    );
+    const replacement =
+      survivingContent.length > 0
+        ? survivingContent
+        : [state.schema.nodes.paragraph.create()];
+    tr.replaceWith(columnParentFrom, columnParentTo, replacement);
+    const totalReplacementSize = replacement.reduce(
+      (sum, n) => sum + n.nodeSize,
+      0,
+    );
+    const cursorPos = deletingFirstColumn
+      ? columnParentFrom + 1
+      : columnParentFrom + totalReplacementSize;
+    tr.setSelection(
+      TextSelection.near(
+        tr.doc.resolve(cursorPos),
+        direction === 'right' ? 1 : -1,
+      ),
+    );
+  } else {
+    // 3 → 2 or 4 → 3: convert to the smaller column layout
+    const smallerLayoutType =
+      state.schema.nodes[NODE_TYPE_MAP[remainingColumns.length]];
+    tr.replaceWith(
+      columnParentFrom,
+      columnParentTo,
+      smallerLayoutType.create(columnParent.attrs, remainingColumns),
+    );
+    focusColumn(tr, columnParentFrom, remainingColumns, focusIndex, direction);
+  }
+
+  editor.view.dispatch(tr);
+  return true;
+}
+
+function focusColumn(
+  tr: Transaction,
+  columnParentPos: number,
+  columns: ProseMirrorNode[],
+  index: number,
+  direction: 'left' | 'right' = 'right',
+): void {
+  let pos = columnParentPos + 1;
+  for (let i = 0; i < index; i++) {
+    pos += columns[i].nodeSize;
+  }
+  pos += 1;
+
+  if (direction === 'left') {
+    pos += columns[index].content.size;
+  }
+
+  const bias = direction === 'right' ? 1 : -1;
+  tr.setSelection(TextSelection.near(tr.doc.resolve(pos), bias));
+}
+
 function createColumnsNode(
   config: ColumnsVariantConfig,
   includeCommands: boolean,
@@ -174,27 +349,38 @@ function createColumnsNode(
         return {
           insertColumns:
             (count: 2 | 3 | 4) =>
-            ({
-              commands,
-              state,
-            }: CommandProps & {
-              state: { doc: ProseMirrorNode; selection: { from: number } };
-            }) => {
-              if (
+            ({ state, dispatch }: CommandProps) => {
+              const tooDeep =
                 getColumnsDepth(state.doc, state.selection.from) >=
-                MAX_COLUMNS_DEPTH
-              ) {
-                return false;
+                MAX_COLUMNS_DEPTH;
+              if (tooDeep) return false;
+
+              const emptyColumn = () =>
+                state.schema.nodes.columnsColumn.create(
+                  null,
+                  state.schema.nodes.paragraph.create(),
+                );
+
+              const columnBlock = state.schema.nodes[
+                NODE_TYPE_MAP[count]
+              ].create(null, Array.from({ length: count }, emptyColumn));
+
+              const tr = state.tr.replaceSelectionWith(columnBlock);
+
+              // Find the inserted column block and focus its first column
+              const $head = tr.selection.$head;
+              for (let d = $head.depth; d >= 0; d--) {
+                if (!COLUMN_PARENT_SET.has($head.node(d).type.name)) continue;
+                const insertedColumns = Array.from(
+                  { length: $head.node(d).childCount },
+                  (_, i) => $head.node(d).child(i),
+                );
+                focusColumn(tr, $head.before(d), insertedColumns, 0);
+                break;
               }
-              const nodeType = NODE_TYPE_MAP[count];
-              const children = Array.from({ length: count }, () => ({
-                type: 'columnsColumn',
-                content: [{ type: 'paragraph', content: [] }],
-              }));
-              return commands.insertContent({
-                type: nodeType,
-                content: children,
-              });
+
+              if (dispatch) dispatch(tr);
+              return true;
             },
         };
       },
@@ -258,29 +444,13 @@ export const ColumnsColumn = EmailNode.create({
         const { selection } = state;
         const { empty, $from } = selection;
 
-        if (!empty) return false;
-
-        for (let depth = $from.depth; depth >= 1; depth--) {
-          if ($from.pos !== $from.start(depth)) break;
-
-          const indexInParent = $from.index(depth - 1);
-
-          if (indexInParent === 0) continue;
-
-          const parent = $from.node(depth - 1);
-          const prevNode = parent.child(indexInParent - 1);
-
-          if (COLUMN_PARENT_SET.has(prevNode.type.name)) {
-            const deleteFrom = $from.before(depth) - prevNode.nodeSize;
-            const deleteTo = $from.before(depth);
-            editor.view.dispatch(state.tr.delete(deleteFrom, deleteTo));
-            return true;
-          }
-
-          break;
+        if (!empty) {
+          return handleNodeSelectionBackspace(editor, selection, $from, state);
         }
 
-        return false;
+        if ($from.parentOffset !== 0) return false;
+
+        return handleCursorBackspace(editor, $from, state);
       },
       'Mod-a': ({ editor }) => {
         const { state } = editor;


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

### Description
This PR enables column deletion, preivoulsy it was not possible, just delete the whole block. Now we let users delete a single column, this opens a list of edge cases that are also handled in this PR as following:

Inside a column (cursor at start of an empty column)                      
  - 4 columns → press Backspace → reduces to 3 columns, cursor goes to      
  previous column                                                           
  - 3 columns → press Backspace → reduces to 2 columns, cursor goes to      
  previous column                                                           
  - 2 columns → press Backspace → unwraps entirely to plain text, cursor    
  stays in surviving content                                                
  - Deleting the first column → cursor moves to the new first column (was   
  col 2)                                                                    
  - Column has content → Backspace does nothing (column is preserved)       
                                                                            
  NodeSelection on a column block (whole block selected)
  - All columns are empty → Backspace deletes the entire block              
  - Any column has content → Backspace does nothing           
                                                                            
  Cursor positioned right after a column block                              
  - Pressing Backspace from the start of the next node deletes the entire   
  column block                                                              
                                                                          
  Inserting columns                                                         
  - After inserting a 2, 3, or 4 column layout, cursor is placed in the     
  first column (not the last)
  
And this is how it looks now:
Editor example:  https://www.loom.com/share/7ac4a536d72d48ce92c0e455c9c7ca5b
Resend's editor: https://www.loom.com/share/55299cea76454da2982808f2638528d2



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable single-column deletion and improve cursor focus in column layouts. Backspace now removes empty columns, collapses layouts correctly, and places the cursor predictably, addressing DEV-572.

- **New Features**
  - Backspace on an empty column deletes it; non‑empty columns are preserved.
  - Layout collapse: 4→3, 3→2, 2→unwraps to plain content with the cursor in the surviving content.
  - Focus: moves to the previous column; deleting the first column focuses the new first; inserting 2/3/4 columns focuses the first column.

- **Bug Fixes**
  - DEV-572: Deleting inside an empty column now works as expected.
  - NodeSelection on an all‑empty column block deletes the block; any non‑empty column prevents deletion.
  - Backspace at the start of the node after a column block deletes that block.
  - Added tests for deletion, collapse, and focus.

<sup>Written for commit 52d6c2aa63854b4df3bce0cd6b517815a5571513. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



