### PR TITLE
fix(web): validate request payloads in test-send endpoint

### DIFF
--- a/apps/web/src/app/api/send/test/body-schema.spec.ts
+++ b/apps/web/src/app/api/send/test/body-schema.spec.ts
@@ -1,0 +1,33 @@
+import { bodySchema } from './route';
+
+describe('send test body schema', () => {
+    test('accepts a valid payload', () => {
+        expect(
+            bodySchema.safeParse({
+                to: 'user@example.com',
+                subject: 'Hello there',
+                html: '<p>Hello</p>',
+            }).success,
+        ).toBe(true);
+    });
+
+    test('rejects invalid email addresses', () => {
+        expect(
+            bodySchema.safeParse({
+                to: 'not-an-email',
+                subject: 'Hello there',
+                html: '<p>Hello</p>',
+            }).success,
+        ).toBe(false);
+    });
+
+    test('rejects overlong subjects and html', () => {
+        expect(
+            bodySchema.safeParse({
+                to: 'user@example.com',
+                subject: 'a'.repeat(201),
+                html: '<p>' + 'a'.repeat(100_001) + '</p>',
+            }).success,
+        ).toBe(false);
+    });
+});

--- a/apps/web/src/app/api/send/test/route.ts
+++ b/apps/web/src/app/api/send/test/route.ts
@@ -8,11 +8,14 @@ export function OPTIONS() {
   return Promise.resolve(NextResponse.json({}));
 }
 
-const bodySchema = z.object({
-  to: z.string(),
-  subject: z.string(),
-  html: z.string(),
+export const bodySchema = z.object({
+  to: z.string().trim().pipe(z.string().email()),
+  subject: z.string().trim().min(1).max(200),
+  html: z.string().min(1).max(100_000),
 });
+
+const invalidRequestBodyResponse = () =>
+  NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
 
 export async function POST(req: NextRequest) {
   const { rateLimited, error } = await checkRateLimit('test-email-sending', {
@@ -46,7 +49,21 @@ export async function POST(req: NextRequest) {
   const supabase = createClient(supabaseUrl, supabaseKey);
 
   try {
-    const { to, subject, html } = bodySchema.parse(await req.json());
+    let body: unknown;
+
+    try {
+      body = await req.json();
+    } catch {
+      return invalidRequestBodyResponse();
+    }
+
+    const result = bodySchema.safeParse(body);
+
+    if (!result.success) {
+      return invalidRequestBodyResponse();
+    }
+
+    const { to, subject, html } = result.data;
 
     const ip = req.headers.get('x-vercel-forwarded-for');
     const latitude = req.headers.get('x-vercel-ip-latitude');


### PR DESCRIPTION
## Description

This PR adds lightweight request body validation for the `/api/send/test` endpoint and improves handling of malformed requests.

### Changes

* Validate the `to` field as an email address
* Add length limits for `subject` and `html`
* Return `400` responses for invalid or malformed request bodies instead of treating them as server errors
* Add schema validation tests covering valid and invalid payloads

### Notes

The change is intentionally minimal and does not affect valid existing requests.

### Tests

Verified with:

```bash id="07c7j8"
pnpm --filter web exec vitest run src/app/api/send/test/body-schema.spec.ts
```

Passing tests include:

* accepts a valid payload
* rejects invalid email addresses
* rejects overlong subjects and html

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds request body validation and proper 400 responses to the `/api/send/test` endpoint to prevent server errors from malformed inputs. Improves input safety without affecting valid requests.

- **Bug Fixes**
  - Validate `to` as an email; enforce `subject` (1–200) and `html` (1–100,000) limits.
  - Return 400 for invalid JSON or body schema failures.
  - Add schema tests for valid and invalid payloads.

<sup>Written for commit 6577d71e07a39711b4ad718b8e7530925b4ad588. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

