### PR TITLE
fix: block typing over the divider block

### DIFF
--- a/.changeset/modern-ravens-stare.md
+++ b/.changeset/modern-ravens-stare.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Blocks typing over the divider block and by mistake removing it from the content.

--- a/apps/web/src/app/editor/full-email-builder/example.tsx
+++ b/apps/web/src/app/editor/full-email-builder/example.tsx
@@ -169,7 +169,7 @@ export function FullEmailBuilder() {
             />
 
             <BubbleMenu
-              hideWhenActiveNodes={['button', 'horizontalRule']}
+              hideWhenActiveNodes={['button']}
               hideWhenActiveMarks={['link']}
             />
             <BubbleMenu.LinkDefault />

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -188,7 +188,9 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
         <RefBridge editorRef={ref} onUpdateRef={onUpdateRef} />
         <EmailEditorReadyBridge onReadyRef={onReadyRef} />
         <BubbleMenu
-          hideWhenActiveNodes={bubbleMenu?.hideWhenActiveNodes ?? ['button', 'horizontalRule']}
+          hideWhenActiveNodes={
+            bubbleMenu?.hideWhenActiveNodes ?? ['button', 'horizontalRule']
+          }
           hideWhenActiveMarks={bubbleMenu?.hideWhenActiveMarks ?? ['link']}
         />
         <BubbleMenu.LinkDefault />

--- a/packages/editor/src/email-editor/email-editor.tsx
+++ b/packages/editor/src/email-editor/email-editor.tsx
@@ -188,7 +188,7 @@ export const EmailEditor = forwardRef<EmailEditorRef, EmailEditorProps>(
         <RefBridge editorRef={ref} onUpdateRef={onUpdateRef} />
         <EmailEditorReadyBridge onReadyRef={onReadyRef} />
         <BubbleMenu
-          hideWhenActiveNodes={bubbleMenu?.hideWhenActiveNodes ?? ['button']}
+          hideWhenActiveNodes={bubbleMenu?.hideWhenActiveNodes ?? ['button', 'horizontalRule']}
           hideWhenActiveMarks={bubbleMenu?.hideWhenActiveMarks ?? ['link']}
         />
         <BubbleMenu.LinkDefault />

--- a/packages/editor/src/extensions/divider.spec.tsx
+++ b/packages/editor/src/extensions/divider.spec.tsx
@@ -1,6 +1,35 @@
+import { Editor } from '@tiptap/core';
 import { render } from 'react-email';
 import { DEFAULT_STYLES } from '../utils/default-styles';
 import { Divider } from './divider';
+import { StarterKit } from './index';
+
+function createDividerEditor() {
+  const element = document.createElement('div');
+  document.body.append(element);
+  return new Editor({
+    element,
+    extensions: [
+      StarterKit.configure({ Container: false, TrailingNode: false }),
+    ],
+    content: {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'Before' }] },
+        { type: 'horizontalRule', attrs: { class: 'divider' } },
+        { type: 'paragraph', content: [{ type: 'text', text: 'After' }] },
+      ],
+    },
+  });
+}
+
+function getHrPosition(editor: Editor): number {
+  let pos = -1;
+  editor.state.doc.descendants((node, p) => {
+    if (node.type.name === 'horizontalRule') pos = p;
+  });
+  return pos;
+}
 
 describe('Divider Node', () => {
   it('renders React Email properly', async () => {
@@ -23,5 +52,45 @@ describe('Divider Node', () => {
         { pretty: true },
       ),
     ).toMatchSnapshot();
+  });
+});
+
+describe('Divider node selection protection', () => {
+  it('does not replace the divider when typing while it is node-selected', () => {
+    const editor = createDividerEditor();
+    const hrPos = getHrPosition(editor);
+    editor.commands.setNodeSelection(hrPos);
+
+    const { state } = editor;
+    const para = state.schema.nodes.paragraph.createAndFill(
+      null,
+      state.schema.text('a'),
+    )!;
+    editor.view.dispatch(state.tr.replaceSelectionWith(para));
+
+    expect(
+      editor.getJSON().content?.some((n) => n.type === 'horizontalRule'),
+    ).toBe(true);
+
+    editor.destroy();
+  });
+
+  it('still deletes the divider when Backspace is pressed while it is node-selected', () => {
+    const editor = createDividerEditor();
+    const hrPos = getHrPosition(editor);
+    editor.commands.setNodeSelection(hrPos);
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Backspace',
+      bubbles: true,
+      cancelable: true,
+    });
+    editor.view.someProp('handleKeyDown', (f) => f(editor.view, event));
+
+    expect(
+      editor.getJSON().content?.some((n) => n.type === 'horizontalRule'),
+    ).toBe(false);
+
+    editor.destroy();
   });
 });

--- a/packages/editor/src/extensions/divider.tsx
+++ b/packages/editor/src/extensions/divider.tsx
@@ -1,13 +1,14 @@
 import { InputRule } from '@tiptap/core';
 import type { HorizontalRuleOptions } from '@tiptap/extension-horizontal-rule';
 import HorizontalRule from '@tiptap/extension-horizontal-rule';
-import { Hr } from 'react-email';
-
-export type DividerOptions = HorizontalRuleOptions;
-
+import { NodeSelection, Plugin } from '@tiptap/pm/state';
+import { ReplaceStep } from '@tiptap/pm/transform';
 import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react';
+import { Hr } from 'react-email';
 import { EmailNode } from '../core';
 import { inlineCssToJs } from '../utils/styles';
+
+export type DividerOptions = HorizontalRuleOptions;
 
 export const Divider: EmailNode<HorizontalRuleOptions, any> = EmailNode.from(
   HorizontalRule.extend({
@@ -34,6 +35,27 @@ export const Divider: EmailNode<HorizontalRuleOptions, any> = EmailNode.from(
               tr.mapping.map(start),
               tr.mapping.map(end),
             );
+          },
+        }),
+      ];
+    },
+    addProseMirrorPlugins() {
+      return [
+        new Plugin({
+          filterTransaction(tr, state) {
+            const { selection } = state;
+            const isDividerNodeSelection =
+              selection instanceof NodeSelection &&
+              selection.node.type.name === 'horizontalRule';
+
+            if (!isDividerNodeSelection || !tr.docChanged) return true;
+
+            const isTypingOverDivider = tr.steps.some(
+              (step) =>
+                step instanceof ReplaceStep && step.slice.content.size > 0,
+            );
+
+            return !isTypingOverDivider;
           },
         }),
       ];

--- a/packages/editor/src/ui/bubble-menu/triggers.ts
+++ b/packages/editor/src/ui/bubble-menu/triggers.ts
@@ -1,5 +1,5 @@
 import type { Editor } from '@tiptap/core';
-import type { EditorState } from '@tiptap/pm/state';
+import { NodeSelection, type EditorState } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
 
 export interface TriggerParams {
@@ -18,6 +18,12 @@ export const bubbleMenuTriggers = {
     hideWhenActiveMarks: string[] = [],
   ): TriggerFn {
     return ({ editor, state }) => {
+      if (
+        state.selection instanceof NodeSelection &&
+        hideWhenActiveNodes.includes(state.selection.node.type.name)
+      ) {
+        return false;
+      }
       for (const node of hideWhenActiveNodes) {
         if (editor.isActive(node)) {
           return false;

--- a/packages/editor/src/ui/bubble-menu/triggers.ts
+++ b/packages/editor/src/ui/bubble-menu/triggers.ts
@@ -1,5 +1,5 @@
 import type { Editor } from '@tiptap/core';
-import { NodeSelection, type EditorState } from '@tiptap/pm/state';
+import { type EditorState, NodeSelection } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
 
 export interface TriggerParams {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

## Description

This PR adds a new ProseMirror plugin to the divider extension that blocks any transactions adding content (like type) over the divider. 

I also had to update the bubble trigger to stop appearing in this case, so by default it's now the button and divider, but the user can override it by passing the prop `hideWhenActiveNodes` as before.

Video showing it working:
https://www.loom.com/share/cf524b2cba48449b91931fdf5532dc4e

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks typing over the divider (`horizontalRule`) and hides the bubble menu when it’s selected to prevent accidental edits. Addresses Linear DEV-632.

- **Bug Fixes**
  - Added a ProseMirror plugin in the divider extension that blocks insert/replace when a `horizontalRule` is node-selected; Backspace still deletes it.
  - Updated bubble menu triggers to check `NodeSelection`; the menu hides when `horizontalRule` is selected.
  - Set default `BubbleMenu` `hideWhenActiveNodes` to `['button', 'horizontalRule']`.
  - Added tests to ensure typing doesn’t replace the divider and Backspace deletes it.

<sup>Written for commit 4346632e27d3016a63689b3c2a4c385ae10b5fb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

