### PR TITLE
feat(editor): add calendar invite slash command plugin

### DIFF
--- a/packages/editor/src/core/event-bus.ts
+++ b/packages/editor/src/core/event-bus.ts
@@ -18,6 +18,7 @@ const EVENT_PREFIX = '@react-email/editor:';
 export interface EditorEventMap {
   'bubble-menu:add-link': undefined;
   'node-clicked': NodeClickedEvent;
+  'calendar-invite:open': { range: { from: number; to: number } };
 }
 
 export type NodeClickedEvent = {

--- a/packages/editor/src/core/event-bus.ts
+++ b/packages/editor/src/core/event-bus.ts
@@ -18,7 +18,7 @@ const EVENT_PREFIX = '@react-email/editor:';
 export interface EditorEventMap {
   'bubble-menu:add-link': undefined;
   'node-clicked': NodeClickedEvent;
-  'calendar-invite:open': { range: { from: number; to: number } };
+  'calendar-invite:open': { range: { from: number; to: number }; editorRef: object };
 }
 
 export type NodeClickedEvent = {

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -17,13 +17,17 @@ import {
 import { createPasteHandler } from '../core/create-paste-handler';
 import { composeReactEmail } from '../core/serializer/compose-react-email';
 import { StarterKit } from '../extensions';
+import { CalendarInvite, CalendarInvitePlugin, calendarInviteSlashCommand, type CalendarPluginOptions } from '../plugins/calendar-invite';
 import { EmailTheming } from '../plugins/email-theming/extension';
 import type { EditorThemeInput } from '../plugins/email-theming/types';
 import { createImageExtension } from '../plugins/image/extension';
 import { BubbleMenu } from '../ui/bubble-menu';
+import { defaultSlashCommands } from '../ui/slash-command/commands';
 import { SlashCommandRoot } from '../ui/slash-command/root';
 import '../ui/themes/default.css';
 import { Placeholder } from '@tiptap/extension-placeholder';
+
+const slashCommands = [...defaultSlashCommands, calendarInviteSlashCommand];
 
 export interface EmailEditorRef {
   getEmail: () => Promise<{ html: string; text: string }>;
@@ -48,6 +52,8 @@ export interface EmailEditorProps {
   onUploadImage?: (file: File) => Promise<{ url: string }>;
   className?: string;
   children?: ReactNode;
+  /** Options forwarded to the built-in CalendarInvitePlugin */
+  calendarInvite?: CalendarPluginOptions;
 }
 
 function buildRef(editor: Editor | null): EmailEditorRef {
@@ -129,6 +135,7 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
       onUploadImage,
       className,
       children,
+      calendarInvite,
     },
     ref,
   ) => {
@@ -146,6 +153,7 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
     const extensions = useMemo(() => {
       const base = extensionsProp ?? [
         StarterKit.configure(),
+        CalendarInvite.configure(),
         Placeholder.configure({
           placeholder:
             placeholder ??
@@ -194,7 +202,8 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
         <BubbleMenu.LinkDefault />
         <BubbleMenu.ButtonDefault />
         <BubbleMenu.ImageDefault />
-        <SlashCommandRoot />
+        <SlashCommandRoot items={slashCommands} />
+        <CalendarInvitePlugin {...(calendarInvite ?? {})} />
         {children}
       </EditorProvider>
     );

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -27,7 +27,6 @@ import { SlashCommandRoot } from '../ui/slash-command/root';
 import '../ui/themes/default.css';
 import { Placeholder } from '@tiptap/extension-placeholder';
 
-const slashCommands = [...defaultSlashCommands, calendarInviteSlashCommand];
 
 export interface EmailEditorRef {
   getEmail: () => Promise<{ html: string; text: string }>;
@@ -174,6 +173,19 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
       return imageExtension ? [...base, imageExtension] : base;
     }, [extensionsProp, theme, placeholder, imageExtension]);
 
+    const hasCalendarInvite = useMemo(
+      () => extensions.some((ext) => ext.name === 'calendarInvite'),
+      [extensions],
+    );
+
+    const slashCommands = useMemo(
+      () =>
+        hasCalendarInvite
+          ? [...defaultSlashCommands, calendarInviteSlashCommand]
+          : defaultSlashCommands,
+      [hasCalendarInvite],
+    );
+
     const editorProps: UseEditorOptions['editorProps'] = useMemo(
       () => ({
         handlePaste: createPasteHandler({
@@ -203,7 +215,7 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
         <BubbleMenu.ButtonDefault />
         <BubbleMenu.ImageDefault />
         <SlashCommandRoot items={slashCommands} />
-        <CalendarInvitePlugin {...(calendarInvite ?? {})} />
+        {hasCalendarInvite && <CalendarInvitePlugin {...(calendarInvite ?? {})} />}
         {children}
       </EditorProvider>
     );

--- a/packages/editor/src/plugins/calendar-invite/editor-card.tsx
+++ b/packages/editor/src/plugins/calendar-invite/editor-card.tsx
@@ -1,0 +1,88 @@
+import { NodeViewWrapper } from '@tiptap/react';
+import type { NodeViewProps } from '@tiptap/react';
+import { computeEndDateTime, formatDisplayTime } from './ical-generator';
+import type { CalendarEvent } from './types';
+
+const PROVIDERS = ['Google Calendar', 'Outlook', 'Apple Calendar', 'Yahoo Calendar'] as const;
+
+export function CalendarEditorCard({ node }: NodeViewProps) {
+  const attrs = node.attrs as CalendarEvent & { accentColor?: string };
+  const { title, date, startTime, duration, timezone, location, accentColor } = attrs;
+  const isAllDay = duration === -1;
+
+  const formattedDate = date
+    ? new Date(`${date}T12:00:00`).toLocaleDateString('en-US', {
+        weekday: 'short', month: 'short', day: 'numeric', year: 'numeric',
+      })
+    : '—';
+
+  let formattedTime = 'All day';
+  if (!isAllDay && startTime) {
+    const end = computeEndDateTime(date, startTime, duration);
+    formattedTime = `${formatDisplayTime(startTime)} – ${formatDisplayTime(end.time)}`;
+  }
+
+  const tzShort = timezone.split('/').pop()?.replace(/_/g, ' ') ?? '';
+  const chipColor = accentColor ?? '#1c1c1c';
+
+  return (
+    <NodeViewWrapper>
+      <div
+        style={{
+          border: '1px solid var(--re-border, #e5e5e5)',
+          borderRadius: '10px',
+          overflow: 'hidden',
+          margin: '2px 0',
+          backgroundColor: 'var(--re-bg, #fff)',
+          cursor: 'default',
+          userSelect: 'none',
+        }}
+        contentEditable={false}
+      >
+        {/* Main content */}
+        <div style={{ padding: '12px 14px' }}>
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: '10px' }}>
+            <div style={{ width: '34px', height: '34px', borderRadius: '7px', backgroundColor: 'var(--re-active, rgba(0,0,0,0.06))', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, fontSize: '17px' }}>
+              📅
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontWeight: 600, fontSize: '13px', color: 'var(--re-text, #1c1c1c)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginBottom: '2px' }}>
+                {title || 'Untitled Event'}
+              </div>
+              <div style={{ fontSize: '12px', color: 'var(--re-text-muted, #6b6b6b)' }}>
+                {formattedDate} · {formattedTime}
+                {!isAllDay && tzShort ? ` (${tzShort})` : ''}
+              </div>
+              {location ? (
+                <div style={{ fontSize: '12px', color: 'var(--re-text-muted, #6b6b6b)', marginTop: '1px' }}>
+                  📍 {location}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        {/* Provider buttons */}
+        <div style={{ borderTop: '1px solid var(--re-border, #e5e5e5)', padding: '8px 14px', display: 'flex', gap: '5px', flexWrap: 'wrap' as const }}>
+          {PROVIDERS.map((label) => (
+            <span
+              key={label}
+              style={{
+                display: 'inline-block',
+                padding: '3px 10px',
+                borderRadius: '4px',
+                backgroundColor: chipColor,
+                color: '#fff',
+                fontSize: '11px',
+                fontWeight: 500,
+                opacity: 0.9,
+              }}
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+      </div>
+    </NodeViewWrapper>
+  );
+}

--- a/packages/editor/src/plugins/calendar-invite/extension.tsx
+++ b/packages/editor/src/plugins/calendar-invite/extension.tsx
@@ -1,0 +1,179 @@
+import type { Range } from '@tiptap/core';
+import { ReactNodeViewRenderer } from '@tiptap/react';
+import { Button as ReactEmailButton, Hr, Section, Text } from 'react-email';
+import { editorEventBus } from '../../core/event-bus';
+import { EmailNode } from '../../core/serializer/email-node';
+import { CalendarEditorCard } from './editor-card';
+import {
+  computeEndDateTime,
+  formatDisplayTime,
+  generateAppleCalendarUri,
+  generateGoogleCalendarUrl,
+  generateOutlookUrl,
+  generateYahooCalendarUrl,
+} from './ical-generator';
+import type { CalendarEvent } from './types';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    calendarInvite: {
+      insertCalendarInvite: (event: CalendarEvent) => ReturnType;
+      openCalendarInviteModal: (range: Range) => ReturnType;
+    };
+  }
+}
+
+export const CalendarInvite = EmailNode.create({
+  name: 'calendarInvite',
+  group: 'block',
+  atom: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      title:       { default: '' },
+      date:        { default: '' },
+      startTime:   { default: '09:00' },
+      duration:    { default: 60 },
+      timezone:    { default: 'UTC' },
+      location:    { default: '' },
+      description: { default: '' },
+      // Card style overrides
+      cardBg:      { default: '#fafafa' },
+      accentColor: { default: '#1c1c1c' },
+      borderColor: { default: '#e5e5e5' },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="calendar-invite"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', { 'data-type': 'calendar-invite', ...HTMLAttributes }];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(CalendarEditorCard);
+  },
+
+  addCommands() {
+    return {
+      insertCalendarInvite:
+        (event: CalendarEvent) =>
+        ({ commands }) =>
+          // Insert the node + a trailing paragraph so the cursor always lands
+          // in a text position. Without this, the atom node gets NodeSelection
+          // and the next insertion replaces it instead of appending.
+          commands.insertContent([
+            { type: 'calendarInvite', attrs: event },
+            { type: 'paragraph' },
+          ]),
+
+      openCalendarInviteModal:
+        (range: Range) =>
+        () => {
+          editorEventBus.dispatch('calendar-invite:open', { range });
+          return true;
+        },
+    };
+  },
+
+  renderToReactEmail({ node }) {
+    const event = node.attrs as CalendarEvent & {
+      cardBg: string;
+      accentColor: string;
+      borderColor: string;
+    };
+    const {
+      title, date, startTime, duration, timezone,
+      location, description,
+      cardBg = '#fafafa',
+      accentColor = '#1c1c1c',
+      borderColor = '#e5e5e5',
+    } = event;
+
+    const isAllDay = duration === -1;
+    const end = isAllDay ? null : computeEndDateTime(date, startTime, duration);
+
+    const googleUrl  = generateGoogleCalendarUrl(event);
+    const outlookUrl = generateOutlookUrl(event);
+    const yahooUrl   = generateYahooCalendarUrl(event);
+    const appleUrl   = generateAppleCalendarUri(event);
+
+    const formattedDate = date
+      ? new Date(`${date}T12:00:00`).toLocaleDateString('en-US', {
+          weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+        })
+      : '';
+
+    const formattedTime = isAllDay
+      ? 'All day'
+      : `${formatDisplayTime(startTime)}${end ? ` – ${formatDisplayTime(end.time)}` : ''}`;
+
+    const tzLabel = timezone.split('/').pop()?.replace(/_/g, ' ') ?? timezone;
+
+    // ── provider buttons ──────────────────────────────────────────────────────
+    const providers = [
+      { label: 'Google Calendar', href: googleUrl  },
+      { label: 'Outlook',         href: outlookUrl },
+      { label: 'Apple Calendar',  href: appleUrl   },
+      { label: 'Yahoo Calendar',  href: yahooUrl   },
+    ] as const;
+
+    const btnStyle: React.CSSProperties = {
+      display: 'inline-block',
+      padding: '7px 14px',
+      backgroundColor: accentColor,
+      color: '#ffffff',
+      textDecoration: 'none',
+      borderRadius: '6px',
+      fontSize: '12px',
+      fontWeight: '500' as const,
+      margin: '0 6px 6px 0',
+    };
+
+    return (
+      <Section
+        style={{
+          border: `1px solid ${borderColor}`,
+          borderRadius: '10px',
+          padding: '20px 24px',
+          marginBottom: '12px',
+          backgroundColor: cardBg,
+        }}
+      >
+        <Text style={{ fontSize: '18px', fontWeight: '700', margin: '0 0 10px', color: '#1c1c1c' }}>
+          {title}
+        </Text>
+        <Text style={{ color: '#444', margin: '3px 0', fontSize: '14px' }}>📅 {formattedDate}</Text>
+        <Text style={{ color: '#444', margin: '3px 0', fontSize: '14px' }}>
+          🕐 {formattedTime}
+          {!isAllDay ? <> · <span style={{ color: '#888' }}>{tzLabel}</span></> : null}
+        </Text>
+        {location ? (
+          <Text style={{ color: '#444', margin: '3px 0', fontSize: '14px' }}>📍 {location}</Text>
+        ) : null}
+        {description ? (
+          <>
+            <Hr style={{ border: 'none', borderTop: `1px solid ${borderColor}`, margin: '14px 0 10px' }} />
+            <Text style={{ color: '#555', margin: '0', fontSize: '14px', lineHeight: '1.55' }}>
+              {description}
+            </Text>
+          </>
+        ) : null}
+        <Hr style={{ border: 'none', borderTop: `1px solid ${borderColor}`, margin: '14px 0 0' }} />
+        <Section style={{ paddingTop: '14px' }}>
+          <Text style={{ color: '#888', fontSize: '11px', margin: '0 0 8px', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+            Add to calendar
+          </Text>
+          {providers.map((p) => (
+            <ReactEmailButton key={p.label} href={p.href} style={btnStyle}>
+              {p.label}
+            </ReactEmailButton>
+          ))}
+        </Section>
+      </Section>
+    );
+  },
+});

--- a/packages/editor/src/plugins/calendar-invite/extension.tsx
+++ b/packages/editor/src/plugins/calendar-invite/extension.tsx
@@ -72,8 +72,8 @@ export const CalendarInvite = EmailNode.create({
 
       openCalendarInviteModal:
         (range: Range) =>
-        () => {
-          editorEventBus.dispatch('calendar-invite:open', { range });
+        ({ editor }) => {
+          editorEventBus.dispatch('calendar-invite:open', { range, editorRef: editor });
           return true;
         },
     };

--- a/packages/editor/src/plugins/calendar-invite/ical-generator.ts
+++ b/packages/editor/src/plugins/calendar-invite/ical-generator.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import type { CalendarEvent } from './types';
 
 function padZero(n: number): string {
@@ -45,7 +46,7 @@ export function formatDisplayTime(time: string): string {
 }
 
 export function generateICalContent(event: CalendarEvent): string {
-  const uid = `${Date.now()}-${Math.random().toString(36).slice(2)}@react-email`;
+  const uid = `${Date.now()}-${randomBytes(16).toString('hex')}@react-email`;
   const now = new Date();
   const dtstamp = [
     now.getUTCFullYear(),

--- a/packages/editor/src/plugins/calendar-invite/ical-generator.ts
+++ b/packages/editor/src/plugins/calendar-invite/ical-generator.ts
@@ -1,0 +1,174 @@
+import type { CalendarEvent } from './types';
+
+function padZero(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function formatDateTimeLocal(date: string, time: string): string {
+  // date: YYYY-MM-DD, time: HH:MM → YYYYMMDDTHHmmss
+  const [year, month, day] = date.split('-');
+  const [hour, minute] = time.split(':');
+  return `${year}${month}${day}T${hour}${minute}00`;
+}
+
+function formatDateOnly(date: string): string {
+  return date.replace(/-/g, '');
+}
+
+export function computeEndDateTime(
+  date: string,
+  startTime: string,
+  duration: number,
+): { date: string; time: string } {
+  const [h, m] = startTime.split(':').map(Number);
+  const totalMinutes = h * 60 + m + duration;
+  const endHour = Math.floor(totalMinutes / 60) % 24;
+  const endMin = totalMinutes % 60;
+  const daysOverflow = Math.floor(totalMinutes / (24 * 60));
+
+  let endDate = date;
+  if (daysOverflow > 0) {
+    const d = new Date(`${date}T12:00:00`);
+    d.setDate(d.getDate() + daysOverflow);
+    endDate = d.toISOString().split('T')[0] ?? date;
+  }
+
+  return { date: endDate, time: `${padZero(endHour)}:${padZero(endMin)}` };
+}
+
+export function formatDisplayTime(time: string): string {
+  const [h, m] = time.split(':').map(Number);
+  const period = (h ?? 0) >= 12 ? 'PM' : 'AM';
+  const rawHour = h ?? 0;
+  const displayHour = rawHour === 0 ? 12 : rawHour > 12 ? rawHour - 12 : rawHour;
+  return `${displayHour}:${padZero(m ?? 0)} ${period}`;
+}
+
+export function generateICalContent(event: CalendarEvent): string {
+  const uid = `${Date.now()}-${Math.random().toString(36).slice(2)}@react-email`;
+  const now = new Date();
+  const dtstamp = [
+    now.getUTCFullYear(),
+    padZero(now.getUTCMonth() + 1),
+    padZero(now.getUTCDate()),
+    'T',
+    padZero(now.getUTCHours()),
+    padZero(now.getUTCMinutes()),
+    padZero(now.getUTCSeconds()),
+    'Z',
+  ].join('');
+
+  let dtstart: string;
+  let dtend: string;
+
+  if (event.duration === -1) {
+    const nextDayDate = new Date(`${event.date}T12:00:00`);
+    nextDayDate.setDate(nextDayDate.getDate() + 1);
+    const nextDay = nextDayDate.toISOString().split('T')[0] ?? event.date;
+    dtstart = `DTSTART;VALUE=DATE:${formatDateOnly(event.date)}`;
+    dtend = `DTEND;VALUE=DATE:${formatDateOnly(nextDay)}`;
+  } else {
+    const end = computeEndDateTime(event.date, event.startTime, event.duration);
+    dtstart = `DTSTART;TZID=${event.timezone}:${formatDateTimeLocal(event.date, event.startTime)}`;
+    dtend = `DTEND;TZID=${event.timezone}:${formatDateTimeLocal(end.date, end.time)}`;
+  }
+
+  const escape = (s: string) => s.replace(/\\/g, '\\\\').replace(/;/g, '\\;').replace(/,/g, '\\,').replace(/\n/g, '\\n');
+
+  const lines: string[] = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//React Email//Calendar Invite//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:REQUEST',
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `DTSTAMP:${dtstamp}`,
+    dtstart,
+    dtend,
+    `SUMMARY:${escape(event.title)}`,
+  ];
+
+  if (event.location) lines.push(`LOCATION:${escape(event.location)}`);
+  if (event.description) lines.push(`DESCRIPTION:${escape(event.description)}`);
+
+  lines.push('END:VEVENT', 'END:VCALENDAR');
+
+  return lines.join('\r\n');
+}
+
+export function generateGoogleCalendarUrl(event: CalendarEvent): string {
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.title,
+    ctz: event.timezone,
+  });
+
+  if (event.duration === -1) {
+    const d = formatDateOnly(event.date);
+    params.set('dates', `${d}/${d}`);
+  } else {
+    const end = computeEndDateTime(event.date, event.startTime, event.duration);
+    const start = formatDateTimeLocal(event.date, event.startTime);
+    const endStr = formatDateTimeLocal(end.date, end.time);
+    params.set('dates', `${start}/${endStr}`);
+  }
+
+  if (event.location) params.set('location', event.location);
+  if (event.description) params.set('details', event.description);
+
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}
+
+export function generateOutlookUrl(event: CalendarEvent): string {
+  const params = new URLSearchParams({
+    rru: 'addevent',
+    path: '/calendar/action/compose',
+    subject: event.title,
+  });
+
+  if (event.duration === -1) {
+    params.set('startdt', event.date);
+    params.set('enddt', event.date);
+    params.set('allday', 'true');
+  } else {
+    const end = computeEndDateTime(event.date, event.startTime, event.duration);
+    params.set('startdt', `${event.date}T${event.startTime}:00`);
+    params.set('enddt', `${end.date}T${end.time}:00`);
+  }
+
+  if (event.location) params.set('location', event.location);
+  if (event.description) params.set('body', event.description);
+
+  return `https://outlook.live.com/calendar/0/deeplink/compose?${params.toString()}`;
+}
+
+export function generateYahooCalendarUrl(event: CalendarEvent): string {
+  const params = new URLSearchParams({
+    v: '60',
+    view: 'd',
+    type: '20',
+    title: event.title,
+  });
+
+  if (event.duration === -1) {
+    const d = formatDateOnly(event.date);
+    params.set('st', d);
+    params.set('et', d);
+    params.set('dur', 'allday');
+  } else {
+    const end = computeEndDateTime(event.date, event.startTime, event.duration);
+    params.set('st', formatDateTimeLocal(event.date, event.startTime));
+    params.set('et', formatDateTimeLocal(end.date, end.time));
+  }
+
+  if (event.description) params.set('desc', event.description);
+  if (event.location) params.set('in_loc', event.location);
+
+  return `https://calendar.yahoo.com/?${params.toString()}`;
+}
+
+export function generateAppleCalendarUri(event: CalendarEvent): string {
+  const ics = generateICalContent(event);
+  return `data:text/calendar;charset=utf-8,${encodeURIComponent(ics)}`;
+}

--- a/packages/editor/src/plugins/calendar-invite/ical-generator.ts
+++ b/packages/editor/src/plugins/calendar-invite/ical-generator.ts
@@ -29,9 +29,13 @@ export function computeEndDateTime(
 
   let endDate = date;
   if (daysOverflow > 0) {
-    const d = new Date(`${date}T12:00:00`);
-    d.setDate(d.getDate() + daysOverflow);
-    endDate = d.toISOString().split('T')[0] ?? date;
+    const [y, mo, dy] = date.split('-').map(Number);
+    const next = new Date(Date.UTC(y!, mo! - 1, dy! + daysOverflow));
+    endDate = [
+      next.getUTCFullYear(),
+      String(next.getUTCMonth() + 1).padStart(2, '0'),
+      String(next.getUTCDate()).padStart(2, '0'),
+    ].join('-');
   }
 
   return { date: endDate, time: `${padZero(endHour)}:${padZero(endMin)}` };
@@ -63,9 +67,13 @@ export function generateICalContent(event: CalendarEvent): string {
   let dtend: string;
 
   if (event.duration === -1) {
-    const nextDayDate = new Date(`${event.date}T12:00:00`);
-    nextDayDate.setDate(nextDayDate.getDate() + 1);
-    const nextDay = nextDayDate.toISOString().split('T')[0] ?? event.date;
+    const [y, m, d] = event.date.split('-').map(Number);
+    const next = new Date(Date.UTC(y!, m! - 1, d! + 1));
+    const nextDay = [
+      next.getUTCFullYear(),
+      String(next.getUTCMonth() + 1).padStart(2, '0'),
+      String(next.getUTCDate()).padStart(2, '0'),
+    ].join('-');
     dtstart = `DTSTART;VALUE=DATE:${formatDateOnly(event.date)}`;
     dtend = `DTEND;VALUE=DATE:${formatDateOnly(nextDay)}`;
   } else {

--- a/packages/editor/src/plugins/calendar-invite/index.ts
+++ b/packages/editor/src/plugins/calendar-invite/index.ts
@@ -1,0 +1,14 @@
+export { CalendarInvite } from './extension';
+export { CalendarInvitePlugin } from './plugin';
+export { calendarInviteSlashCommand } from './slash-command';
+export type { CalendarEvent, CalendarPluginOptions } from './types';
+export { CALENDAR_TIMEZONES } from './types';
+
+/** Returns the IANA timezone from the browser (e.g. "America/New_York"). Falls back to "UTC". */
+export function detectCalendarTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return 'UTC';
+  }
+}

--- a/packages/editor/src/plugins/calendar-invite/modal.tsx
+++ b/packages/editor/src/plugins/calendar-invite/modal.tsx
@@ -1,0 +1,841 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { formatDisplayTime } from './ical-generator';
+import type { CalendarEvent } from './types';
+import { CALENDAR_TIMEZONES } from './types';
+
+// ─── constants ────────────────────────────────────────────────────────────────
+
+const MONTHS_SHORT = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+const MONTHS_LONG = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+
+/** Half-hour slots from 6:00 AM to 11:00 PM */
+const TIME_SLOTS: string[] = [];
+for (let h = 6; h <= 23; h++) {
+  TIME_SLOTS.push(`${String(h).padStart(2, '0')}:00`);
+  if (h < 23) TIME_SLOTS.push(`${String(h).padStart(2, '0')}:30`);
+}
+
+const DURATION_PILLS = [
+  { label: '15 min', value: 15 },
+  { label: '30 min', value: 30 },
+  { label: '45 min', value: 45 },
+  { label: '1 hr', value: 60 },
+  { label: '1.5 hr', value: 90 },
+  { label: '2 hr', value: 120 },
+  { label: '3 hr', value: 180 },
+  { label: '4 hr', value: 240 },
+  { label: 'All day', value: -1 },
+];
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function detectTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return 'UTC';
+  }
+}
+
+function getGmtOffset(tz: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat('en', {
+      timeZone: tz,
+      timeZoneName: 'shortOffset',
+    }).formatToParts(new Date());
+    return parts.find((p) => p.type === 'timeZoneName')?.value ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function buildCalendarGrid(month: number, year: number): (number | null)[][] {
+  const firstDow = new Date(year, month - 1, 1).getDay();
+  const days = new Date(year, month, 0).getDate();
+  const cells: (number | null)[] = [
+    ...Array<null>(firstDow).fill(null),
+    ...Array.from({ length: days }, (_, i) => i + 1),
+  ];
+  while (cells.length % 7 !== 0) cells.push(null);
+  const rows: (number | null)[][] = [];
+  for (let i = 0; i < cells.length; i += 7) rows.push(cells.slice(i, i + 7));
+  return rows;
+}
+
+function getDefaultStartTime(): string {
+  const next = new Date();
+  next.setHours(next.getHours() + 1, 0, 0, 0);
+  const h = Math.max(6, Math.min(23, next.getHours()));
+  return `${String(h).padStart(2, '0')}:00`;
+}
+
+interface SelectedDate {
+  year: number;
+  month: number;
+  day: number;
+}
+
+interface FormState {
+  title: string;
+  selected: SelectedDate;
+  viewYear: number;
+  viewMonth: number;
+  startTime: string; // HH:MM 24h
+  duration: number;
+  timezone: string;
+  location: string;
+  description: string;
+}
+
+function makeInitialState(defaultTimezone?: string): FormState {
+  const now = new Date();
+  const rawTz = defaultTimezone ?? detectTimezone();
+  const tz = CALENDAR_TIMEZONES.some((t) => t.value === rawTz) ? rawTz : 'UTC';
+  return {
+    title: '',
+    selected: {
+      year: now.getFullYear(),
+      month: now.getMonth() + 1,
+      day: now.getDate(),
+    },
+    viewYear: now.getFullYear(),
+    viewMonth: now.getMonth() + 1,
+    startTime: getDefaultStartTime(),
+    duration: 60,
+    timezone: tz,
+    location: '',
+    description: '',
+  };
+}
+
+function formToEvent(f: FormState): CalendarEvent {
+  const m = String(f.selected.month).padStart(2, '0');
+  const d = String(f.selected.day).padStart(2, '0');
+  return {
+    title: f.title,
+    date: `${f.selected.year}-${m}-${d}`,
+    startTime: f.startTime,
+    duration: f.duration,
+    timezone: f.timezone,
+    location: f.location,
+    description: f.description,
+  };
+}
+
+function Pill({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        padding: '5px 11px',
+        borderRadius: '20px',
+        border: `1px solid ${active ? 'transparent' : 'var(--re-border, #e5e5e5)'}`,
+        backgroundColor: active ? 'var(--re-text, #1c1c1c)' : 'transparent',
+        color: active ? 'var(--re-bg, #fff)' : 'var(--re-text, #1c1c1c)',
+        fontSize: '12px',
+        fontWeight: active ? 600 : 400,
+        cursor: 'pointer',
+        whiteSpace: 'nowrap' as const,
+        flexShrink: 0,
+        lineHeight: '1.4',
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function CalendarGrid({
+  selected,
+  viewYear,
+  viewMonth,
+  onSelectDay,
+  onPrevMonth,
+  onNextMonth,
+}: {
+  selected: SelectedDate;
+  viewYear: number;
+  viewMonth: number;
+  onSelectDay: (day: number, month: number, year: number) => void;
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+}) {
+  const grid = buildCalendarGrid(viewMonth, viewYear);
+  const today = new Date();
+  const todayY = today.getFullYear();
+  const todayM = today.getMonth() + 1;
+  const todayD = today.getDate();
+
+  const cellBase: React.CSSProperties = {
+    width: '32px',
+    height: '32px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '50%',
+    fontSize: '13px',
+    cursor: 'pointer',
+    border: 'none',
+    background: 'none',
+    margin: '0 auto',
+  };
+
+  return (
+    <div>
+      {/* Month nav */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: '10px',
+        }}
+      >
+        <button
+          type="button"
+          onClick={onPrevMonth}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '4px 8px',
+            borderRadius: '4px',
+            color: 'var(--re-text-muted, #6b6b6b)',
+            fontSize: '14px',
+          }}
+          aria-label="Previous month"
+        >
+          ‹
+        </button>
+        <span
+          style={{
+            fontSize: '13px',
+            fontWeight: 600,
+            color: 'var(--re-text, #1c1c1c)',
+          }}
+        >
+          {MONTHS_LONG[viewMonth - 1]} {viewYear}
+        </span>
+        <button
+          type="button"
+          onClick={onNextMonth}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '4px 8px',
+            borderRadius: '4px',
+            color: 'var(--re-text-muted, #6b6b6b)',
+            fontSize: '14px',
+          }}
+          aria-label="Next month"
+        >
+          ›
+        </button>
+      </div>
+
+      {/* Weekday headers */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(7, 1fr)',
+          marginBottom: '4px',
+        }}
+      >
+        {WEEKDAYS.map((wd) => (
+          <div
+            key={wd}
+            style={{
+              textAlign: 'center',
+              fontSize: '11px',
+              color: 'var(--re-text-muted, #6b6b6b)',
+              fontWeight: 500,
+              padding: '2px 0',
+            }}
+          >
+            {wd}
+          </div>
+        ))}
+      </div>
+
+      {/* Day rows */}
+      {grid.map((row, ri) => (
+        <div
+          key={ri}
+          style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)' }}
+        >
+          {row.map((day, ci) => {
+            if (day === null)
+              return <div key={ci} style={{ height: '32px' }} />;
+            const isSelected =
+              day === selected.day &&
+              viewMonth === selected.month &&
+              viewYear === selected.year;
+            const isToday =
+              day === todayD && viewMonth === todayM && viewYear === todayY;
+            return (
+              <button
+                key={ci}
+                type="button"
+                onClick={() => onSelectDay(day, viewMonth, viewYear)}
+                style={{
+                  ...cellBase,
+                  backgroundColor: isSelected
+                    ? 'var(--re-text, #1c1c1c)'
+                    : 'transparent',
+                  color: isSelected
+                    ? 'var(--re-bg, #fff)'
+                    : isToday
+                      ? 'var(--re-text, #1c1c1c)'
+                      : 'var(--re-text, #1c1c1c)',
+                  fontWeight: isToday && !isSelected ? 700 : 400,
+                  boxShadow:
+                    isToday && !isSelected
+                      ? 'inset 0 0 0 1.5px var(--re-border, #e5e5e5)'
+                      : 'none',
+                }}
+                aria-label={`${MONTHS_SHORT[viewMonth - 1]} ${day}`}
+                aria-pressed={isSelected}
+              >
+                {day}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export interface CalendarModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (event: CalendarEvent) => void;
+  defaultTimezone?: string;
+}
+
+export function CalendarModal({
+  open,
+  onClose,
+  onSubmit,
+  defaultTimezone,
+}: CalendarModalProps) {
+  const [form, setForm] = useState<FormState>(() =>
+    makeInitialState(defaultTimezone),
+  );
+  const [titleError, setTitleError] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const timePillsRef = useRef<HTMLDivElement>(null);
+  const activeTimePillRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setForm(makeInitialState(defaultTimezone));
+      setTitleError(false);
+      setTimeout(() => titleRef.current?.focus(), 60);
+    }
+  }, [open, defaultTimezone]);
+
+  // Scroll selected time pill into view when modal opens
+  useLayoutEffect(() => {
+    if (open && activeTimePillRef.current && timePillsRef.current) {
+      const pill = activeTimePillRef.current;
+      const container = timePillsRef.current;
+      const offset =
+        pill.offsetLeft - container.clientWidth / 2 + pill.clientWidth / 2;
+      container.scrollLeft = offset;
+    }
+  }, [open]);
+
+  const set = useCallback(
+    <K extends keyof FormState>(k: K, v: FormState[K]) => {
+      setForm((p) => ({ ...p, [k]: v }));
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(() => {
+    if (!form.title.trim()) {
+      setTitleError(true);
+      titleRef.current?.focus();
+      return;
+    }
+    onSubmit(formToEvent(form));
+  }, [form, onSubmit]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) handleSubmit();
+    },
+    [onClose, handleSubmit],
+  );
+
+  const prevMonth = useCallback(() => {
+    setForm((p) => {
+      let m = p.viewMonth - 1;
+      let y = p.viewYear;
+      if (m < 1) {
+        m = 12;
+        y--;
+      }
+      return { ...p, viewMonth: m, viewYear: y };
+    });
+  }, []);
+
+  const nextMonth = useCallback(() => {
+    setForm((p) => {
+      let m = p.viewMonth + 1;
+      let y = p.viewYear;
+      if (m > 12) {
+        m = 1;
+        y++;
+      }
+      return { ...p, viewMonth: m, viewYear: y };
+    });
+  }, []);
+
+  const selectDay = useCallback(
+    (day: number, month: number, year: number) => {
+      set('selected', { day, month, year });
+    },
+    [set],
+  );
+
+  if (!open) return null;
+
+  const isAllDay = form.duration === -1;
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    height: '32px',
+    padding: '0 10px',
+    border: '1px solid var(--re-border, #e5e5e5)',
+    borderRadius: '6px',
+    backgroundColor: 'var(--re-bg, #fff)',
+    color: 'var(--re-text, #1c1c1c)',
+    fontSize: '13px',
+    outline: 'none',
+    boxSizing: 'border-box',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    display: 'block',
+    fontSize: '11px',
+    fontWeight: 600,
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.04em',
+    color: 'var(--re-text-muted, #6b6b6b)',
+    marginBottom: '8px',
+  };
+
+  const sectionStyle: React.CSSProperties = { marginBottom: '20px' };
+
+  const dividerStyle: React.CSSProperties = {
+    border: 'none',
+    borderTop: '1px solid var(--re-border, #e5e5e5)',
+    margin: '0 -20px 20px',
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 9999,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      onKeyDown={handleKeyDown}
+    >
+      {/* Backdrop */}
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          backgroundColor: 'rgba(0,0,0,0.45)',
+        }}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Add Calendar Invite"
+        style={{
+          position: 'relative',
+          backgroundColor: 'var(--re-bg, #fff)',
+          border: '1px solid var(--re-border, #e5e5e5)',
+          borderRadius: '14px',
+          width: '400px',
+          maxWidth: '92vw',
+          maxHeight: '90vh',
+          overflowY: 'auto',
+          boxShadow: 'var(--re-shadow, 0 20px 60px rgba(0,0,0,0.2))',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '16px 20px 14px',
+            borderBottom: '1px solid var(--re-border, #e5e5e5)',
+            flexShrink: 0,
+          }}
+        >
+          <span
+            style={{
+              fontSize: '14px',
+              fontWeight: 600,
+              color: 'var(--re-text, #1c1c1c)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '7px',
+            }}
+          >
+            <span style={{ fontSize: '16px' }}>📅</span> Calendar Invite
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '4px 6px',
+              color: 'var(--re-text-muted, #6b6b6b)',
+              fontSize: '20px',
+              lineHeight: 1,
+              borderRadius: '4px',
+            }}
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: '20px', overflowY: 'auto', flex: 1 }}>
+          {/* Event name */}
+          <div style={sectionStyle}>
+            <label style={labelStyle} htmlFor="cal-title">
+              Event name
+            </label>
+            <input
+              id="cal-title"
+              ref={titleRef}
+              style={{
+                ...inputStyle,
+                ...(titleError
+                  ? { borderColor: 'var(--re-danger, #dc2626)' }
+                  : {}),
+              }}
+              type="text"
+              value={form.title}
+              onChange={(e) => {
+                set('title', e.target.value);
+                if (titleError) setTitleError(false);
+              }}
+              placeholder="Team sync, Product launch…"
+              autoComplete="off"
+            />
+            {titleError && (
+              <span
+                style={{
+                  fontSize: '11px',
+                  color: 'var(--re-danger, #dc2626)',
+                  marginTop: '4px',
+                  display: 'block',
+                }}
+              >
+                Required
+              </span>
+            )}
+          </div>
+
+          <hr style={dividerStyle} />
+
+          {/* Date — calendar grid */}
+          <div style={sectionStyle}>
+            <label style={labelStyle}>Date</label>
+            <CalendarGrid
+              selected={form.selected}
+              viewYear={form.viewYear}
+              viewMonth={form.viewMonth}
+              onSelectDay={selectDay}
+              onPrevMonth={prevMonth}
+              onNextMonth={nextMonth}
+            />
+          </div>
+
+          <hr style={dividerStyle} />
+
+          {/* Start time — pill row */}
+          {!isAllDay && (
+            <div style={sectionStyle}>
+              <label style={labelStyle}>Start time</label>
+              <div
+                ref={timePillsRef}
+                style={{
+                  display: 'flex',
+                  gap: '6px',
+                  overflowX: 'auto',
+                  paddingBottom: '4px',
+                  scrollbarWidth: 'none',
+                }}
+              >
+                {TIME_SLOTS.map((slot) => {
+                  const active = slot === form.startTime;
+                  return (
+                    <button
+                      key={slot}
+                      ref={active ? activeTimePillRef : undefined}
+                      type="button"
+                      onClick={() => set('startTime', slot)}
+                      style={{
+                        padding: '5px 11px',
+                        borderRadius: '20px',
+                        border: `1px solid ${active ? 'transparent' : 'var(--re-border, #e5e5e5)'}`,
+                        backgroundColor: active
+                          ? 'var(--re-text, #1c1c1c)'
+                          : 'transparent',
+                        color: active
+                          ? 'var(--re-bg, #fff)'
+                          : 'var(--re-text, #1c1c1c)',
+                        fontSize: '12px',
+                        fontWeight: active ? 600 : 400,
+                        cursor: 'pointer',
+                        whiteSpace: 'nowrap',
+                        flexShrink: 0,
+                        lineHeight: '1.4',
+                      }}
+                    >
+                      {formatDisplayTime(slot)}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Duration — pill grid */}
+          <div style={sectionStyle}>
+            <label style={labelStyle}>Duration</label>
+            <div
+              style={{ display: 'flex', flexWrap: 'wrap' as const, gap: '6px' }}
+            >
+              {DURATION_PILLS.map((d) => (
+                <Pill
+                  key={d.value}
+                  label={d.label}
+                  active={form.duration === d.value}
+                  onClick={() => set('duration', d.value)}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Timezone */}
+          {!isAllDay && (
+            <>
+              <hr style={dividerStyle} />
+              <div style={sectionStyle}>
+                <label style={labelStyle} htmlFor="cal-tz">
+                  Time zone
+                </label>
+                <div style={{ position: 'relative' }}>
+                  <select
+                    id="cal-tz"
+                    value={form.timezone}
+                    onChange={(e) => set('timezone', e.target.value)}
+                    style={{
+                      ...inputStyle,
+                      height: 'auto',
+                      padding: '7px 32px 7px 10px',
+                      appearance: 'none',
+                      cursor: 'pointer',
+                      backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%236b6b6b' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")`,
+                      backgroundRepeat: 'no-repeat',
+                      backgroundPosition: 'right 10px center',
+                    }}
+                  >
+                    {CALENDAR_TIMEZONES.map((tz) => {
+                      const offset = getGmtOffset(tz.value);
+                      return (
+                        <option key={tz.value} value={tz.value}>
+                          {tz.label}
+                          {offset ? `  ·  ${offset}` : ''}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </div>
+                {/* Inline offset hint below */}
+                <div
+                  style={{
+                    fontSize: '11px',
+                    color: 'var(--re-text-muted, #6b6b6b)',
+                    marginTop: '5px',
+                  }}
+                >
+                  {getGmtOffset(form.timezone)} · {form.timezone}
+                </div>
+              </div>
+            </>
+          )}
+
+          <hr style={dividerStyle} />
+
+          {/* Location */}
+          <div style={sectionStyle}>
+            <label style={labelStyle} htmlFor="cal-location">
+              Location{' '}
+              <span
+                style={{
+                  fontWeight: 400,
+                  textTransform: 'none',
+                  letterSpacing: 0,
+                }}
+              >
+                (optional)
+              </span>
+            </label>
+            <input
+              id="cal-location"
+              style={inputStyle}
+              type="text"
+              value={form.location}
+              onChange={(e) => set('location', e.target.value)}
+              placeholder="Conference Room A, Zoom link…"
+              autoComplete="off"
+            />
+          </div>
+
+          {/* Notes */}
+          <div style={sectionStyle}>
+            <label style={labelStyle} htmlFor="cal-notes">
+              Notes{' '}
+              <span
+                style={{
+                  fontWeight: 400,
+                  textTransform: 'none',
+                  letterSpacing: 0,
+                }}
+              >
+                (optional)
+              </span>
+            </label>
+            <textarea
+              id="cal-notes"
+              style={{
+                ...inputStyle,
+                height: '72px',
+                padding: '8px 10px',
+                resize: 'vertical',
+                lineHeight: '1.5',
+              }}
+              value={form.description}
+              onChange={(e) => set('description', e.target.value)}
+              placeholder="Agenda, dial-in info…"
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: '8px',
+            padding: '12px 20px 16px',
+            borderTop: '1px solid var(--re-border, #e5e5e5)',
+            flexShrink: 0,
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              height: '32px',
+              padding: '0 16px',
+              border: '1px solid var(--re-border, #e5e5e5)',
+              borderRadius: '6px',
+              backgroundColor: 'transparent',
+              color: 'var(--re-text, #1c1c1c)',
+              fontSize: '13px',
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            style={{
+              height: '32px',
+              padding: '0 16px',
+              border: 'none',
+              borderRadius: '6px',
+              backgroundColor: 'var(--re-text, #1c1c1c)',
+              color: 'var(--re-bg, #fff)',
+              fontSize: '13px',
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Add to email
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/editor/src/plugins/calendar-invite/modal.tsx
+++ b/packages/editor/src/plugins/calendar-invite/modal.tsx
@@ -96,10 +96,17 @@ function buildCalendarGrid(month: number, year: number): (number | null)[][] {
 }
 
 function getDefaultStartTime(): string {
-  const next = new Date();
-  next.setHours(next.getHours() + 1, 0, 0, 0);
-  const h = Math.max(6, Math.min(23, next.getHours()));
-  return `${String(h).padStart(2, '0')}:00`;
+  const now = new Date();
+  // Snap forward 1 hour then round up to the next :00/:30 boundary
+  const msAhead = now.getTime() + 60 * 60 * 1000;
+  const snapped = new Date(Math.ceil(msAhead / (30 * 60 * 1000)) * (30 * 60 * 1000));
+  const h = snapped.getHours();
+  const m = snapped.getMinutes();
+  // If still on today and within TIME_SLOTS range (06:00–23:00), use it
+  if (snapped.getDate() === now.getDate() && h >= 6 && h <= 23) {
+    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+  }
+  return '09:00';
 }
 
 interface SelectedDate {
@@ -120,10 +127,19 @@ interface FormState {
   description: string;
 }
 
+function isValidTimezone(tz: string): boolean {
+  try {
+    Intl.DateTimeFormat('en', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function makeInitialState(defaultTimezone?: string): FormState {
   const now = new Date();
   const rawTz = defaultTimezone ?? detectTimezone();
-  const tz = CALENDAR_TIMEZONES.some((t) => t.value === rawTz) ? rawTz : 'UTC';
+  const tz = isValidTimezone(rawTz) ? rawTz : 'UTC';
   return {
     title: '',
     selected: {
@@ -708,6 +724,13 @@ export function CalendarModal({
                       backgroundPosition: 'right 10px center',
                     }}
                   >
+                    {/* If the active timezone isn't in the curated list, show it first */}
+                    {!CALENDAR_TIMEZONES.some((t) => t.value === form.timezone) && (
+                      <option value={form.timezone}>
+                        {form.timezone.split('/').pop()?.replace(/_/g, ' ') ?? form.timezone}
+                        {getGmtOffset(form.timezone) ? `  ·  ${getGmtOffset(form.timezone)}` : ''}
+                      </option>
+                    )}
                     {CALENDAR_TIMEZONES.map((tz) => {
                       const offset = getGmtOffset(tz.value);
                       return (

--- a/packages/editor/src/plugins/calendar-invite/plugin.tsx
+++ b/packages/editor/src/plugins/calendar-invite/plugin.tsx
@@ -16,6 +16,7 @@ export function CalendarInvitePlugin({
 
   useEffect(() => {
     const sub = editorEventBus.on('calendar-invite:open', (payload) => {
+      if (payload.editorRef !== editor) return;
       setPendingRange(payload.range);
       setIsOpen(true);
     });

--- a/packages/editor/src/plugins/calendar-invite/plugin.tsx
+++ b/packages/editor/src/plugins/calendar-invite/plugin.tsx
@@ -1,0 +1,75 @@
+import { useCurrentEditor } from '@tiptap/react';
+import { useCallback, useEffect, useState } from 'react';
+import { editorEventBus } from '../../core/event-bus';
+import { CalendarModal } from './modal';
+import type { CalendarEvent, CalendarPluginOptions } from './types';
+
+export function CalendarInvitePlugin({
+  defaultTimezone,
+  cardBg,
+  accentColor,
+  borderColor,
+}: CalendarPluginOptions = {}) {
+  const { editor } = useCurrentEditor();
+  const [isOpen, setIsOpen] = useState(false);
+  const [pendingRange, setPendingRange] = useState<{ from: number; to: number } | null>(null);
+
+  useEffect(() => {
+    const sub = editorEventBus.on('calendar-invite:open', (payload) => {
+      setPendingRange(payload.range);
+      setIsOpen(true);
+    });
+    return () => sub.unsubscribe();
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+    setPendingRange(null);
+    editor?.commands.focus();
+  }, [editor]);
+
+  const handleSubmit = useCallback(
+    (event: CalendarEvent) => {
+      if (!editor || !pendingRange) return;
+
+      const mergedEvent = {
+        ...event,
+        cardBg: event.cardBg ?? cardBg,
+        accentColor: event.accentColor ?? accentColor,
+        borderColor: event.borderColor ?? borderColor,
+      };
+
+      // Resolve the parent block (paragraph) that contains the slash command text
+      // so we replace the whole block rather than just deleting inline text and
+      // letting insertContent pick an unpredictable cursor position.
+      const $pos = editor.state.doc.resolve(pendingRange.from);
+      const blockStart = $pos.before($pos.depth);
+      const blockEnd = $pos.after($pos.depth);
+
+      editor
+        .chain()
+        .focus()
+        .insertContentAt(
+          { from: blockStart, to: blockEnd },
+          [
+            { type: 'calendarInvite', attrs: mergedEvent },
+            { type: 'paragraph' },
+          ],
+        )
+        .run();
+
+      setIsOpen(false);
+      setPendingRange(null);
+    },
+    [editor, pendingRange, cardBg, accentColor, borderColor],
+  );
+
+  return (
+    <CalendarModal
+      open={isOpen}
+      onClose={handleClose}
+      onSubmit={handleSubmit}
+      defaultTimezone={defaultTimezone}
+    />
+  );
+}

--- a/packages/editor/src/plugins/calendar-invite/slash-command.tsx
+++ b/packages/editor/src/plugins/calendar-invite/slash-command.tsx
@@ -1,0 +1,13 @@
+import { CalendarIcon } from '../../ui/icons/calendar';
+import type { SlashCommandItem } from '../../ui/slash-command/types';
+
+export const calendarInviteSlashCommand: SlashCommandItem = {
+  title: 'Calendar invite',
+  description: 'Add a calendar event invitation',
+  icon: <CalendarIcon size={20} />,
+  category: 'Utility',
+  searchTerms: ['calendar', 'invite', 'event', 'meeting', 'schedule', 'ical', 'ics'],
+  command: ({ editor, range }) => {
+    editor.commands.openCalendarInviteModal(range);
+  },
+};

--- a/packages/editor/src/plugins/calendar-invite/types.ts
+++ b/packages/editor/src/plugins/calendar-invite/types.ts
@@ -1,0 +1,40 @@
+export interface CalendarEvent {
+  title: string;
+  date: string;       // YYYY-MM-DD
+  startTime: string;  // HH:MM (24-hour)
+  duration: number;   // minutes; -1 = all day
+  timezone: string;   // IANA timezone identifier
+  location: string;
+  description: string;
+  // Optional card style overrides set by the developer
+  cardBg?: string;
+  accentColor?: string;
+  borderColor?: string;
+}
+
+export interface CalendarPluginOptions {
+  defaultTimezone?: string;
+  cardBg?: string;       // Card background color
+  accentColor?: string;  // Accent color for provider buttons
+  borderColor?: string;  // Card border color
+}
+
+export const CALENDAR_TIMEZONES = [
+  { label: 'UTC', value: 'UTC' },
+  { label: 'Eastern Time (ET)', value: 'America/New_York' },
+  { label: 'Central Time (CT)', value: 'America/Chicago' },
+  { label: 'Mountain Time (MT)', value: 'America/Denver' },
+  { label: 'Pacific Time (PT)', value: 'America/Los_Angeles' },
+  { label: 'Alaska Time', value: 'America/Anchorage' },
+  { label: 'Hawaii Time', value: 'Pacific/Honolulu' },
+  { label: 'London (GMT/BST)', value: 'Europe/London' },
+  { label: 'Paris / Berlin (CET)', value: 'Europe/Paris' },
+  { label: 'Moscow (MSK)', value: 'Europe/Moscow' },
+  { label: 'Dubai (GST)', value: 'Asia/Dubai' },
+  { label: 'India (IST)', value: 'Asia/Kolkata' },
+  { label: 'Bangkok (ICT)', value: 'Asia/Bangkok' },
+  { label: 'Singapore (SGT)', value: 'Asia/Singapore' },
+  { label: 'Tokyo (JST)', value: 'Asia/Tokyo' },
+  { label: 'Sydney (AEDT)', value: 'Australia/Sydney' },
+  { label: 'Auckland (NZST)', value: 'Pacific/Auckland' },
+] as const;

--- a/packages/editor/src/plugins/index.ts
+++ b/packages/editor/src/plugins/index.ts
@@ -1,2 +1,3 @@
+export * from './calendar-invite';
 export * from './email-theming';
 export * from './image';

--- a/packages/editor/src/ui/icons/calendar.tsx
+++ b/packages/editor/src/ui/icons/calendar.tsx
@@ -1,0 +1,25 @@
+import type { IconProps } from './types';
+
+export function CalendarIcon({ size, width, height, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size ?? width ?? 24}
+      height={size ?? height ?? 24}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
+      <line x1="16" x2="16" y1="2" y2="6" />
+      <line x1="8" x2="8" y1="2" y2="6" />
+      <line x1="3" x2="21" y1="10" y2="10" />
+      <path d="M8 14h.01M12 14h.01M16 14h.01M8 18h.01M12 18h.01" />
+    </svg>
+  );
+}

--- a/packages/editor/src/ui/icons/index.ts
+++ b/packages/editor/src/ui/icons/index.ts
@@ -1,3 +1,4 @@
+export { CalendarIcon } from './calendar';
 export { AlignCenterIcon } from './align-center';
 export { AlignCenterVerticalIcon } from './align-center-vertical';
 export { AlignEndVerticalIcon } from './align-end-vertical';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,7 +273,7 @@ importers:
     dependencies:
       mintlify:
         specifier: 4.2.521
-        version: 4.2.521(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@25.5.0)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 4.2.521(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@22.19.17)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -4040,6 +4040,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@use-gesture/core@10.3.1':
     resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
@@ -9791,51 +9792,51 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.1(@types/node@25.5.0)':
+  '@inquirer/checkbox@4.3.1(@types/node@22.19.17)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/confirm@5.1.20(@types/node@25.5.0)':
+  '@inquirer/confirm@5.1.20(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/core@10.3.1(@types/node@25.5.0)':
+  '@inquirer/core@10.3.1(@types/node@22.19.17)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
       cli-width: 4.1.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/editor@4.2.22(@types/node@25.5.0)':
+  '@inquirer/editor@4.2.22(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/external-editor': 1.0.3(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/expand@4.0.22(@types/node@25.5.0)':
+  '@inquirer/expand@4.0.22(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
   '@inquirer/external-editor@1.0.3(@types/node@22.19.17)':
     dependencies:
@@ -9844,97 +9845,90 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.5.0)':
-    dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.0
-    optionalDependencies:
-      '@types/node': 25.5.0
-
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.0(@types/node@25.5.0)':
+  '@inquirer/input@4.3.0(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/number@3.0.22(@types/node@25.5.0)':
+  '@inquirer/number@3.0.22(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/password@4.0.22(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/prompts@7.10.0(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.1(@types/node@25.5.0)
-      '@inquirer/confirm': 5.1.20(@types/node@25.5.0)
-      '@inquirer/editor': 4.2.22(@types/node@25.5.0)
-      '@inquirer/expand': 4.0.22(@types/node@25.5.0)
-      '@inquirer/input': 4.3.0(@types/node@25.5.0)
-      '@inquirer/number': 3.0.22(@types/node@25.5.0)
-      '@inquirer/password': 4.0.22(@types/node@25.5.0)
-      '@inquirer/rawlist': 4.1.10(@types/node@25.5.0)
-      '@inquirer/search': 3.2.1(@types/node@25.5.0)
-      '@inquirer/select': 4.4.1(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/prompts@7.9.0(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.1(@types/node@25.5.0)
-      '@inquirer/confirm': 5.1.20(@types/node@25.5.0)
-      '@inquirer/editor': 4.2.22(@types/node@25.5.0)
-      '@inquirer/expand': 4.0.22(@types/node@25.5.0)
-      '@inquirer/input': 4.3.0(@types/node@25.5.0)
-      '@inquirer/number': 3.0.22(@types/node@25.5.0)
-      '@inquirer/password': 4.0.22(@types/node@25.5.0)
-      '@inquirer/rawlist': 4.1.10(@types/node@25.5.0)
-      '@inquirer/search': 3.2.1(@types/node@25.5.0)
-      '@inquirer/select': 4.4.1(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/rawlist@4.1.10(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/search@3.2.1(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/select@4.4.1(@types/node@25.5.0)':
+  '@inquirer/password@4.0.22(@types/node@22.19.17)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/prompts@7.10.0(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.1(@types/node@22.19.17)
+      '@inquirer/confirm': 5.1.20(@types/node@22.19.17)
+      '@inquirer/editor': 4.2.22(@types/node@22.19.17)
+      '@inquirer/expand': 4.0.22(@types/node@22.19.17)
+      '@inquirer/input': 4.3.0(@types/node@22.19.17)
+      '@inquirer/number': 3.0.22(@types/node@22.19.17)
+      '@inquirer/password': 4.0.22(@types/node@22.19.17)
+      '@inquirer/rawlist': 4.1.10(@types/node@22.19.17)
+      '@inquirer/search': 3.2.1(@types/node@22.19.17)
+      '@inquirer/select': 4.4.1(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/prompts@7.9.0(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.1(@types/node@22.19.17)
+      '@inquirer/confirm': 5.1.20(@types/node@22.19.17)
+      '@inquirer/editor': 4.2.22(@types/node@22.19.17)
+      '@inquirer/expand': 4.0.22(@types/node@22.19.17)
+      '@inquirer/input': 4.3.0(@types/node@22.19.17)
+      '@inquirer/number': 3.0.22(@types/node@22.19.17)
+      '@inquirer/password': 4.0.22(@types/node@22.19.17)
+      '@inquirer/rawlist': 4.1.10(@types/node@22.19.17)
+      '@inquirer/search': 3.2.1(@types/node@22.19.17)
+      '@inquirer/select': 4.4.1(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/rawlist@4.1.10(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
 
-  '@inquirer/type@3.0.10(@types/node@25.5.0)':
+  '@inquirer/search@3.2.1(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.17
+
+  '@inquirer/select@4.4.1(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/type@3.0.10(@types/node@22.19.17)':
+    optionalDependencies:
+      '@types/node': 22.19.17
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -10057,9 +10051,9 @@ snapshots:
 
   '@mediapipe/tasks-vision@0.10.17': {}
 
-  '@mintlify/cli@4.0.1124(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@25.5.0)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+  '@mintlify/cli@4.0.1124(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@22.19.17)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
-      '@inquirer/prompts': 7.9.0(@types/node@25.5.0)
+      '@inquirer/prompts': 7.9.0(@types/node@22.19.17)
       '@mintlify/common': 1.0.858(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/link-rot': 3.0.1034(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/prebuild': 1.0.1000(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
@@ -10072,7 +10066,7 @@ snapshots:
       front-matter: 4.0.2
       fs-extra: 11.2.0
       ink: 6.3.0(@types/react@19.2.14)(react@19.2.4)
-      inquirer: 12.3.0(@types/node@25.5.0)
+      inquirer: 12.3.0(@types/node@22.19.17)
       js-yaml: 4.1.1
       mdast-util-mdx-jsx: 3.2.0
       open: 8.4.2
@@ -14277,12 +14271,12 @@ snapshots:
 
   inline-style-parser@0.2.4: {}
 
-  inquirer@12.3.0(@types/node@25.5.0):
+  inquirer@12.3.0(@types/node@22.19.17):
     dependencies:
-      '@inquirer/core': 10.3.1(@types/node@25.5.0)
-      '@inquirer/prompts': 7.10.0(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-      '@types/node': 25.5.0
+      '@inquirer/core': 10.3.1(@types/node@22.19.17)
+      '@inquirer/prompts': 7.10.0(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      '@types/node': 22.19.17
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 3.0.0
@@ -15354,9 +15348,9 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
-  mintlify@4.2.521(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@25.5.0)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  mintlify@4.2.521(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@22.19.17)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
-      '@mintlify/cli': 4.0.1124(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@25.5.0)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@mintlify/cli': 4.0.1124(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@22.19.17)(@types/react@19.2.14)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/node'


### PR DESCRIPTION
I spoke to a few people at an event recently that asked for the ability to send calendar invites via Resend. I thought that would be a cool add to the open source editor, too. This is my vibe coded proof-of-concept version of it.

---

Adds a /calendar-invite slash command that opens a modal for configuring a calendar event.

Inserts a card with provider buttons (Google, Outlook, Apple, Yahoo) that link directly to add-to-calendar URLs. Apple Calendar uses a data:text/calendar URI so no file hosting is needed. 

Supports multiple invites per email, custom card styling via CalendarPluginOptions, and renders correctly to React Email HTML output.

## Testing
Run the app, then visit http://localhost:3000/editor/standalone-editor
Type /calendar and select the calendar invite option
Set the details for the event and it should insert an invite
(I haven't verified this yet, but Claude assures me that the calendar invite buttons do work in the generated HTML of the email)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `/calendar-invite` slash command that opens a modal to create an event and inserts an “Add to calendar” card with Google, Outlook, Apple, and Yahoo links. The card renders in React Email and can be customized via `EmailEditor` props, with fixes for all‑day/multi‑day date math, editor scoping, and smarter defaults.

- **New Features**
  - Slash command with modal: date picker, start time, duration (incl. “All day”), timezone, location, notes.
  - Inserts a calendar invite card with provider buttons; Apple uses a `data:text/calendar` URI (no file hosting).
  - Multiple invites per email; draggable atom node with an in-editor preview card.
  - New `CalendarInvite` node with React Email rendering and URL/ICS generation.
  - Enabled by default; customize via `calendarInvite` prop (`defaultTimezone`, `cardBg`, `accentColor`, `borderColor`).
  - Event bus: `'calendar-invite:open'` for launching the modal.
  - Exports: `CalendarInvite`, `CalendarInvitePlugin`, `calendarInviteSlashCommand`, `detectCalendarTimezone()`, `CALENDAR_TIMEZONES`, and types.

- **Bug Fixes**
  - Correct all-day next-day and multi-day end dates using UTC arithmetic to avoid timezone shifts in iCal.
  - Scope `'calendar-invite:open'` to the originating editor instance to prevent cross-triggering.
  - Register the slash command and plugin only when `CalendarInvite` is present to avoid crashes with custom extensions.
  - Compute the default start time via epoch-based rounding to handle day rollover; validate `defaultTimezone` with `Intl.DateTimeFormat` and include unknown but valid zones in the select.
  - Generate ICS `UID` with `crypto.randomBytes` to avoid insecure randomness.

<sup>Written for commit e14bfae5b3617e5f07e6fa325c1cd5f848cd122a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



