### PR TITLE
chore: remove dangling changeset

### DIFF
--- a/.changeset/mean-feet-go.md
+++ b/.changeset/mean-feet-go.md
@@ -1,5 +1,0 @@
----
-"@react-email/render": patch
----
-
-fix missing `MessageChannel` error


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove dangling changeset `.changeset/mean-feet-go.md` that referenced a patch for `@react-email/render` (“fix missing MessageChannel error”). This avoids an unintended release bump and keeps the changeset queue clean.

<sup>Written for commit 4eae6c4fd3034b74cf0ae61a0849b017aa52717e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

