### PR TITLE
chore: remove @types/prettier

### DIFF
--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -125,7 +125,6 @@
   "devDependencies": {
     "@edge-runtime/vm": "5.0.0",
     "@types/html-to-text": "9.0.4",
-    "@types/prettier": "3.0.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@types/shelljs": "0.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,9 +784,6 @@ importers:
       '@types/html-to-text':
         specifier: 9.0.4
         version: 9.0.4
-      '@types/prettier':
-        specifier: 3.0.0
-        version: 3.0.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -4001,10 +3998,6 @@ packages:
 
   '@types/phoenix@1.6.6':
     resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
-
-  '@types/prettier@3.0.0':
-    resolution: {integrity: sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==}
-    deprecated: This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.
 
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
@@ -12212,10 +12205,6 @@ snapshots:
   '@types/offscreencanvas@2019.7.3': {}
 
   '@types/phoenix@1.6.6': {}
-
-  '@types/prettier@3.0.0':
-    dependencies:
-      prettier: 3.8.3
 
   '@types/prismjs@1.26.6': {}
 


### PR DESCRIPTION
addressing pnpm's warning:

```zig
 WARN  deprecated @types/prettier@3.0.0: This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `@types/prettier` from `packages/render` devDependencies since `prettier` provides its own types. Updated `pnpm-lock.yaml` to remove the stub package and silence pnpm warnings.

<sup>Written for commit c67fcebd75e33143c1828cb9a6bcff359f8d9765. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

