### PR TITLE
chore: bump public-shared-workflows hash

### DIFF
--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@13c71d228b49123ff7731a45d56bce4540948814
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@3eb5c6b385a32cbef0551f50f4b6b01651cf1644
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}


### PR DESCRIPTION
Pins to `3eb5c6b385a32cbef0551f50f4b6b01651cf1644` which includes the ESM fix for `@actions/core@3.x`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the `resend/public-shared-workflows` `sync_prs_to_linear` action to a version that includes the ESM fix for `@actions/core@3.x`. This prevents runtime errors and keeps PRs syncing to Linear reliably.

<sup>Written for commit 278719adfb1681d15011b79cb5aed04c702bf1b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

