### PR TITLE
fix(cli): dependency installation not including dev dependencies

### DIFF
--- a/.changeset/weak-kids-admire.md
+++ b/.changeset/weak-kids-admire.md
@@ -1,0 +1,6 @@
+---
+"react-email": patch
+---
+
+- deprecate packageManager CLI option for `email build`, only supporting npm
+- ensure `email build` dependency installation includes dev dependencies

--- a/packages/react-email/src/cli/commands/build.ts
+++ b/packages/react-email/src/cli/commands/build.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getPackages } from '@manypkg/get-packages';
 import logSymbols from 'log-symbols';
-import { installDependencies, type PackageManagerName, runScript } from 'nypm';
+import { installDependencies, runScript } from 'nypm';
 import {
   type EmailsDirectory,
   getEmailsDirectoryMetadata,
@@ -14,7 +14,7 @@ import { createSpinner, stopSpinnerAndPersist } from '../utils/spinner.js';
 
 interface Args {
   dir: string;
-  packageManager: PackageManagerName;
+  packageManager?: string;
 }
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -174,6 +174,12 @@ export const build = async ({
   dir: emailsDirRelativePath,
   packageManager,
 }: Args) => {
+  if (packageManager) {
+    console.warn(
+      'The --packageManager option is deprecated and ignored. The build command now just uses npm.',
+    );
+  }
+
   try {
     const usersProjectLocation = process.cwd();
     const previewServerLocation = await getUiLocation();
@@ -248,11 +254,22 @@ export const build = async ({
 
     if (!isInReactEmailMonorepo) {
       spinner.setText('Installing dependencies on `.react-email`');
-      await installDependencies({
-        cwd: builtPreviewAppPath,
-        silent: true,
-        packageManager,
-      });
+      const previousInclude = process.env.NPM_CONFIG_INCLUDE;
+      process.env.NPM_CONFIG_INCLUDE = 'dev';
+
+      try {
+        await installDependencies({
+          cwd: builtPreviewAppPath,
+          silent: true,
+          packageManager: 'npm',
+        });
+      } finally {
+        if (previousInclude === undefined) {
+          delete process.env.NPM_CONFIG_INCLUDE;
+        } else {
+          process.env.NPM_CONFIG_INCLUDE = previousInclude;
+        }
+      }
     }
 
     stopSpinnerAndPersist(spinner, {
@@ -261,7 +278,7 @@ export const build = async ({
     });
 
     await runScript('build', {
-      packageManager,
+      packageManager: 'npm',
       cwd: builtPreviewAppPath,
     });
   } catch (error) {

--- a/packages/react-email/src/cli/index.ts
+++ b/packages/react-email/src/cli/index.ts
@@ -61,8 +61,8 @@ if (!hasRequiredFlags) {
       './emails',
     )
     .addOption(
-      // Deprecated and hidden from --help; the runtime warning lives in build.ts.
-      new Option('-p, --packageManager <name>').default('npm').hideHelp(),
+      // deprecated
+      new Option('-p, --packageManager <name>').hideHelp(),
     )
     .action(build);
 

--- a/packages/react-email/src/cli/index.ts
+++ b/packages/react-email/src/cli/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
-import { program } from 'commander';
+import { Option, program } from 'commander';
 import { build } from './commands/build.js';
 import { dev } from './commands/dev.js';
 import { exportTemplates } from './commands/export.js';
@@ -60,10 +60,9 @@ if (!hasRequiredFlags) {
       'Directory with your email templates',
       './emails',
     )
-    .option(
-      '-p --packageManager <name>',
-      'Package name to use on installation on `.react-email`',
-      'npm',
+    .addOption(
+      // Deprecated and hidden from --help; the runtime warning lives in build.ts.
+      new Option('-p, --packageManager <name>').default('npm').hideHelp(),
     )
     .action(build);
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes `email build` installs by including dev dependencies and standardizes the build to always use `npm`. This resolves build failures in the generated `.react-email` app.

- **Bug Fixes**
  - Set `NPM_CONFIG_INCLUDE=dev` during dependency install in `.react-email`.
  - Use `npm` for both `installDependencies` and `runScript('build')` via `nypm`.

- **Migration**
  - `--packageManager` is deprecated and ignored; `email build` always uses `npm`. The option is hidden from `--help`, has no default, and shows a runtime warning if passed.

<sup>Written for commit 4e30e0b801492efbf550cc4ad3d0b9df97962df8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

