### PR TITLE
fix: hide rich text bubble menu options when inline code is active

### DIFF
--- a/.changeset/inline-code-hides-other-options.md
+++ b/.changeset/inline-code-hides-other-options.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Hide rich text bubble menu options when inline code is active

--- a/packages/editor/src/ui/bubble-menu/root.tsx
+++ b/packages/editor/src/ui/bubble-menu/root.tsx
@@ -1,5 +1,5 @@
 import { PluginKey } from '@tiptap/pm/state';
-import { useCurrentEditor } from '@tiptap/react';
+import { useCurrentEditor, useEditorState } from '@tiptap/react';
 import { BubbleMenu } from '@tiptap/react/menus';
 import * as React from 'react';
 import { EditorFocusScope } from '../editor-focus-scope';
@@ -102,6 +102,12 @@ function Default({
 }: BubbleMenuDefaultProps) {
   const [isNodeSelectorOpen, setIsNodeSelectorOpen] = React.useState(false);
   const [isLinkSelectorOpen, setIsLinkSelectorOpen] = React.useState(false);
+  const { editor } = useCurrentEditor();
+
+  const isCodeActive = useEditorState({
+    editor,
+    selector: ({ editor: e }) => e?.isActive('code') ?? false,
+  });
 
   const handleNodeSelectorOpenChange = React.useCallback((open: boolean) => {
     setIsNodeSelectorOpen(open);
@@ -134,27 +140,39 @@ function Default({
       className={className}
       {...rest}
     >
-      <BubbleMenuNodeSelector
-        open={isNodeSelectorOpen}
-        onOpenChange={handleNodeSelectorOpenChange}
-      />
-      <BubbleMenuLinkSelector
-        open={isLinkSelectorOpen}
-        onOpenChange={handleLinkSelectorOpenChange}
-      />
-      <BubbleMenuItemGroup>
-        <BubbleMenuBold />
-        <BubbleMenuItalic />
-        <BubbleMenuUnderline />
-        <BubbleMenuStrike />
-        <BubbleMenuCode />
-        <BubbleMenuUppercase />
-      </BubbleMenuItemGroup>
-      <BubbleMenuItemGroup>
-        <BubbleMenuAlignLeft />
-        <BubbleMenuAlignCenter />
-        <BubbleMenuAlignRight />
-      </BubbleMenuItemGroup>
+      {isCodeActive ? (
+        <>
+          <BubbleMenuNodeSelector
+            open={isNodeSelectorOpen}
+            onOpenChange={handleNodeSelectorOpenChange}
+          />
+          <BubbleMenuCode />
+        </>
+      ) : (
+        <>
+          <BubbleMenuNodeSelector
+            open={isNodeSelectorOpen}
+            onOpenChange={handleNodeSelectorOpenChange}
+          />
+          <BubbleMenuLinkSelector
+            open={isLinkSelectorOpen}
+            onOpenChange={handleLinkSelectorOpenChange}
+          />
+          <BubbleMenuItemGroup>
+            <BubbleMenuBold />
+            <BubbleMenuItalic />
+            <BubbleMenuUnderline />
+            <BubbleMenuStrike />
+            <BubbleMenuCode />
+            <BubbleMenuUppercase />
+          </BubbleMenuItemGroup>
+          <BubbleMenuItemGroup>
+            <BubbleMenuAlignLeft />
+            <BubbleMenuAlignCenter />
+            <BubbleMenuAlignRight />
+          </BubbleMenuItemGroup>
+        </>
+      )}
     </Root>
   );
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

## Description

This is how it looks like now:
https://www.loom.com/share/f89ba51587f2401997d1ce24800747ea

Essentially we hide all rich text options from the menu when the mark is the inline code


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide rich-text bubble menu options when inline code is active so only the node selector and code toggle are shown. Includes a patch changeset for `@react-email/editor`.

- **Bug Fixes**
  - Use `useEditorState` from `@tiptap/react` to detect `editor.isActive('code')` and render only node selector + code toggle.
  - Hide link, formatting, and alignment controls in code mode to meet Linear MES-546.

<sup>Written for commit 9f498511b211f07c44e238a65772527a012a321f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



