### PR TITLE
chore(ci): harden security

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -6,6 +6,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   bump:
+    timeout-minutes: 30
     runs-on: depot-ubuntu-22.04-2
     permissions: 
       contents: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,14 +5,16 @@ on:
       - main
       - canary
   pull_request:
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 permissions:
   contents: read
   pull-requests: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   e2e:
+    # Org secrets in step env: push + same-repo PRs only; fork PRs evaluate to empty (explicit for review).
+    timeout-minutes: 45
     runs-on: depot-ubuntu-22.04-8
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-noble
@@ -36,15 +38,15 @@ jobs:
         run: pnpm build
         env:
           REDIS_URL: redis://localhost:6379
-          SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
-          SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          SPAM_ASSASSIN_HOST: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.SPAM_ASSASSIN_HOST || '' }}
+          SPAM_ASSASSIN_PORT: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.SPAM_ASSASSIN_PORT || '' }}
+          TURBO_TOKEN: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.TURBO_TOKEN || '' }}
+          TURBO_TEAM: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.TURBO_TEAM || '' }}
       - name: Run Tailwind integration tests
         run: pnpm turbo test:e2e
         env:
           REDIS_URL: redis://localhost:6379
-          SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
-          SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          SPAM_ASSASSIN_HOST: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.SPAM_ASSASSIN_HOST || '' }}
+          SPAM_ASSASSIN_PORT: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.SPAM_ASSASSIN_PORT || '' }}
+          TURBO_TOKEN: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.TURBO_TOKEN || '' }}
+          TURBO_TEAM: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.TURBO_TEAM || '' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,14 +5,15 @@ on:
       - main
       - canary
   pull_request:
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 permissions:
   contents: read
   pull-requests: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   lint:
+    timeout-minutes: 20
     runs-on: depot-ubuntu-22.04-2
     container:
       image: node:24-slim

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -5,14 +5,15 @@ on:
       - main
       - canary
   pull_request:
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 permissions:
   contents: read
   pull-requests: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   pin-dependencies-check:
+    timeout-minutes: 15
     runs-on: depot-ubuntu-22.04-2
     container:
       image: node:24-slim

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -7,6 +7,8 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   preview-release:
+    # Build secrets: same-repo PRs only; fork PRs evaluate to empty (explicit for review).
+    timeout-minutes: 45
     runs-on: depot-ubuntu-22.04-8
     permissions: 
       contents: write
@@ -34,10 +36,10 @@ jobs:
         if: steps.changed_packages.outputs.all_changed_and_modified_files != ''
         run: pnpm build
         env:
-          SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
-          SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          SPAM_ASSASSIN_HOST: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.SPAM_ASSASSIN_HOST || '' }}
+          SPAM_ASSASSIN_PORT: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.SPAM_ASSASSIN_PORT || '' }}
+          TURBO_TOKEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.TURBO_TOKEN || '' }}
+          TURBO_TEAM: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.TURBO_TEAM || '' }}
       - name: Publish changed packages to pkg.pr.new
         if: steps.changed_packages.outputs.all_changed_and_modified_files != ''
         run: pnpm pkg-pr-new publish ${{ steps.changed_packages.outputs.all_changed_and_modified_files }} --pnpm

--- a/.github/workflows/pull-request-title-check.yml
+++ b/.github/workflows/pull-request-title-check.yml
@@ -2,13 +2,14 @@ name: Pull Request Title Check
 on:
   pull_request:
     types: [opened, edited, synchronize]
+permissions:
+  pull-requests: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-permissions:
-  pull-requests: read
 jobs:
   pull-request-title-check:
+    timeout-minutes: 15
     runs-on: depot-ubuntu-22.04-2
     container:
       image: node:24-slim

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,14 @@ on:
     branches:
       - main
       - canary
+permissions:
+  contents: read
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     # npm trusted publishing (OIDC) is only supported on GitHub-hosted `ubuntu-latest` runners.
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions: 
       id-token: write
       contents: write

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   sync:
+    timeout-minutes: 10
     runs-on: depot-ubuntu-22.04-2
     steps:
       - name: Trigger sync on resend-skills

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,14 +5,16 @@ on:
       - main
       - canary
   pull_request:
+permissions:
+  contents: read
+  pull-requests: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-permissions: 
-  contents: read
-  pull-requests: read
 jobs:
   tests:
+    # Org secrets in step env: push + same-repo PRs only; fork PRs evaluate to empty (explicit for review).
+    timeout-minutes: 45
     runs-on: depot-ubuntu-22.04-8
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-noble
@@ -34,16 +36,16 @@ jobs:
         run: pnpm build
         env:
           REDIS_URL: redis://localhost:6379
-          SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
-          SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          SPAM_ASSASSIN_HOST: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.SPAM_ASSASSIN_HOST || '' }}
+          SPAM_ASSASSIN_PORT: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.SPAM_ASSASSIN_PORT || '' }}
+          TURBO_TOKEN: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.TURBO_TOKEN || '' }}
+          TURBO_TEAM: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.TURBO_TEAM || '' }}
       - name: Run Tests
         run: pnpm test
         env:
           PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
           REDIS_URL: redis://localhost:6379
-          SPAM_ASSASSIN_HOST: ${{ secrets.SPAM_ASSASSIN_HOST }}
-          SPAM_ASSASSIN_PORT: ${{ secrets.SPAM_ASSASSIN_PORT }}
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          SPAM_ASSASSIN_HOST: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.SPAM_ASSASSIN_HOST || '' }}
+          SPAM_ASSASSIN_PORT: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.SPAM_ASSASSIN_PORT || '' }}
+          TURBO_TOKEN: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.TURBO_TOKEN || '' }}
+          TURBO_TEAM: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.TURBO_TEAM || '' }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened GitHub Actions by enforcing least-privilege permissions, adding job timeouts, and gating secrets to safe contexts. Addresses DEV-652 (0 high / 2 med / 12 low) and reduces risk on forked PRs.

- **Refactors**
  - Added top-level read permissions; kept write permissions only where needed. Normalized concurrency blocks.
  - Gated `SPAM_ASSASSIN_*` and `TURBO_*` envs to pushes and same-repo PRs; forks get empty values.
  - Added timeouts across CI jobs (10–45 min) to prevent hangs.

<sup>Written for commit 080ae45843a38276976a4ae13f02e3fc00e9d3ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

