### PR TITLE
chore: use public-shared-workflows for sync-prs-to-linear

### DIFF
--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@a25ae88674e3c8650510065401a899e323c2d1eb
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@13c71d228b49123ff7731a45d56bce4540948814
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}

--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: resend/shared-workflows/.github/actions/sync_prs_to_linear@8e33cb9ddb5aff92e371cc99c27fdb41698a2613
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@a25ae88674e3c8650510065401a899e323c2d1eb
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}


### PR DESCRIPTION
Updates the `sync-prs-to-linear` workflow to use the action from `resend/public-shared-workflows` instead of `resend/shared-workflows`.

Since `shared-workflows` is a private repo, using actions from it requires org-level settings to be enabled. Moving to a public repo removes that requirement.

Pinned to commit `a25ae88674e3c8650510065401a899e323c2d1eb`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the PR-to-Linear sync to the public `resend/public-shared-workflows` action to remove org-level settings and simplify setup. Pins to `13c71d228b49123ff7731a45d56bce4540948814`, keeps minimal permissions (PRs: read; Issues: write), and runs daily at 10:00 UTC and via workflow_dispatch.

<sup>Written for commit ebe386da71687f0cdf3393fafbd24c7bab581a04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

