### PR TITLE
fix: spinner rendering for non tty environments

### DIFF
--- a/.changeset/quiet-spinner-on-ci.md
+++ b/.changeset/quiet-spinner-on-ci.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Avoid spamming each spinner frame as a new line on non-TTY streams (CI logs, pipes, dumb terminals). The spinner now logs each status text once instead of redrawing animated frames when the output is not a TTY.

--- a/packages/react-email/src/cli/utils/spinner.spec.ts
+++ b/packages/react-email/src/cli/utils/spinner.spec.ts
@@ -1,0 +1,109 @@
+import { Writable } from 'node:stream';
+import { afterEach, beforeEach } from 'vitest';
+import { createSpinner, stopSpinnerAndPersist } from './spinner.js';
+
+const createNonTTYStream = () => {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  }) as Writable & { isTTY?: boolean };
+  stream.isTTY = false;
+  return { stream: stream as unknown as NodeJS.WriteStream, chunks };
+};
+
+const previousCI = process.env.CI;
+
+beforeEach(() => {
+  // Force the non-TTY codepath even if a developer happens to run the test
+  // suite on a real TTY where process.stdout.isTTY is true.
+  process.env.CI = 'true';
+});
+
+afterEach(() => {
+  if (previousCI === undefined) {
+    delete process.env.CI;
+  } else {
+    process.env.CI = previousCI;
+  }
+});
+
+test('non-TTY spinner only logs each unique line once', () => {
+  const { stream, chunks } = createNonTTYStream();
+
+  const spinner = createSpinner({
+    text: 'Installing dependencies on `.react-email`',
+    prefixText: '  ',
+    stream,
+  });
+
+  spinner.start();
+  // simulate the picospinner ticking many times with the same text
+  for (let i = 0; i < 20; i += 1) {
+    spinner.setText('Installing dependencies on `.react-email`');
+  }
+  stopSpinnerAndPersist(spinner, {
+    text: 'Successfully prepared `.react-email` for `next build`',
+    symbol: '✔',
+  });
+
+  expect(chunks).toEqual([
+    '  Installing dependencies on `.react-email`\n',
+    '  ✔ Successfully prepared `.react-email` for `next build`\n',
+  ]);
+});
+
+test('non-TTY spinner logs each new text exactly once', () => {
+  const { stream, chunks } = createNonTTYStream();
+
+  const spinner = createSpinner({
+    text: 'Step one',
+    prefixText: '  ',
+    stream,
+  });
+
+  spinner.start();
+  spinner.setText('Step two');
+  spinner.setText('Step two');
+  spinner.setText('Step three');
+  spinner.succeed('All done');
+
+  expect(chunks).toEqual([
+    '  Step one\n',
+    '  Step two\n',
+    '  Step three\n',
+    '  ✔ All done\n',
+  ]);
+});
+
+test('non-TTY spinner stops cleanly without crashing', () => {
+  const { stream, chunks } = createNonTTYStream();
+
+  const spinner = createSpinner({ text: 'Working', stream });
+
+  spinner.start();
+  expect(spinner.running).toBe(true);
+
+  spinner.stop();
+  expect(spinner.running).toBe(false);
+
+  // setText after stop should not log anything new
+  spinner.setText('Should not be logged');
+  expect(chunks).toEqual(['Working\n']);
+});
+
+test('non-TTY spinner trims trailing newlines from the rendered text', () => {
+  const { stream, chunks } = createNonTTYStream();
+
+  const spinner = createSpinner({
+    text: 'Getting things ready...\n',
+    prefixText: ' ',
+    stream,
+  });
+
+  spinner.start();
+
+  expect(chunks).toEqual([' Getting things ready...\n']);
+});

--- a/packages/react-email/src/cli/utils/spinner.ts
+++ b/packages/react-email/src/cli/utils/spinner.ts
@@ -16,7 +16,15 @@ type PersistDisplay = DisplayOptions & {
   symbol: string;
 };
 
-export type Spinner = PicoSpinner;
+export interface Spinner {
+  readonly running: boolean;
+  start(): void;
+  stop(): void;
+  setText(text: string): void;
+  setDisplay(display: DisplayOptions): void;
+  succeed(display?: string | DisplayOptions): void;
+  fail(display?: string | DisplayOptions): void;
+}
 
 const withPrefixText = (
   prefixText: string | undefined,
@@ -44,10 +52,103 @@ const normalizeDisplay = (display: SpinnerDisplay): DisplayOptions | string => {
   };
 };
 
+// Animated spinners only render correctly on a TTY, where ANSI cursor
+// movement codes can overwrite the previous frame. On non-TTY streams (CI
+// logs, files, pipes) every frame would otherwise be appended verbatim,
+// spamming the output. See https://github.com/resend/react-email/issues/...
+const isInteractiveStream = (stream: NodeJS.WriteStream): boolean => {
+  if (!stream.isTTY) return false;
+  if (process.env.TERM === 'dumb') return false;
+  if (process.env.CI) return false;
+  return true;
+};
+
+class NonInteractiveSpinner implements Spinner {
+  running = false;
+
+  private text = '';
+  private prefixText = '';
+  private readonly stream: NodeJS.WriteStream;
+  private lastLoggedLine: string | undefined;
+
+  constructor(display: SpinnerDisplay) {
+    if (typeof display === 'string') {
+      this.text = display;
+      this.stream = process.stdout;
+    } else {
+      this.text = display.text ?? '';
+      this.prefixText = display.prefixText ?? '';
+      this.stream = display.stream ?? process.stdout;
+    }
+  }
+
+  start(): void {
+    this.running = true;
+    this.log();
+  }
+
+  stop(): void {
+    this.running = false;
+  }
+
+  setText(text: string): void {
+    this.text = text;
+    if (this.running) {
+      this.log();
+    }
+  }
+
+  setDisplay(display: DisplayOptions & { symbol?: string }): void {
+    if (typeof display.text === 'string') {
+      this.text = display.text;
+    }
+    const { symbol } = display;
+    this.log(symbol);
+    if (typeof symbol === 'string') {
+      this.running = false;
+    }
+  }
+
+  succeed(display?: string | DisplayOptions): void {
+    this.finish('✔', display);
+  }
+
+  fail(display?: string | DisplayOptions): void {
+    this.finish('✖', display);
+  }
+
+  private finish(symbol: string, display?: string | DisplayOptions): void {
+    if (typeof display === 'string') {
+      this.text = display;
+    } else if (typeof display?.text === 'string') {
+      this.text = display.text;
+    }
+    this.log(symbol);
+    this.running = false;
+  }
+
+  private log(symbol?: string): void {
+    const symbolPrefix =
+      typeof symbol === 'string' && symbol.length > 0 ? `${symbol} ` : '';
+    const trimmedText = this.text.replace(/\n+$/, '');
+    const line = `${this.prefixText}${symbolPrefix}${trimmedText}`;
+    if (line === this.lastLoggedLine) return;
+    this.lastLoggedLine = line;
+    this.stream.write(`${line}\n`);
+  }
+}
+
 export const createSpinner = (
   display: SpinnerDisplay,
   options?: SpinnerOptions,
-) => new PicoSpinner(normalizeDisplay(display), options);
+): Spinner => {
+  const stream =
+    (typeof display !== 'string' && display.stream) || process.stdout;
+  if (!isInteractiveStream(stream)) {
+    return new NonInteractiveSpinner(display);
+  }
+  return new PicoSpinner(normalizeDisplay(display), options);
+};
 
 export const stopSpinnerAndPersist = (
   spinner: Spinner | undefined,

--- a/packages/react-email/src/cli/utils/tree.spec.ts
+++ b/packages/react-email/src/cli/utils/tree.spec.ts
@@ -22,6 +22,7 @@ test('tree(__dirname, 2)', async () => {
     ├── index.ts
     ├── packageJson.ts
     ├── register-spinner-autostopping.ts
+    ├── spinner.spec.ts
     ├── spinner.ts
     ├── style-text.ts
     ├── tree.spec.ts

--- a/packages/ui/src/utils/spinner.ts
+++ b/packages/ui/src/utils/spinner.ts
@@ -16,7 +16,15 @@ type PersistDisplay = DisplayOptions & {
   symbol: string;
 };
 
-export type Spinner = PicoSpinner;
+export interface Spinner {
+  readonly running: boolean;
+  start(): void;
+  stop(): void;
+  setText(text: string): void;
+  setDisplay(display: DisplayOptions): void;
+  succeed(display?: string | DisplayOptions): void;
+  fail(display?: string | DisplayOptions): void;
+}
 
 const withPrefixText = (
   prefixText: string | undefined,
@@ -44,10 +52,103 @@ const normalizeDisplay = (display: SpinnerDisplay): DisplayOptions | string => {
   };
 };
 
+// Animated spinners only render correctly on a TTY, where ANSI cursor
+// movement codes can overwrite the previous frame. On non-TTY streams (CI
+// logs, files, pipes) every frame would otherwise be appended verbatim,
+// spamming the output.
+const isInteractiveStream = (stream: NodeJS.WriteStream): boolean => {
+  if (!stream.isTTY) return false;
+  if (process.env.TERM === 'dumb') return false;
+  if (process.env.CI) return false;
+  return true;
+};
+
+class NonInteractiveSpinner implements Spinner {
+  running = false;
+
+  private text = '';
+  private prefixText = '';
+  private readonly stream: NodeJS.WriteStream;
+  private lastLoggedLine: string | undefined;
+
+  constructor(display: SpinnerDisplay) {
+    if (typeof display === 'string') {
+      this.text = display;
+      this.stream = process.stdout;
+    } else {
+      this.text = display.text ?? '';
+      this.prefixText = display.prefixText ?? '';
+      this.stream = display.stream ?? process.stdout;
+    }
+  }
+
+  start(): void {
+    this.running = true;
+    this.log();
+  }
+
+  stop(): void {
+    this.running = false;
+  }
+
+  setText(text: string): void {
+    this.text = text;
+    if (this.running) {
+      this.log();
+    }
+  }
+
+  setDisplay(display: DisplayOptions & { symbol?: string }): void {
+    if (typeof display.text === 'string') {
+      this.text = display.text;
+    }
+    const { symbol } = display;
+    this.log(symbol);
+    if (typeof symbol === 'string') {
+      this.running = false;
+    }
+  }
+
+  succeed(display?: string | DisplayOptions): void {
+    this.finish('✔', display);
+  }
+
+  fail(display?: string | DisplayOptions): void {
+    this.finish('✖', display);
+  }
+
+  private finish(symbol: string, display?: string | DisplayOptions): void {
+    if (typeof display === 'string') {
+      this.text = display;
+    } else if (typeof display?.text === 'string') {
+      this.text = display.text;
+    }
+    this.log(symbol);
+    this.running = false;
+  }
+
+  private log(symbol?: string): void {
+    const symbolPrefix =
+      typeof symbol === 'string' && symbol.length > 0 ? `${symbol} ` : '';
+    const trimmedText = this.text.replace(/\n+$/, '');
+    const line = `${this.prefixText}${symbolPrefix}${trimmedText}`;
+    if (line === this.lastLoggedLine) return;
+    this.lastLoggedLine = line;
+    this.stream.write(`${line}\n`);
+  }
+}
+
 export const createSpinner = (
   display: SpinnerDisplay,
   options?: SpinnerOptions,
-) => new PicoSpinner(normalizeDisplay(display), options);
+): Spinner => {
+  const stream =
+    (typeof display !== 'string' && display.stream) || process.stdout;
+  if (!isInteractiveStream(stream)) {
+    return new NonInteractiveSpinner(display);
+  }
+  return new PicoSpinner(normalizeDisplay(display), options);
+};
 
 export const stopSpinnerAndPersist = (
   spinner: Spinner | undefined,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes spinner output on non-TTY streams (CI, pipes, dumb terminals) by switching to a non-interactive mode that prints each status once instead of animating frames. Updates spinner utils in `react-email` and `ui`; TTY behavior is unchanged.

- **Bug Fixes**
  - Detect non-interactive streams (`!isTTY`, `TERM=dumb`, or `CI`) and use a non-interactive spinner.
  - In non-TTY, log only new text lines, trim trailing newlines, and persist final success/fail lines with symbols.
  - Added tests for non-TTY behavior and updated tree snapshot.

<sup>Written for commit 89588735eb58e041323f1350b2e58a064ed3cdf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

