### PR TITLE
fix(web): hide bubble menu when divider is selected in full-email-builder example

### DIFF
--- a/apps/web/src/app/editor/full-email-builder/example.tsx
+++ b/apps/web/src/app/editor/full-email-builder/example.tsx
@@ -169,7 +169,7 @@ export function FullEmailBuilder() {
             />
 
             <BubbleMenu
-              hideWhenActiveNodes={['button']}
+              hideWhenActiveNodes={['button', 'horizontalRule']}
               hideWhenActiveMarks={['link']}
             />
             <BubbleMenu.LinkDefault />


### PR DESCRIPTION
## Summary

- Adds `'horizontalRule'` to `hideWhenActiveNodes` in the full-email-builder example so the text bubble menu no longer appears when a divider block is selected.

## Context

The bubble menu trigger (`textSelection`) now correctly suppresses the menu for any `NodeSelection` whose node type is in `hideWhenActiveNodes` (fixed in the companion PR). This change updates the example to opt in to that behavior for the divider.

## Test plan

- [ ] Open the full-email-builder example (`/editor/full-email-builder`)
- [ ] Add a divider block via the slash command
- [ ] Click the divider — bubble menu should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the text bubble menu when a divider is selected in the full-email-builder example by adding horizontalRule to the BubbleMenu’s hideWhenActiveNodes list.

<sup>Written for commit b16be0f855fd4662930005ce341e2d3e6a6ca5c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

